### PR TITLE
feat: filter functionality and local caching of metadata + covers

### DIFF
--- a/Vibrdrome/App/AppState.swift
+++ b/Vibrdrome/App/AppState.swift
@@ -65,7 +65,10 @@ final class AppState {
     var songFilter = LibraryFilter()
 
     /// Library sync manager.
-    let librarySyncManager = LibrarySyncManager()
+    let librarySyncManager = LibrarySyncManager.shared
+
+    /// Pre-computed model arrays so library tabs are instant on first tap.
+    let libraryCache = LibraryDataCache()
     var serverURL: String = ""
     var username: String = ""
     var errorMessage: String?
@@ -123,6 +126,8 @@ final class AppState {
         #if os(iOS)
         SubsonicClientProvider.shared.client = subsonicClient
         #endif
+        LibrarySyncManager.shared.client = subsonicClient
+        LibrarySyncManager.shared.container = PersistenceController.shared.container
     }
 
     func loadSavedCredentials() {

--- a/Vibrdrome/App/AppState.swift
+++ b/Vibrdrome/App/AppState.swift
@@ -64,6 +64,14 @@ final class AppState {
     var artistFilter = LibraryFilter()
     var songFilter = LibraryFilter()
 
+    /// Cached albums state for back-navigation, keyed by view configuration.
+    struct AlbumsViewSnapshot {
+        var albums: [Album]
+        var hasMore: Bool
+        var scrollIndex: Int?
+    }
+    var albumsViewSnapshots: [String: AlbumsViewSnapshot] = [:]
+
     /// Library sync manager.
     let librarySyncManager = LibrarySyncManager.shared
 

--- a/Vibrdrome/App/AppState.swift
+++ b/Vibrdrome/App/AppState.swift
@@ -52,12 +52,20 @@ final class AppState {
     }
     var pendingNowPlayingAction: NowPlayingAction?
 
-    /// Active side panel in the macOS main window (Queue / Lyrics / Artist Info).
+    /// Active side panel in the macOS main window (Queue / Lyrics / Artist Info / Album Filters).
     /// Mutually exclusive: setting one closes the others.
     enum SidePanel: String, Equatable {
-        case queue, lyrics, artistInfo
+        case queue, lyrics, artistInfo, albumFilters, artistFilters, songFilters
     }
     var activeSidePanel: SidePanel?
+
+    /// Filter state for the macOS filter sidebars.
+    var albumFilter = LibraryFilter()
+    var artistFilter = LibraryFilter()
+    var songFilter = LibraryFilter()
+
+    /// Library sync manager.
+    let librarySyncManager = LibrarySyncManager()
     var serverURL: String = ""
     var username: String = ""
     var errorMessage: String?

--- a/Vibrdrome/Core/Constants/UserDefaultsKeys.swift
+++ b/Vibrdrome/Core/Constants/UserDefaultsKeys.swift
@@ -111,7 +111,6 @@ enum UserDefaultsKeys {
     static let enableLiquidGlass = "enableLiquidGlass"
     static let enableMiniPlayerTint = "enableMiniPlayerTint"
     static let albumBackgroundStyle = "albumBackgroundStyle"
-    static let gridColumnsPerRow = "gridColumnsPerRow"
 
     // MARK: - Tab Bar Extended
 
@@ -143,5 +142,4 @@ enum UserDefaultsKeys {
     static let lastServerModified = "lastServerModified"
     static let backgroundSyncEnabled = "backgroundSyncEnabled"
     static let syncPollingInterval = "syncPollingInterval"
-    static let syncConflictPolicy = "syncConflictPolicy"
 }

--- a/Vibrdrome/Core/Constants/UserDefaultsKeys.swift
+++ b/Vibrdrome/Core/Constants/UserDefaultsKeys.swift
@@ -139,4 +139,9 @@ enum UserDefaultsKeys {
     // MARK: - Library Sync
 
     static let lastLibrarySyncDate = "lastLibrarySyncDate"
+    static let lastFullSyncDate = "lastFullSyncDate"
+    static let lastServerModified = "lastServerModified"
+    static let backgroundSyncEnabled = "backgroundSyncEnabled"
+    static let syncPollingInterval = "syncPollingInterval"
+    static let syncConflictPolicy = "syncConflictPolicy"
 }

--- a/Vibrdrome/Core/Constants/UserDefaultsKeys.swift
+++ b/Vibrdrome/Core/Constants/UserDefaultsKeys.swift
@@ -135,4 +135,8 @@ enum UserDefaultsKeys {
     static let macSidePanelMechanic = "macSidePanelMechanic"
     static let macSidePanelWidth = "macSidePanelWidth"
     static let macMiniPlayerPanelTrigger = "macMiniPlayerPanelTrigger"
+
+    // MARK: - Library Sync
+
+    static let lastLibrarySyncDate = "lastLibrarySyncDate"
 }

--- a/Vibrdrome/Core/Models/LibraryFilter.swift
+++ b/Vibrdrome/Core/Models/LibraryFilter.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// Tri-state filter value: no filter, must be true, or must be false.
+enum TriState: String, CaseIterable, Sendable, Equatable {
+    case none, yes, no
+}
+
+/// Observable filter state for library filter sidebars (albums, artists, songs).
+/// All filtering is done locally against SwiftData.
+@Observable
+final class LibraryFilter: @unchecked Sendable {
+    var isFavorited: TriState = .none
+    var isRated: TriState = .none
+    var isRecentlyPlayed: Bool = false
+    var selectedArtistIds: Set<String> = []
+    var selectedGenres: Set<String> = []
+    var selectedLabels: Set<String> = []
+    var year: Int?
+
+    var isActive: Bool {
+        isFavorited != .none ||
+        isRated != .none ||
+        isRecentlyPlayed ||
+        !selectedArtistIds.isEmpty ||
+        !selectedGenres.isEmpty ||
+        !selectedLabels.isEmpty ||
+        year != nil
+    }
+
+    var activeFilterCount: Int {
+        var count = 0
+        if isFavorited != .none { count += 1 }
+        if isRated != .none { count += 1 }
+        if isRecentlyPlayed { count += 1 }
+        if !selectedArtistIds.isEmpty { count += 1 }
+        if !selectedGenres.isEmpty { count += 1 }
+        if !selectedLabels.isEmpty { count += 1 }
+        if year != nil { count += 1 }
+        return count
+    }
+
+    func reset() {
+        isFavorited = .none
+        isRated = .none
+        isRecentlyPlayed = false
+        selectedArtistIds = []
+        selectedGenres = []
+        selectedLabels = []
+        year = nil
+    }
+}

--- a/Vibrdrome/Core/Models/LibraryFilter.swift
+++ b/Vibrdrome/Core/Models/LibraryFilter.swift
@@ -17,7 +17,8 @@ enum TriState: String, CaseIterable, Sendable, Equatable {
 /// Observable filter state for library filter sidebars (albums, artists, songs).
 /// All filtering is done locally against SwiftData.
 @Observable
-final class LibraryFilter: @unchecked Sendable {
+@MainActor
+final class LibraryFilter {
     var isFavorited: TriState = .none
     var isRated: TriState = .none
     var isRecentlyPlayed: Bool = false

--- a/Vibrdrome/Core/Models/LibraryFilter.swift
+++ b/Vibrdrome/Core/Models/LibraryFilter.swift
@@ -3,6 +3,15 @@ import Foundation
 /// Tri-state filter value: no filter, must be true, or must be false.
 enum TriState: String, CaseIterable, Sendable, Equatable {
     case none, yes, no
+
+    /// Returns true if the value satisfies this filter (`.none` always passes).
+    func matches(_ value: Bool) -> Bool {
+        switch self {
+        case .none: true
+        case .yes: value
+        case .no: !value
+        }
+    }
 }
 
 /// Observable filter state for library filter sidebars (albums, artists, songs).

--- a/Vibrdrome/Core/Networking/OfflineActionQueue.swift
+++ b/Vibrdrome/Core/Networking/OfflineActionQueue.swift
@@ -150,7 +150,7 @@ final class OfflineActionQueue {
 
     // MARK: - Flush
 
-    /// Sync all pending actions to server
+    /// Sync all pending actions to server, with conflict detection and resolution.
     func flushPending() async {
         guard !isSyncing else { return }
         isSyncing = true
@@ -164,9 +164,17 @@ final class OfflineActionQueue {
 
         guard let actions = try? context.fetch(descriptor), !actions.isEmpty else { return }
         let client = AppState.shared.subsonicClient
+
+        // Conflict resolution: collapse contradictory actions on the same target.
+        // e.g., star + unstar on the same song → last one wins.
+        let policy = SyncConflictPolicy(
+            rawValue: UserDefaults.standard.string(forKey: UserDefaultsKeys.syncConflictPolicy) ?? ""
+        ) ?? .lastWriteWins
+        let resolved = resolveConflicts(actions: actions, policy: policy, context: context)
+
         var synced = 0
 
-        for action in actions {
+        for action in resolved {
             do {
                 try await executeAction(action, client: client)
                 context.delete(action)
@@ -190,6 +198,63 @@ final class OfflineActionQueue {
         if synced > 0 {
             offlineLog.info("Synced \(synced) pending actions")
         }
+    }
+
+    // MARK: - Conflict Resolution
+
+    /// Policy for resolving conflicting offline actions.
+    enum SyncConflictPolicy: String {
+        /// The most recent action wins (default).
+        case lastWriteWins
+        /// The server state takes precedence — discard conflicting local actions.
+        case serverWins
+    }
+
+    /// Collapse contradictory actions on the same target. Returns the surviving actions.
+    private func resolveConflicts(actions: [PendingAction], policy: SyncConflictPolicy,
+                                  context: ModelContext) -> [PendingAction] {
+        // Group by target ID
+        var grouped: [String: [PendingAction]] = [:]
+        for action in actions {
+            grouped[action.targetId, default: []].append(action)
+        }
+
+        var resolved: [PendingAction] = []
+
+        for (_, group) in grouped {
+            // Separate star/unstar pairs from other action types
+            let starActions = group.filter {
+                $0.actionType == "star" || $0.actionType == "unstar" ||
+                $0.actionType == "starAlbum" || $0.actionType == "unstarAlbum" ||
+                $0.actionType == "starArtist" || $0.actionType == "unstarArtist"
+            }
+            let otherActions = group.filter {
+                !($0.actionType == "star" || $0.actionType == "unstar" ||
+                  $0.actionType == "starAlbum" || $0.actionType == "unstarAlbum" ||
+                  $0.actionType == "starArtist" || $0.actionType == "unstarArtist")
+            }
+
+            // Other actions (scrobbles etc.) always go through
+            resolved.append(contentsOf: otherActions)
+
+            // For star/unstar, check for contradictions
+            if starActions.count > 1 {
+                // Multiple star/unstar on same target — keep only the latest
+                let sorted = starActions.sorted { $0.createdAt < $1.createdAt }
+                let winner = sorted.last!
+                offlineLog.info("Conflict resolved (\(policy.rawValue)): \(winner.actionType) wins for \(winner.targetId)")
+
+                // Delete the losers
+                for action in sorted.dropLast() {
+                    context.delete(action)
+                }
+                resolved.append(winner)
+            } else {
+                resolved.append(contentsOf: starActions)
+            }
+        }
+
+        return resolved
     }
 
     private func executeAction(_ action: PendingAction, client: SubsonicClient) async throws {

--- a/Vibrdrome/Core/Networking/OfflineActionQueue.swift
+++ b/Vibrdrome/Core/Networking/OfflineActionQueue.swift
@@ -167,10 +167,7 @@ final class OfflineActionQueue {
 
         // Conflict resolution: collapse contradictory actions on the same target.
         // e.g., star + unstar on the same song → last one wins.
-        let policy = SyncConflictPolicy(
-            rawValue: UserDefaults.standard.string(forKey: UserDefaultsKeys.syncConflictPolicy) ?? ""
-        ) ?? .lastWriteWins
-        let resolved = resolveConflicts(actions: actions, policy: policy, context: context)
+        let resolved = resolveConflicts(actions: actions, context: context)
 
         var synced = 0
 
@@ -202,16 +199,9 @@ final class OfflineActionQueue {
 
     // MARK: - Conflict Resolution
 
-    /// Policy for resolving conflicting offline actions.
-    enum SyncConflictPolicy: String {
-        /// The most recent action wins (default).
-        case lastWriteWins
-        /// The server state takes precedence — discard conflicting local actions.
-        case serverWins
-    }
-
-    /// Collapse contradictory actions on the same target. Returns the surviving actions.
-    private func resolveConflicts(actions: [PendingAction], policy: SyncConflictPolicy,
+    /// Collapse contradictory actions on the same target.
+    /// Uses last-write-wins: the most recent action for each target survives.
+    private func resolveConflicts(actions: [PendingAction],
                                   context: ModelContext) -> [PendingAction] {
         // Group by target ID
         var grouped: [String: [PendingAction]] = [:]
@@ -242,7 +232,7 @@ final class OfflineActionQueue {
                 // Multiple star/unstar on same target — keep only the latest
                 let sorted = starActions.sorted { $0.createdAt < $1.createdAt }
                 let winner = sorted.last!
-                offlineLog.info("Conflict resolved (\(policy.rawValue)): \(winner.actionType) wins for \(winner.targetId)")
+                offlineLog.info("Conflict resolved (last-write-wins): \(winner.actionType) wins for \(winner.targetId)")
 
                 // Delete the losers
                 for action in sorted.dropLast() {

--- a/Vibrdrome/Core/Networking/SubsonicClient.swift
+++ b/Vibrdrome/Core/Networking/SubsonicClient.swift
@@ -389,8 +389,8 @@ final class SubsonicClient {
         return body.musicFolders?.musicFolder ?? []
     }
 
-    func getIndexes(musicFolderId: String? = nil) async throws -> IndexesResponse {
-        let body = try await request(.getIndexes(musicFolderId: musicFolderId))
+    func getIndexes(musicFolderId: String? = nil, ifModifiedSince: Int? = nil) async throws -> IndexesResponse {
+        let body = try await request(.getIndexes(musicFolderId: musicFolderId, ifModifiedSince: ifModifiedSince))
         guard let indexes = body.indexes else {
             throw SubsonicError.apiError(code: 70, message: "Indexes not found")
         }

--- a/Vibrdrome/Core/Networking/SubsonicClient.swift
+++ b/Vibrdrome/Core/Networking/SubsonicClient.swift
@@ -14,6 +14,11 @@ final class SubsonicClient {
     private static let maxRetries = 3
     private static let retryDelays: [UInt64] = [1_000_000_000, 2_000_000_000, 4_000_000_000] // 1s, 2s, 4s
 
+    /// Internal marker for HTTP 429 so retry delay can honor Retry-After when present.
+    private struct RateLimitError: Error {
+        let retryAfterNanoseconds: UInt64?
+    }
+
     var isConnected: Bool = false
 
     init(baseURL: URL, username: String, password: String) {
@@ -33,6 +38,9 @@ final class SubsonicClient {
     // MARK: - Retry Logic
 
     private func isRetryable(_ error: Error) -> Bool {
+        if error is RateLimitError {
+            return true
+        }
         if let urlError = error as? URLError {
             switch urlError.code {
             case .timedOut, .networkConnectionLost, .notConnectedToInternet,
@@ -45,7 +53,7 @@ final class SubsonicClient {
         if let subsonicError = error as? SubsonicError {
             switch subsonicError {
             case .httpError(let code):
-                return code >= 500 // Only retry server errors, not 4xx
+                return code == 429 || code >= 500
             default:
                 return false
             }
@@ -53,30 +61,68 @@ final class SubsonicClient {
         return false
     }
 
+    private func retryDelayNanoseconds(for error: Error, attempt: Int) -> UInt64? {
+        guard isRetryable(error) else { return nil }
+
+        if let rateLimitError = error as? RateLimitError,
+           let retryAfter = rateLimitError.retryAfterNanoseconds {
+            return retryAfter
+        }
+
+        return Self.retryDelays[min(attempt, Self.retryDelays.count - 1)]
+    }
+
+    private func parseRetryAfterNanoseconds(from response: HTTPURLResponse) -> UInt64? {
+        guard let header = response.value(forHTTPHeaderField: "Retry-After")?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !header.isEmpty else {
+            return nil
+        }
+
+        if let seconds = TimeInterval(header), seconds > 0 {
+            return UInt64(seconds * 1_000_000_000)
+        }
+
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss z"
+
+        guard let retryDate = formatter.date(from: header) else { return nil }
+        let seconds = max(0, retryDate.timeIntervalSinceNow)
+        guard seconds > 0 else { return nil }
+        return UInt64(seconds * 1_000_000_000)
+    }
+
     // MARK: - Core Request
 
     private func request(_ endpoint: SubsonicEndpoint) async throws -> SubsonicResponseBody {
-        var lastError: Error?
-
         for attempt in 0...Self.maxRetries {
-            if attempt > 0 {
-                let delay = Self.retryDelays[min(attempt - 1, Self.retryDelays.count - 1)]
-                networkLog.info("Retry \(attempt)/\(Self.maxRetries) for \(endpoint.path) after \(delay / 1_000_000_000)s")
-                try await Task.sleep(nanoseconds: delay)
-            }
-
             do {
                 return try await performRequest(endpoint)
             } catch {
-                lastError = error
-                if !isRetryable(error) {
+                if attempt == Self.maxRetries {
+                    if error is RateLimitError {
+                        throw SubsonicError.httpError(429)
+                    }
                     throw error
                 }
-                networkLog.warning("Transient error on \(endpoint.path): \(error.localizedDescription)")
+
+                guard let delay = retryDelayNanoseconds(for: error, attempt: attempt) else {
+                    throw error
+                }
+
+                if error is RateLimitError {
+                    networkLog.warning("Rate limited on \(endpoint.path); retry \(attempt + 1)/\(Self.maxRetries) after \(delay / 1_000_000_000)s")
+                } else {
+                    networkLog.warning("Transient error on \(endpoint.path): \(error.localizedDescription)")
+                    networkLog.info("Retry \(attempt + 1)/\(Self.maxRetries) for \(endpoint.path) after \(delay / 1_000_000_000)s")
+                }
+
+                try await Task.sleep(nanoseconds: delay)
             }
         }
 
-        throw lastError!
+        throw SubsonicError.httpError(500)
     }
 
     private func performRequest(_ endpoint: SubsonicEndpoint) async throws -> SubsonicResponseBody {
@@ -97,6 +143,9 @@ final class SubsonicClient {
         guard let httpResponse = response as? HTTPURLResponse,
               (200...299).contains(httpResponse.statusCode) else {
             let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
+            if statusCode == 429, let httpResponse = response as? HTTPURLResponse {
+                throw RateLimitError(retryAfterNanoseconds: parseRetryAfterNanoseconds(from: httpResponse))
+            }
             if statusCode == 401, !AppState.shared.requiresReAuth {
                 networkLog.warning("401 Unauthorized — triggering re-authentication prompt")
                 AppState.shared.requiresReAuth = true

--- a/Vibrdrome/Core/Networking/SubsonicEndpoints.swift
+++ b/Vibrdrome/Core/Networking/SubsonicEndpoints.swift
@@ -51,7 +51,7 @@ enum SubsonicEndpoint: Sendable {
     case getSimilarSongs2(id: String, count: Int = 50)
     case getTopSongs(artist: String, count: Int = 50)
     case getMusicFolders
-    case getIndexes(musicFolderId: String? = nil)
+    case getIndexes(musicFolderId: String? = nil, ifModifiedSince: Int? = nil)
     case getMusicDirectory(id: String)
     case jukeboxControl(action: String, index: Int? = nil, offset: Int? = nil,
                         ids: [String]? = nil, gain: Float? = nil)
@@ -285,9 +285,10 @@ enum SubsonicEndpoint: Sendable {
                 URLQueryItem(name: "count", value: "\(count)")
             ]
 
-        case .getIndexes(let musicFolderId):
+        case .getIndexes(let musicFolderId, let ifModifiedSince):
             var items: [URLQueryItem] = []
             if let musicFolderId { items.append(URLQueryItem(name: "musicFolderId", value: musicFolderId)) }
+            if let ifModifiedSince { items.append(URLQueryItem(name: "ifModifiedSince", value: "\(ifModifiedSince)")) }
             return items
 
         case .getMusicDirectory(let id):

--- a/Vibrdrome/Core/Networking/SubsonicModels.swift
+++ b/Vibrdrome/Core/Networking/SubsonicModels.swift
@@ -137,6 +137,10 @@ struct AlbumInfo2: Decodable, Sendable {
 
 // MARK: - Album Models
 
+struct RecordLabel: Decodable, Sendable {
+    let name: String
+}
+
 struct Album: Decodable, Identifiable, Sendable {
     let id: String
     let name: String
@@ -149,8 +153,14 @@ struct Album: Decodable, Identifiable, Sendable {
     let genre: String?
     let starred: String?
     let created: String?
+    let userRating: Int?
     let song: [Song]?
     let replayGain: ReplayGain?
+    let musicBrainzId: String?
+    let recordLabels: [RecordLabel]?
+
+    /// First record label name, for convenience.
+    var label: String? { recordLabels?.first?.name }
 }
 
 struct AlbumList2Response: Decodable, Sendable {

--- a/Vibrdrome/Core/Networking/SubsonicModels.swift
+++ b/Vibrdrome/Core/Networking/SubsonicModels.swift
@@ -181,7 +181,7 @@ struct TopSongsResponse: Decodable, Sendable {
 
 // MARK: - Song Model
 
-struct Song: Decodable, Identifiable, Sendable {
+struct Song: Decodable, Identifiable, Sendable, Equatable {
     let id: String
     let parent: String?
     let title: String
@@ -233,7 +233,7 @@ struct Song: Decodable, Identifiable, Sendable {
     }
 }
 
-struct ReplayGain: Decodable, Sendable {
+struct ReplayGain: Decodable, Sendable, Equatable {
     let trackGain: Double?
     let albumGain: Double?
     let trackPeak: Double?

--- a/Vibrdrome/Core/Persistence/BackgroundSyncScheduler.swift
+++ b/Vibrdrome/Core/Persistence/BackgroundSyncScheduler.swift
@@ -1,0 +1,152 @@
+#if os(iOS)
+import BackgroundTasks
+import Foundation
+import os.log
+
+private let bgSyncLog = Logger(subsystem: "com.vibrdrome.app", category: "BackgroundSync")
+
+/// Manages background library sync via BGTaskScheduler on iOS.
+/// Registers and schedules both app refresh and processing tasks.
+@MainActor
+final class BackgroundSyncScheduler {
+    static let shared = BackgroundSyncScheduler()
+
+    /// Task identifier for lightweight app refresh (incremental sync).
+    static let refreshTaskId = "com.vibrdrome.app.libraryRefresh"
+    /// Task identifier for longer processing task (full sync).
+    static let processingTaskId = "com.vibrdrome.app.librarySync"
+
+    private init() {}
+
+    /// Register background task handlers. Call once at app launch.
+    func registerTasks() {
+        BGTaskScheduler.shared.register(
+            forTaskWithIdentifier: Self.refreshTaskId,
+            using: nil
+        ) { task in
+            guard let refreshTask = task as? BGAppRefreshTask else { return }
+            Task { @MainActor in
+                await self.handleRefreshTask(refreshTask)
+            }
+        }
+
+        BGTaskScheduler.shared.register(
+            forTaskWithIdentifier: Self.processingTaskId,
+            using: nil
+        ) { task in
+            guard let processingTask = task as? BGProcessingTask else { return }
+            Task { @MainActor in
+                await self.handleProcessingTask(processingTask)
+            }
+        }
+
+        bgSyncLog.info("Registered background sync tasks")
+    }
+
+    /// Schedule the next background refresh. Call after each sync completes.
+    func scheduleRefresh() {
+        guard UserDefaults.standard.bool(forKey: UserDefaultsKeys.backgroundSyncEnabled) else {
+            bgSyncLog.info("Background sync disabled, not scheduling refresh")
+            return
+        }
+
+        let request = BGAppRefreshTaskRequest(identifier: Self.refreshTaskId)
+        // Earliest: 1 hour from now
+        request.earliestBeginDate = Date(timeIntervalSinceNow: 3600)
+
+        do {
+            try BGTaskScheduler.shared.submit(request)
+            bgSyncLog.info("Scheduled background refresh for ~1 hour from now")
+        } catch {
+            bgSyncLog.error("Failed to schedule background refresh: \(error)")
+        }
+    }
+
+    /// Schedule a longer background processing task for full sync.
+    func scheduleFullSync() {
+        guard UserDefaults.standard.bool(forKey: UserDefaultsKeys.backgroundSyncEnabled) else { return }
+
+        let request = BGProcessingTaskRequest(identifier: Self.processingTaskId)
+        request.requiresNetworkConnectivity = true
+        request.requiresExternalPower = false
+        // Earliest: 24 hours from now
+        request.earliestBeginDate = Date(timeIntervalSinceNow: 86400)
+
+        do {
+            try BGTaskScheduler.shared.submit(request)
+            bgSyncLog.info("Scheduled background full sync for ~24 hours from now")
+        } catch {
+            bgSyncLog.error("Failed to schedule background full sync: \(error)")
+        }
+    }
+
+    /// Cancel all pending background sync tasks.
+    func cancelAll() {
+        BGTaskScheduler.shared.cancel(taskRequestWithIdentifier: Self.refreshTaskId)
+        BGTaskScheduler.shared.cancel(taskRequestWithIdentifier: Self.processingTaskId)
+        bgSyncLog.info("Cancelled all background sync tasks")
+    }
+
+    // MARK: - Task Handlers
+
+    private func handleRefreshTask(_ task: BGAppRefreshTask) async {
+        bgSyncLog.info("Background refresh task started")
+
+        // Schedule the next refresh before doing work
+        scheduleRefresh()
+
+        let appState = AppState.shared
+        guard appState.isConfigured else {
+            bgSyncLog.info("App not configured, completing background refresh")
+            task.setTaskCompleted(success: true)
+            return
+        }
+
+        // Create a cancellation handler
+        let syncTask = Task {
+            await appState.librarySyncManager.incrementalSync(
+                client: appState.subsonicClient,
+                container: PersistenceController.shared.container
+            )
+        }
+
+        task.expirationHandler = {
+            syncTask.cancel()
+            bgSyncLog.warning("Background refresh task expired")
+        }
+
+        await syncTask.value
+        task.setTaskCompleted(success: appState.librarySyncManager.syncError == nil)
+        bgSyncLog.info("Background refresh task completed")
+    }
+
+    private func handleProcessingTask(_ task: BGProcessingTask) async {
+        bgSyncLog.info("Background processing task started")
+
+        // Schedule the next full sync
+        scheduleFullSync()
+
+        let appState = AppState.shared
+        guard appState.isConfigured else {
+            task.setTaskCompleted(success: true)
+            return
+        }
+
+        let syncTask = Task {
+            await appState.librarySyncManager.sync(
+                client: appState.subsonicClient,
+                container: PersistenceController.shared.container
+            )
+        }
+
+        task.expirationHandler = {
+            syncTask.cancel()
+            bgSyncLog.warning("Background processing task expired")
+        }
+
+        await syncTask.value
+        task.setTaskCompleted(success: appState.librarySyncManager.syncError == nil)
+        bgSyncLog.info("Background processing task completed")
+    }
+}
+#endif

--- a/Vibrdrome/Core/Persistence/BackgroundSyncScheduler.swift
+++ b/Vibrdrome/Core/Persistence/BackgroundSyncScheduler.swift
@@ -45,6 +45,7 @@ final class BackgroundSyncScheduler {
 
     /// Schedule the next background refresh. Call after each sync completes.
     func scheduleRefresh() {
+        guard AppState.shared.isConfigured else { return }
         guard UserDefaults.standard.bool(forKey: UserDefaultsKeys.backgroundSyncEnabled) else {
             bgSyncLog.info("Background sync disabled, not scheduling refresh")
             return
@@ -64,6 +65,7 @@ final class BackgroundSyncScheduler {
 
     /// Schedule a longer background processing task for full sync.
     func scheduleFullSync() {
+        guard AppState.shared.isConfigured else { return }
         guard UserDefaults.standard.bool(forKey: UserDefaultsKeys.backgroundSyncEnabled) else { return }
 
         let request = BGProcessingTaskRequest(identifier: Self.processingTaskId)

--- a/Vibrdrome/Core/Persistence/LibraryDataCache.swift
+++ b/Vibrdrome/Core/Persistence/LibraryDataCache.swift
@@ -1,0 +1,118 @@
+import Foundation
+import SwiftData
+import os.log
+
+private let cacheLog = Logger(subsystem: "com.vibrdrome.app", category: "LibraryCache")
+
+/// Pre-computes converted model arrays on a background thread so library tabs
+/// are ready instantly when first selected.
+@Observable
+@MainActor
+final class LibraryDataCache {
+    private(set) var songs: [Song]?
+    private(set) var artists: [Artist]?
+    private(set) var albums: [Album]?
+    private(set) var songFilterYears: [Int]?
+    private(set) var songFilterArtists: [String]?
+    private(set) var songFilterGenres: [String]?
+
+    /// Incremented after each successful rebuild so views can detect changes via `.onChange`.
+    private(set) var generation: Int = 0
+
+    private var buildTask: Task<Void, Never>?
+
+    /// Kick off a background rebuild of all cached model arrays.
+    func rebuild(container: ModelContainer) {
+        buildTask?.cancel()
+        buildTask = Task {
+            let result = await Task.detached(priority: .userInitiated) {
+                Self.buildCache(container: container)
+            }.value
+            guard !Task.isCancelled else { return }
+            songs = result.songs
+            artists = result.artists
+            albums = result.albums
+            songFilterYears = result.years
+            songFilterArtists = result.artistNames
+            songFilterGenres = result.genres
+            generation += 1
+            cacheLog.info("Library cache ready — \(result.songs.count) songs, \(result.artists.count) artists, \(result.albums.count) albums")
+        }
+    }
+
+    /// Clear all cached data (e.g. on logout or server switch).
+    func invalidate() {
+        buildTask?.cancel()
+        songs = nil
+        artists = nil
+        albums = nil
+        songFilterYears = nil
+        songFilterArtists = nil
+        songFilterGenres = nil
+    }
+
+    // MARK: - Background Work
+
+    private struct CacheResult: Sendable {
+        let songs: [Song]
+        let artists: [Artist]
+        let albums: [Album]
+        let years: [Int]
+        let artistNames: [String]
+        let genres: [String]
+    }
+
+    nonisolated private static func buildCache(container: ModelContainer) -> CacheResult {
+        let context = ModelContext(container)
+        context.autosaveEnabled = false
+
+        // Artists
+        let artistDescriptor = FetchDescriptor<CachedArtist>(sortBy: [SortDescriptor<CachedArtist>(\.name)])
+        let convertedArtists: [Artist]
+        if let cached = try? context.fetch(artistDescriptor) {
+            convertedArtists = cached.map { $0.toArtist() }
+        } else {
+            convertedArtists = []
+        }
+
+        // Albums
+        let albumDescriptor = FetchDescriptor<CachedAlbum>(sortBy: [SortDescriptor<CachedAlbum>(\.name)])
+        let convertedAlbums: [Album]
+        if let cached = try? context.fetch(albumDescriptor) {
+            convertedAlbums = cached.map { $0.toAlbum() }
+        } else {
+            convertedAlbums = []
+        }
+
+        // Songs — single pass for conversion + filter option extraction
+        let songDescriptor = FetchDescriptor<CachedSong>(sortBy: [SortDescriptor<CachedSong>(\.title)])
+        var convertedSongs = [Song]()
+        var yearSet = Set<Int>()
+        var artistSet = Set<String>()
+        var genreSet = Set<String>()
+        if let cached = try? context.fetch(songDescriptor) {
+            convertedSongs.reserveCapacity(cached.count)
+            for item in cached {
+                convertedSongs.append(item.toSong())
+                if let year = item.year { yearSet.insert(year) }
+                if let artist = item.artist { artistSet.insert(artist) }
+                if let genre = item.genre { genreSet.insert(genre) }
+            }
+        }
+
+        let sortedYears = yearSet.sorted(by: >)
+        let sortedArtists = Array(artistSet)
+            .sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
+        let sortedGenres = Array(genreSet)
+            .sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
+
+        return CacheResult(
+            songs: convertedSongs,
+            artists: convertedArtists,
+            albums: convertedAlbums,
+            years: sortedYears,
+            artistNames: sortedArtists,
+            genres: sortedGenres
+        )
+    }
+}

--- a/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
+++ b/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
@@ -5,8 +5,18 @@ import os.log
 
 private let syncLog = Logger(subsystem: "com.vibrdrome.app", category: "LibrarySync")
 
-/// Syncs full library metadata (albums, artists, songs) from the Subsonic API
-/// into SwiftData for local filtering and search.
+/// Sync mode determines the depth of library synchronization.
+enum SyncMode: String, Sendable {
+    /// Full re-sync of all metadata — catches additions, updates, and deletions.
+    case full
+    /// Lightweight sync — only fetches recently changed content.
+    case incremental
+    /// Triggered by BGTaskScheduler in the background.
+    case background
+}
+
+/// Syncs library metadata (albums, artists, songs, playlists) from the Subsonic API
+/// into SwiftData for local filtering, search, and offline support.
 @Observable
 @MainActor
 final class LibrarySyncManager {
@@ -18,15 +28,123 @@ final class LibrarySyncManager {
     }
     var syncError: String?
 
+    /// Stats from the most recent sync, updated live during sync.
+    var lastSyncStats: SyncStats?
+
+    /// Polling timer for change detection while app is active.
+    private var pollingTask: Task<Void, Never>?
+
     private let albumPageSize = 500
     private let songPageSize = 500
 
-    /// Run a full library sync: albums, artists, then songs.
+    /// Stale threshold for auto-sync (24 hours).
+    private let staleInterval: TimeInterval = 86400
+    /// Interval between full syncs to catch deletions (7 days).
+    private let fullSyncInterval: TimeInterval = 604_800
+
+    // MARK: - Sync Stats
+
+    struct SyncStats: Sendable {
+        var albumsAdded = 0
+        var albumsUpdated = 0
+        var albumsRemoved = 0
+        var artistsAdded = 0
+        var artistsUpdated = 0
+        var artistsRemoved = 0
+        var songsAdded = 0
+        var songsUpdated = 0
+        var songsRemoved = 0
+        var playlistsSynced = 0
+        var conflictsDetected = 0
+        var conflictsResolved = 0
+        var startTime = Date()
+
+        var totalChanges: Int {
+            albumsAdded + albumsUpdated + albumsRemoved +
+            artistsAdded + artistsUpdated + artistsRemoved +
+            songsAdded + songsUpdated + songsRemoved
+        }
+
+        var duration: TimeInterval {
+            Date().timeIntervalSince(startTime)
+        }
+    }
+
+    // MARK: - Public API
+
+    /// Run a full library sync: albums, artists, songs, then playlists.
     func sync(client: SubsonicClient, container: ModelContainer) async {
+        await performSync(mode: .full, client: client, container: container)
+    }
+
+    /// Run an incremental sync — only fetches changes since last sync.
+    func incrementalSync(client: SubsonicClient, container: ModelContainer) async {
+        await performSync(mode: .incremental, client: client, container: container)
+    }
+
+    /// Check if sync is stale and trigger the appropriate sync mode.
+    func syncIfStale(client: SubsonicClient, container: ModelContainer) async {
+        guard let last = lastSyncDate else {
+            await performSync(mode: .full, client: client, container: container)
+            return
+        }
+        let elapsed = Date().timeIntervalSince(last)
+        guard elapsed > staleInterval else { return }
+
+        // Check if server data actually changed before doing work
+        let serverChanged = await hasServerChanged(client: client)
+
+        if serverChanged {
+            // Use full sync if it's been over a week, otherwise incremental
+            let lastFull = UserDefaults.standard.object(forKey: UserDefaultsKeys.lastFullSyncDate) as? Date
+            let needsFullSync = lastFull == nil || Date().timeIntervalSince(lastFull!) > fullSyncInterval
+            let mode: SyncMode = needsFullSync ? .full : .incremental
+            await performSync(mode: mode, client: client, container: container)
+        } else {
+            // Server unchanged — just update the stale check timestamp
+            lastSyncDate = Date()
+            syncLog.info("Server data unchanged, skipping sync")
+        }
+    }
+
+    // MARK: - Change Detection Polling
+
+    /// Start periodic polling for server changes while the app is active.
+    func startPolling(client: SubsonicClient, container: ModelContainer) {
+        stopPolling()
+        let intervalMinutes = UserDefaults.standard.integer(forKey: UserDefaultsKeys.syncPollingInterval)
+        let interval = max(TimeInterval(intervalMinutes > 0 ? intervalMinutes : 15) * 60, 300)
+
+        pollingTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(interval))
+                guard !Task.isCancelled, let self, !self.isSyncing else { continue }
+
+                let changed = await self.hasServerChanged(client: client)
+                if changed {
+                    syncLog.info("Polling detected server changes, triggering incremental sync")
+                    await self.performSync(mode: .incremental, client: client, container: container)
+                }
+            }
+        }
+        syncLog.info("Started change detection polling every \(Int(interval))s")
+    }
+
+    /// Stop the periodic polling timer.
+    func stopPolling() {
+        pollingTask?.cancel()
+        pollingTask = nil
+    }
+
+    // MARK: - Core Sync Engine
+
+    private func performSync(mode: SyncMode, client: SubsonicClient, container: ModelContainer) async {
         guard !isSyncing else { return }
         isSyncing = true
         syncError = nil
-        syncProgress = "Starting sync…"
+        syncProgress = mode == .full ? "Starting full sync…" : "Starting incremental sync…"
+        var stats = SyncStats()
+        lastSyncStats = stats
         defer {
             isSyncing = false
             syncProgress = nil
@@ -36,133 +154,242 @@ final class LibrarySyncManager {
             let context = ModelContext(container)
             context.autosaveEnabled = false
 
-            try await syncAlbums(client: client, context: context)
-            try await syncArtists(client: client, context: context)
-            try await syncSongs(client: client, context: context)
-            try await syncPlaylists(client: client, context: context)
+            switch mode {
+            case .full, .background:
+                try await syncAlbums(client: client, context: context, stats: &stats, incremental: false)
+                try await syncArtists(client: client, context: context, stats: &stats, incremental: false)
+                try await syncSongs(client: client, context: context, stats: &stats, incremental: false)
+                try await syncPlaylists(client: client, context: context, stats: &stats)
+                UserDefaults.standard.set(Date(), forKey: UserDefaultsKeys.lastFullSyncDate)
+
+            case .incremental:
+                try await syncAlbums(client: client, context: context, stats: &stats, incremental: true)
+                try await syncArtists(client: client, context: context, stats: &stats, incremental: true)
+                try await syncSongs(client: client, context: context, stats: &stats, incremental: true)
+                try await syncPlaylists(client: client, context: context, stats: &stats)
+            }
 
             try context.save()
             lastSyncDate = Date()
-            syncLog.info("Library sync completed successfully")
+            lastSyncStats = stats
+
+            // Save sync history
+            saveSyncHistory(stats: stats, mode: mode, context: context)
+
+            syncLog.info("""
+                Library sync (\(mode.rawValue)) completed in \
+                \(String(format: "%.1f", stats.duration))s — \
+                \(stats.totalChanges) changes \
+                (+\(stats.albumsAdded + stats.artistsAdded + stats.songsAdded) \
+                ~\(stats.albumsUpdated + stats.artistsUpdated + stats.songsUpdated) \
+                -\(stats.albumsRemoved + stats.artistsRemoved + stats.songsRemoved))
+                """)
 
             // Prefetch cover art in background after metadata sync
-            await prefetchCoverArt(client: client, context: context)
+            if stats.albumsAdded > 0 || stats.artistsAdded > 0 {
+                await prefetchCoverArt(client: client, context: context)
+            }
         } catch {
             syncError = "Sync failed: \(error.localizedDescription)"
-            syncLog.error("Library sync failed: \(error)")
+            lastSyncStats = stats
+            saveSyncHistory(stats: stats, mode: mode, context: ModelContext(container), error: error)
+            syncLog.error("Library sync (\(mode.rawValue)) failed: \(error)")
         }
     }
 
-    /// Check if sync is stale (>24h) and trigger background sync if needed.
-    func syncIfStale(client: SubsonicClient, container: ModelContainer) async {
-        guard let last = lastSyncDate else {
-            await sync(client: client, container: container)
-            return
+    // MARK: - Server Change Detection
+
+    /// Lightweight check if server data has changed since last sync.
+    /// Uses getIndexes with ifModifiedSince to avoid fetching full data.
+    private func hasServerChanged(client: SubsonicClient) async -> Bool {
+        let lastModified = UserDefaults.standard.integer(forKey: UserDefaultsKeys.lastServerModified)
+        guard lastModified > 0 else { return true }
+
+        do {
+            let indexes = try await client.getIndexes(ifModifiedSince: lastModified)
+            if let serverModified = indexes.lastModified, serverModified > lastModified {
+                return true
+            }
+            let hasContent = indexes.index?.isEmpty == false || indexes.child?.isEmpty == false
+            return hasContent
+        } catch {
+            syncLog.warning("Change detection failed: \(error.localizedDescription)")
+            return true
         }
-        if Date().timeIntervalSince(last) > 86400 {
-            await sync(client: client, container: container)
+    }
+
+    /// Update the stored server lastModified timestamp.
+    private func updateServerModifiedTimestamp(client: SubsonicClient) async {
+        do {
+            let indexes = try await client.getIndexes()
+            if let lastModified = indexes.lastModified {
+                UserDefaults.standard.set(lastModified, forKey: UserDefaultsKeys.lastServerModified)
+            }
+        } catch {
+            syncLog.warning("Failed to fetch server modified timestamp: \(error.localizedDescription)")
         }
     }
 
     // MARK: - Albums
 
-    private func syncAlbums(client: SubsonicClient, context: ModelContext) async throws {
+    private func syncAlbums(client: SubsonicClient, context: ModelContext,
+                            stats: inout SyncStats, incremental: Bool) async throws {
         syncProgress = "Syncing albums…"
+
+        // Build lookup dictionary of existing albums for O(1) access
+        let allLocal = try context.fetch(FetchDescriptor<CachedAlbum>())
+        var localMap = Dictionary(uniqueKeysWithValues: allLocal.map { ($0.id, $0) })
+
         var offset = 0
         var serverAlbumIds = Set<String>()
         var totalFetched = 0
 
-        while true {
-            let page = try await client.getAlbumList(
-                type: .alphabeticalByName, size: albumPageSize, offset: offset
-            )
-            if page.isEmpty { break }
-
-            for album in page {
+        if incremental {
+            // Fetch only newest albums (added/modified recently)
+            let newestAlbums = try await client.getAlbumList(type: .newest, size: albumPageSize)
+            for album in newestAlbums {
                 serverAlbumIds.insert(album.id)
-                upsertAlbum(album, context: context)
+                if let existing = localMap[album.id] {
+                    if hasAlbumChanged(existing, album) {
+                        existing.update(from: album)
+                        stats.albumsUpdated += 1
+                    }
+                } else {
+                    let cached = CachedAlbum(from: album)
+                    context.insert(cached)
+                    localMap[album.id] = cached
+                    stats.albumsAdded += 1
+                }
+            }
+            totalFetched = newestAlbums.count
+        } else {
+            // Full sync: fetch all albums
+            while true {
+                let page = try await client.getAlbumList(
+                    type: .alphabeticalByName, size: albumPageSize, offset: offset
+                )
+                if page.isEmpty { break }
+
+                for album in page {
+                    serverAlbumIds.insert(album.id)
+                    if let existing = localMap[album.id] {
+                        if hasAlbumChanged(existing, album) {
+                            existing.update(from: album)
+                            stats.albumsUpdated += 1
+                        }
+                    } else {
+                        let cached = CachedAlbum(from: album)
+                        context.insert(cached)
+                        localMap[album.id] = cached
+                        stats.albumsAdded += 1
+                    }
+                }
+
+                totalFetched += page.count
+                syncProgress = "Syncing albums… \(totalFetched)"
+                offset += page.count
+
+                if page.count < albumPageSize { break }
             }
 
-            totalFetched += page.count
-            syncProgress = "Syncing albums… \(totalFetched)"
-            offset += page.count
-
-            if page.count < albumPageSize { break }
-        }
-
-        // Remove albums no longer on server
-        let allLocal = try context.fetch(FetchDescriptor<CachedAlbum>())
-        for local in allLocal where !serverAlbumIds.contains(local.id) {
-            context.delete(local)
+            // Remove albums no longer on server
+            for local in allLocal where !serverAlbumIds.contains(local.id) {
+                context.delete(local)
+                stats.albumsRemoved += 1
+            }
         }
 
         try context.save()
-        syncLog.info("Synced \(totalFetched) albums")
+        lastSyncStats = stats
+        let added = stats.albumsAdded
+        let updated = stats.albumsUpdated
+        let removed = stats.albumsRemoved
+        syncLog.info("Synced \(totalFetched) albums (+\(added) ~\(updated) -\(removed))")
     }
 
-    private func upsertAlbum(_ album: Album, context: ModelContext) {
-        let albumId = album.id
-        var descriptor = FetchDescriptor<CachedAlbum>(
-            predicate: #Predicate { $0.id == albumId }
-        )
-        descriptor.fetchLimit = 1
-        if let existing = try? context.fetch(descriptor).first {
-            existing.update(from: album)
-        } else {
-            context.insert(CachedAlbum(from: album))
-        }
+    private func hasAlbumChanged(_ cached: CachedAlbum, _ server: Album) -> Bool {
+        cached.name != server.name ||
+        cached.artistName != server.artist ||
+        cached.year != server.year ||
+        cached.genre != server.genre ||
+        cached.songCount != server.songCount ||
+        cached.duration != server.duration ||
+        cached.isStarred != (server.starred != nil) ||
+        cached.coverArtId != server.coverArt
     }
 
     // MARK: - Artists
 
-    private func syncArtists(client: SubsonicClient, context: ModelContext) async throws {
+    private func syncArtists(client: SubsonicClient, context: ModelContext,
+                             stats: inout SyncStats, incremental: Bool) async throws {
         syncProgress = "Syncing artists…"
         let indexes = try await client.getArtists()
         var serverArtistIds = Set<String>()
 
+        // Build lookup dictionary
+        let allLocal = try context.fetch(FetchDescriptor<CachedArtist>())
+        let localMap = Dictionary(uniqueKeysWithValues: allLocal.map { ($0.id, $0) })
+
         for index in indexes {
             for artist in index.artist ?? [] {
                 serverArtistIds.insert(artist.id)
-                upsertArtist(artist, context: context)
+                if let existing = localMap[artist.id] {
+                    if hasArtistChanged(existing, artist) {
+                        existing.name = artist.name
+                        existing.coverArtId = artist.coverArt
+                        existing.albumCount = artist.albumCount
+                        existing.isStarred = artist.starred != nil
+                        existing.cachedAt = Date()
+                        stats.artistsUpdated += 1
+                    }
+                } else {
+                    context.insert(CachedArtist(from: artist))
+                    stats.artistsAdded += 1
+                }
             }
         }
 
-        // Remove artists no longer on server
-        let allLocal = try context.fetch(FetchDescriptor<CachedArtist>())
-        for local in allLocal where !serverArtistIds.contains(local.id) {
-            context.delete(local)
+        // Remove artists no longer on server (only on full sync)
+        if !incremental {
+            for local in allLocal where !serverArtistIds.contains(local.id) {
+                context.delete(local)
+                stats.artistsRemoved += 1
+            }
         }
 
         try context.save()
-        syncLog.info("Synced \(serverArtistIds.count) artists")
+        lastSyncStats = stats
+        let artAdded = stats.artistsAdded
+        let artUpdated = stats.artistsUpdated
+        let artRemoved = stats.artistsRemoved
+        syncLog.info("Synced \(serverArtistIds.count) artists (+\(artAdded) ~\(artUpdated) -\(artRemoved))")
     }
 
-    private func upsertArtist(_ artist: Artist, context: ModelContext) {
-        let artistId = artist.id
-        var descriptor = FetchDescriptor<CachedArtist>(
-            predicate: #Predicate { $0.id == artistId }
-        )
-        descriptor.fetchLimit = 1
-        if let existing = try? context.fetch(descriptor).first {
-            existing.name = artist.name
-            existing.coverArtId = artist.coverArt
-            existing.albumCount = artist.albumCount
-            existing.isStarred = artist.starred != nil
-            existing.cachedAt = Date()
-        } else {
-            context.insert(CachedArtist(from: artist))
-        }
+    private func hasArtistChanged(_ cached: CachedArtist, _ server: Artist) -> Bool {
+        cached.name != server.name ||
+        cached.coverArtId != server.coverArt ||
+        cached.albumCount != server.albumCount ||
+        cached.isStarred != (server.starred != nil)
     }
 
     // MARK: - Songs
 
-    private func syncSongs(client: SubsonicClient, context: ModelContext) async throws {
+    private func syncSongs(client: SubsonicClient, context: ModelContext,
+                           stats: inout SyncStats, incremental: Bool) async throws {
         syncProgress = "Syncing songs…"
+
+        // Build lookup dictionary for O(1) access
+        let allLocal = try context.fetch(FetchDescriptor<CachedSong>())
+        var localMap = Dictionary(uniqueKeysWithValues: allLocal.map { ($0.id, $0) })
+
+        // Pre-fetch album map for linking
+        let allAlbums = try context.fetch(FetchDescriptor<CachedAlbum>())
+        let albumMap = Dictionary(uniqueKeysWithValues: allAlbums.map { ($0.id, $0) })
+
         var offset = 0
         var serverSongIds = Set<String>()
         var totalFetched = 0
 
-        // Use search3 with empty query to get all songs
         while true {
             let result = try await client.search(
                 query: "", artistCount: 0, albumCount: 0,
@@ -173,105 +400,117 @@ final class LibrarySyncManager {
 
             for song in songs {
                 serverSongIds.insert(song.id)
-                upsertSong(song, context: context)
+                if let existing = localMap[song.id] {
+                    if hasSongChanged(existing, song) {
+                        updateSongFields(existing, from: song)
+                        stats.songsUpdated += 1
+                    }
+                } else {
+                    let cached = CachedSong(from: song)
+                    if let albumId = song.albumId {
+                        cached.album = albumMap[albumId]
+                    }
+                    context.insert(cached)
+                    localMap[song.id] = cached
+                    stats.songsAdded += 1
+                }
             }
 
             totalFetched += songs.count
             syncProgress = "Syncing songs… \(totalFetched)"
             offset += songs.count
 
-            // Save periodically to manage memory
             if totalFetched % 2000 == 0 {
                 try context.save()
+                lastSyncStats = stats
             }
 
             if songs.count < songPageSize { break }
         }
 
-        // Remove songs no longer on server (only cached songs without downloads)
-        let allLocal = try context.fetch(FetchDescriptor<CachedSong>())
-        for local in allLocal where !serverSongIds.contains(local.id) && local.download == nil {
-            context.delete(local)
+        // Remove songs no longer on server (only on full sync, preserve downloads)
+        if !incremental {
+            for local in allLocal where !serverSongIds.contains(local.id) && local.download == nil {
+                context.delete(local)
+                stats.songsRemoved += 1
+            }
         }
 
         try context.save()
-        syncLog.info("Synced \(totalFetched) songs")
+        lastSyncStats = stats
+        await updateServerModifiedTimestamp(client: client)
+        let songAdded = stats.songsAdded
+        let songUpdated = stats.songsUpdated
+        let songRemoved = stats.songsRemoved
+        syncLog.info("Synced \(totalFetched) songs (+\(songAdded) ~\(songUpdated) -\(songRemoved))")
     }
 
-    private func upsertSong(_ song: Song, context: ModelContext) {
-        let songId = song.id
-        var descriptor = FetchDescriptor<CachedSong>(
-            predicate: #Predicate { $0.id == songId }
-        )
-        descriptor.fetchLimit = 1
-        if let existing = try? context.fetch(descriptor).first {
-            existing.title = song.title
-            existing.artist = song.artist
-            existing.albumArtist = song.albumArtist
-            existing.albumName = song.album
-            existing.albumId = song.albumId
-            existing.artistId = song.artistId
-            existing.coverArtId = song.coverArt
-            existing.track = song.track
-            existing.discNumber = song.discNumber
-            existing.year = song.year
-            existing.genre = song.genre
-            existing.duration = song.duration
-            existing.bitRate = song.bitRate
-            existing.suffix = song.suffix
-            existing.contentType = song.contentType
-            existing.size = song.size
-            existing.isStarred = song.starred != nil
-            existing.rating = song.userRating ?? 0
-            existing.cachedAt = Date()
-        } else {
-            let cached = CachedSong(from: song)
-            // Link to album if it exists
-            if let albumId = song.albumId {
-                var albumDesc = FetchDescriptor<CachedAlbum>(
-                    predicate: #Predicate { $0.id == albumId }
-                )
-                albumDesc.fetchLimit = 1
-                cached.album = try? context.fetch(albumDesc).first
-            }
-            context.insert(cached)
-        }
+    private func hasSongChanged(_ cached: CachedSong, _ server: Song) -> Bool {
+        cached.title != server.title ||
+        cached.artist != server.artist ||
+        cached.albumName != server.album ||
+        cached.track != server.track ||
+        cached.year != server.year ||
+        cached.genre != server.genre ||
+        cached.duration != server.duration ||
+        cached.isStarred != (server.starred != nil) ||
+        cached.coverArtId != server.coverArt ||
+        cached.bitRate != server.bitRate
+    }
+
+    private func updateSongFields(_ cached: CachedSong, from song: Song) {
+        cached.title = song.title
+        cached.artist = song.artist
+        cached.albumArtist = song.albumArtist
+        cached.albumName = song.album
+        cached.albumId = song.albumId
+        cached.artistId = song.artistId
+        cached.coverArtId = song.coverArt
+        cached.track = song.track
+        cached.discNumber = song.discNumber
+        cached.year = song.year
+        cached.genre = song.genre
+        cached.duration = song.duration
+        cached.bitRate = song.bitRate
+        cached.suffix = song.suffix
+        cached.contentType = song.contentType
+        cached.size = song.size
+        cached.isStarred = song.starred != nil
+        cached.rating = song.userRating ?? 0
+        cached.cachedAt = Date()
     }
 
     // MARK: - Playlists
 
-    private func syncPlaylists(client: SubsonicClient, context: ModelContext) async throws {
+    private func syncPlaylists(client: SubsonicClient, context: ModelContext,
+                               stats: inout SyncStats) async throws {
         syncProgress = "Syncing playlists…"
         let playlists = try await client.getPlaylists()
         var serverPlaylistIds = Set<String>()
 
+        let allLocal = try context.fetch(FetchDescriptor<CachedPlaylist>())
+        let localMap = Dictionary(uniqueKeysWithValues: allLocal.map { ($0.id, $0) })
+
         for playlist in playlists {
             serverPlaylistIds.insert(playlist.id)
-
-            // Fetch full playlist with song entries
             let detail = try await client.getPlaylist(id: playlist.id)
-            upsertPlaylist(detail, context: context)
+            upsertPlaylist(detail, context: context, localMap: localMap)
+            stats.playlistsSynced += 1
         }
 
-        // Remove playlists no longer on server
-        let allLocal = try context.fetch(FetchDescriptor<CachedPlaylist>())
         for local in allLocal where !serverPlaylistIds.contains(local.id) {
             context.delete(local)
         }
 
         try context.save()
+        lastSyncStats = stats
         syncLog.info("Synced \(playlists.count) playlists with entries")
     }
 
-    private func upsertPlaylist(_ playlist: Playlist, context: ModelContext) {
-        let playlistId = playlist.id
-        var descriptor = FetchDescriptor<CachedPlaylist>(
-            predicate: #Predicate { $0.id == playlistId }
-        )
-        descriptor.fetchLimit = 1
-
+    private func upsertPlaylist(_ playlist: Playlist, context: ModelContext,
+                                localMap: [String: CachedPlaylist]) {
         let cached: CachedPlaylist
-        if let existing = try? context.fetch(descriptor).first {
+        if let existing = localMap[playlist.id] {
             existing.name = playlist.name
             existing.songCount = playlist.songCount
             existing.duration = playlist.duration
@@ -285,13 +524,10 @@ final class LibrarySyncManager {
             context.insert(cached)
         }
 
-        // Sync playlist entries (ordered song references)
-        // Remove old entries
         for entry in cached.entries {
             context.delete(entry)
         }
 
-        // Add current entries in order
         if let songs = playlist.entry {
             for (index, song) in songs.enumerated() {
                 let entry = CachedPlaylistEntry(songId: song.id, order: index)
@@ -306,7 +542,6 @@ final class LibrarySyncManager {
     private func prefetchCoverArt(client: SubsonicClient, context: ModelContext) async {
         syncProgress = "Prefetching cover art…"
 
-        // Collect all unique coverArtIds from albums (albums cover most songs too)
         var coverArtIds = Set<String>()
 
         let albums = (try? context.fetch(FetchDescriptor<CachedAlbum>())) ?? []
@@ -324,15 +559,11 @@ final class LibrarySyncManager {
         syncLog.info("Prefetching \(total) cover art images")
 
         let pipeline = ImagePipeline.shared
-
-        // Pre-compute URLs on the main actor (SubsonicClient is @MainActor)
         let urlMap: [(String, URL)] = coverArtIds.map { id in
             (id, client.coverArtURL(id: id, size: 600))
         }
 
         var fetched = 0
-
-        // Process in batches of 10 concurrent requests
         let batchSize = 10
         for batchStart in stride(from: 0, to: urlMap.count, by: batchSize) {
             let batch = urlMap[batchStart..<min(batchStart + batchSize, urlMap.count)]
@@ -350,5 +581,43 @@ final class LibrarySyncManager {
         }
 
         syncLog.info("Cover art prefetch complete: \(fetched) processed")
+    }
+
+    // MARK: - Sync History
+
+    private func saveSyncHistory(stats: SyncStats, mode: SyncMode,
+                                 context: ModelContext, error: Error? = nil) {
+        let history = SyncHistory(syncType: mode.rawValue)
+        history.durationSeconds = stats.duration
+        history.albumsAdded = stats.albumsAdded
+        history.albumsUpdated = stats.albumsUpdated
+        history.albumsRemoved = stats.albumsRemoved
+        history.artistsAdded = stats.artistsAdded
+        history.artistsUpdated = stats.artistsUpdated
+        history.artistsRemoved = stats.artistsRemoved
+        history.songsAdded = stats.songsAdded
+        history.songsUpdated = stats.songsUpdated
+        history.songsRemoved = stats.songsRemoved
+        history.playlistsSynced = stats.playlistsSynced
+        history.conflictsDetected = stats.conflictsDetected
+        history.conflictsResolved = stats.conflictsResolved
+        history.succeeded = error == nil
+        history.errorMessage = error?.localizedDescription
+        context.insert(history)
+        try? context.save()
+
+        pruneSyncHistory(context: context)
+    }
+
+    private func pruneSyncHistory(context: ModelContext) {
+        var descriptor = FetchDescriptor<SyncHistory>(
+            sortBy: [SortDescriptor(\.syncDate, order: .reverse)]
+        )
+        descriptor.fetchOffset = 50
+        guard let old = try? context.fetch(descriptor), !old.isEmpty else { return }
+        for entry in old {
+            context.delete(entry)
+        }
+        try? context.save()
     }
 }

--- a/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
+++ b/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
@@ -322,12 +322,16 @@ final class LibrarySyncManager {
     private func hasAlbumChanged(_ cached: CachedAlbum, _ server: Album) -> Bool {
         cached.name != server.name ||
         cached.artistName != server.artist ||
+        cached.artistId != server.artistId ||
         cached.year != server.year ||
         cached.genre != server.genre ||
         cached.songCount != server.songCount ||
         cached.duration != server.duration ||
         cached.isStarred != (server.starred != nil) ||
-        cached.coverArtId != server.coverArt
+        cached.coverArtId != server.coverArt ||
+        cached.created != server.created ||
+        cached.userRating != (server.userRating ?? 0) ||
+        cached.label != server.label
     }
 
     // MARK: - Artists

--- a/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
+++ b/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
@@ -503,9 +503,33 @@ final class LibrarySyncManager {
         let allLocal = try context.fetch(FetchDescriptor<CachedPlaylist>())
         let localMap = Dictionary(uniqueKeysWithValues: allLocal.map { ($0.id, $0) })
 
-        for playlist in playlists {
-            serverPlaylistIds.insert(playlist.id)
-            let detail = try await client.getPlaylist(id: playlist.id)
+        // Fetch playlist details with bounded concurrency
+        let details = try await withThrowingTaskGroup(of: Playlist.self, returning: [Playlist].self) { group in
+            var results: [Playlist] = []
+            var inflight = 0
+            let maxConcurrency = 5
+
+            for playlist in playlists {
+                if inflight >= maxConcurrency {
+                    if let detail = try await group.next() {
+                        results.append(detail)
+                    }
+                    inflight -= 1
+                }
+                group.addTask {
+                    try await client.getPlaylist(id: playlist.id)
+                }
+                inflight += 1
+            }
+
+            for try await detail in group {
+                results.append(detail)
+            }
+            return results
+        }
+
+        for detail in details {
+            serverPlaylistIds.insert(detail.id)
             upsertPlaylist(detail, context: context, localMap: localMap)
             stats.playlistsSynced += 1
         }
@@ -555,14 +579,21 @@ final class LibrarySyncManager {
     private func prefetchCoverArt(client: SubsonicClient, context: ModelContext) async {
         syncProgress = "Prefetching cover art…"
 
+        // Collect cover art IDs from albums and artists without loading full objects
         var coverArtIds = Set<String>()
 
-        let albums = (try? context.fetch(FetchDescriptor<CachedAlbum>())) ?? []
+        let albumDescriptor = FetchDescriptor<CachedAlbum>(
+            predicate: #Predicate<CachedAlbum> { $0.coverArtId != nil }
+        )
+        let albums = (try? context.fetch(albumDescriptor)) ?? []
         for album in albums {
             if let id = album.coverArtId { coverArtIds.insert(id) }
         }
 
-        let artists = (try? context.fetch(FetchDescriptor<CachedArtist>())) ?? []
+        let artistDescriptor = FetchDescriptor<CachedArtist>(
+            predicate: #Predicate<CachedArtist> { $0.coverArtId != nil }
+        )
+        let artists = (try? context.fetch(artistDescriptor)) ?? []
         for artist in artists {
             if let id = artist.coverArtId { coverArtIds.insert(id) }
         }
@@ -627,10 +658,15 @@ final class LibrarySyncManager {
             sortBy: [SortDescriptor(\.syncDate, order: .reverse)]
         )
         descriptor.fetchOffset = 50
-        guard let old = try? context.fetch(descriptor), !old.isEmpty else { return }
-        for entry in old {
-            context.delete(entry)
+        do {
+            let old = try context.fetch(descriptor)
+            guard !old.isEmpty else { return }
+            for entry in old {
+                context.delete(entry)
+            }
+            try context.save()
+        } catch {
+            syncLog.warning("Failed to prune sync history: \(error.localizedDescription)")
         }
-        try? context.save()
     }
 }

--- a/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
+++ b/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
@@ -20,6 +20,12 @@ enum SyncMode: String, Sendable {
 @Observable
 @MainActor
 final class LibrarySyncManager {
+    static let shared = LibrarySyncManager()
+
+    /// Configured by AppState at login for convenience sync calls.
+    weak var client: SubsonicClient?
+    var container: ModelContainer?
+
     var isSyncing = false
     var syncProgress: String?
     var lastSyncDate: Date? {
@@ -80,6 +86,12 @@ final class LibrarySyncManager {
     /// Run an incremental sync — only fetches changes since last sync.
     func incrementalSync(client: SubsonicClient, container: ModelContainer) async {
         await performSync(mode: .incremental, client: client, container: container)
+    }
+
+    /// Convenience: sync using the configured client and container.
+    func syncIfStale() async {
+        guard let client, let container else { return }
+        await syncIfStale(client: client, container: container)
     }
 
     /// Check if sync is stale and trigger the appropriate sync mode.
@@ -517,6 +529,7 @@ final class LibrarySyncManager {
             existing.coverArtId = playlist.coverArt
             existing.owner = playlist.owner
             existing.isPublic = playlist.isPublic ?? false
+            existing.changed = playlist.changed
             existing.cachedAt = Date()
             cached = existing
         } else {

--- a/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
+++ b/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
@@ -580,9 +580,14 @@ final class LibrarySyncManager {
 
     // MARK: - Cover Art Prefetch
 
+    /// Whether a prefetch pass already ran this session (avoids duplicate work).
+    private var didPrefetchThisSession = false
+
     /// Warm the in-memory image cache on startup by loading all known cover art.
     /// Images already in memory are skipped; images in disk cache load instantly.
+    /// Skipped if a prefetch already ran during sync this session.
     func warmImageCache(client: SubsonicClient, container: ModelContainer) async {
+        guard !didPrefetchThisSession else { return }
         let context = ModelContext(container)
         await prefetchCoverArt(client: client, context: context)
     }
@@ -610,7 +615,10 @@ final class LibrarySyncManager {
         }
 
         let total = coverArtIds.count
-        guard total > 0 else { return }
+        guard total > 0 else {
+            didPrefetchThisSession = true
+            return
+        }
         syncLog.info("Prefetching \(total) cover art images")
 
         let pipeline = ImagePipeline.shared
@@ -620,14 +628,28 @@ final class LibrarySyncManager {
 
         var fetched = 0
         let batchSize = 10
+        let perImageTimeout: UInt64 = 15_000_000_000 // 15 seconds
+
         for batchStart in stride(from: 0, to: urlMap.count, by: batchSize) {
+            guard !Task.isCancelled else { break }
             let batch = urlMap[batchStart..<min(batchStart + batchSize, urlMap.count)]
             await withTaskGroup(of: Void.self) { group in
                 for (_, url) in batch {
                     group.addTask {
                         let request = ImageRequest(url: url)
                         if pipeline.cache.containsCachedImage(for: request) { return }
-                        _ = try? await pipeline.image(for: request)
+                        // Timeout prevents a single stalled request from blocking the entire prefetch
+                        await withTaskGroup(of: Void.self) { inner in
+                            inner.addTask {
+                                _ = try? await pipeline.image(for: request)
+                            }
+                            inner.addTask {
+                                try? await Task.sleep(nanoseconds: perImageTimeout)
+                            }
+                            // Return as soon as the first child completes (image loaded or timeout)
+                            await inner.next()
+                            inner.cancelAll()
+                        }
                     }
                 }
             }
@@ -635,6 +657,7 @@ final class LibrarySyncManager {
             syncProgress = "Prefetching cover art… \(fetched)/\(total)"
         }
 
+        didPrefetchThisSession = true
         syncLog.info("Cover art prefetch complete: \(fetched) processed")
     }
 

--- a/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
+++ b/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
@@ -1,0 +1,354 @@
+import Foundation
+import Nuke
+import SwiftData
+import os.log
+
+private let syncLog = Logger(subsystem: "com.vibrdrome.app", category: "LibrarySync")
+
+/// Syncs full library metadata (albums, artists, songs) from the Subsonic API
+/// into SwiftData for local filtering and search.
+@Observable
+@MainActor
+final class LibrarySyncManager {
+    var isSyncing = false
+    var syncProgress: String?
+    var lastSyncDate: Date? {
+        get { UserDefaults.standard.object(forKey: UserDefaultsKeys.lastLibrarySyncDate) as? Date }
+        set { UserDefaults.standard.set(newValue, forKey: UserDefaultsKeys.lastLibrarySyncDate) }
+    }
+    var syncError: String?
+
+    private let albumPageSize = 500
+    private let songPageSize = 500
+
+    /// Run a full library sync: albums, artists, then songs.
+    func sync(client: SubsonicClient, container: ModelContainer) async {
+        guard !isSyncing else { return }
+        isSyncing = true
+        syncError = nil
+        syncProgress = "Starting sync…"
+        defer {
+            isSyncing = false
+            syncProgress = nil
+        }
+
+        do {
+            let context = ModelContext(container)
+            context.autosaveEnabled = false
+
+            try await syncAlbums(client: client, context: context)
+            try await syncArtists(client: client, context: context)
+            try await syncSongs(client: client, context: context)
+            try await syncPlaylists(client: client, context: context)
+
+            try context.save()
+            lastSyncDate = Date()
+            syncLog.info("Library sync completed successfully")
+
+            // Prefetch cover art in background after metadata sync
+            await prefetchCoverArt(client: client, context: context)
+        } catch {
+            syncError = "Sync failed: \(error.localizedDescription)"
+            syncLog.error("Library sync failed: \(error)")
+        }
+    }
+
+    /// Check if sync is stale (>24h) and trigger background sync if needed.
+    func syncIfStale(client: SubsonicClient, container: ModelContainer) async {
+        guard let last = lastSyncDate else {
+            await sync(client: client, container: container)
+            return
+        }
+        if Date().timeIntervalSince(last) > 86400 {
+            await sync(client: client, container: container)
+        }
+    }
+
+    // MARK: - Albums
+
+    private func syncAlbums(client: SubsonicClient, context: ModelContext) async throws {
+        syncProgress = "Syncing albums…"
+        var offset = 0
+        var serverAlbumIds = Set<String>()
+        var totalFetched = 0
+
+        while true {
+            let page = try await client.getAlbumList(
+                type: .alphabeticalByName, size: albumPageSize, offset: offset
+            )
+            if page.isEmpty { break }
+
+            for album in page {
+                serverAlbumIds.insert(album.id)
+                upsertAlbum(album, context: context)
+            }
+
+            totalFetched += page.count
+            syncProgress = "Syncing albums… \(totalFetched)"
+            offset += page.count
+
+            if page.count < albumPageSize { break }
+        }
+
+        // Remove albums no longer on server
+        let allLocal = try context.fetch(FetchDescriptor<CachedAlbum>())
+        for local in allLocal where !serverAlbumIds.contains(local.id) {
+            context.delete(local)
+        }
+
+        try context.save()
+        syncLog.info("Synced \(totalFetched) albums")
+    }
+
+    private func upsertAlbum(_ album: Album, context: ModelContext) {
+        let albumId = album.id
+        var descriptor = FetchDescriptor<CachedAlbum>(
+            predicate: #Predicate { $0.id == albumId }
+        )
+        descriptor.fetchLimit = 1
+        if let existing = try? context.fetch(descriptor).first {
+            existing.update(from: album)
+        } else {
+            context.insert(CachedAlbum(from: album))
+        }
+    }
+
+    // MARK: - Artists
+
+    private func syncArtists(client: SubsonicClient, context: ModelContext) async throws {
+        syncProgress = "Syncing artists…"
+        let indexes = try await client.getArtists()
+        var serverArtistIds = Set<String>()
+
+        for index in indexes {
+            for artist in index.artist ?? [] {
+                serverArtistIds.insert(artist.id)
+                upsertArtist(artist, context: context)
+            }
+        }
+
+        // Remove artists no longer on server
+        let allLocal = try context.fetch(FetchDescriptor<CachedArtist>())
+        for local in allLocal where !serverArtistIds.contains(local.id) {
+            context.delete(local)
+        }
+
+        try context.save()
+        syncLog.info("Synced \(serverArtistIds.count) artists")
+    }
+
+    private func upsertArtist(_ artist: Artist, context: ModelContext) {
+        let artistId = artist.id
+        var descriptor = FetchDescriptor<CachedArtist>(
+            predicate: #Predicate { $0.id == artistId }
+        )
+        descriptor.fetchLimit = 1
+        if let existing = try? context.fetch(descriptor).first {
+            existing.name = artist.name
+            existing.coverArtId = artist.coverArt
+            existing.albumCount = artist.albumCount
+            existing.isStarred = artist.starred != nil
+            existing.cachedAt = Date()
+        } else {
+            context.insert(CachedArtist(from: artist))
+        }
+    }
+
+    // MARK: - Songs
+
+    private func syncSongs(client: SubsonicClient, context: ModelContext) async throws {
+        syncProgress = "Syncing songs…"
+        var offset = 0
+        var serverSongIds = Set<String>()
+        var totalFetched = 0
+
+        // Use search3 with empty query to get all songs
+        while true {
+            let result = try await client.search(
+                query: "", artistCount: 0, albumCount: 0,
+                songCount: songPageSize, songOffset: offset
+            )
+            let songs = result.song ?? []
+            if songs.isEmpty { break }
+
+            for song in songs {
+                serverSongIds.insert(song.id)
+                upsertSong(song, context: context)
+            }
+
+            totalFetched += songs.count
+            syncProgress = "Syncing songs… \(totalFetched)"
+            offset += songs.count
+
+            // Save periodically to manage memory
+            if totalFetched % 2000 == 0 {
+                try context.save()
+            }
+
+            if songs.count < songPageSize { break }
+        }
+
+        // Remove songs no longer on server (only cached songs without downloads)
+        let allLocal = try context.fetch(FetchDescriptor<CachedSong>())
+        for local in allLocal where !serverSongIds.contains(local.id) && local.download == nil {
+            context.delete(local)
+        }
+
+        try context.save()
+        syncLog.info("Synced \(totalFetched) songs")
+    }
+
+    private func upsertSong(_ song: Song, context: ModelContext) {
+        let songId = song.id
+        var descriptor = FetchDescriptor<CachedSong>(
+            predicate: #Predicate { $0.id == songId }
+        )
+        descriptor.fetchLimit = 1
+        if let existing = try? context.fetch(descriptor).first {
+            existing.title = song.title
+            existing.artist = song.artist
+            existing.albumArtist = song.albumArtist
+            existing.albumName = song.album
+            existing.albumId = song.albumId
+            existing.artistId = song.artistId
+            existing.coverArtId = song.coverArt
+            existing.track = song.track
+            existing.discNumber = song.discNumber
+            existing.year = song.year
+            existing.genre = song.genre
+            existing.duration = song.duration
+            existing.bitRate = song.bitRate
+            existing.suffix = song.suffix
+            existing.contentType = song.contentType
+            existing.size = song.size
+            existing.isStarred = song.starred != nil
+            existing.rating = song.userRating ?? 0
+            existing.cachedAt = Date()
+        } else {
+            let cached = CachedSong(from: song)
+            // Link to album if it exists
+            if let albumId = song.albumId {
+                var albumDesc = FetchDescriptor<CachedAlbum>(
+                    predicate: #Predicate { $0.id == albumId }
+                )
+                albumDesc.fetchLimit = 1
+                cached.album = try? context.fetch(albumDesc).first
+            }
+            context.insert(cached)
+        }
+    }
+
+    // MARK: - Playlists
+
+    private func syncPlaylists(client: SubsonicClient, context: ModelContext) async throws {
+        syncProgress = "Syncing playlists…"
+        let playlists = try await client.getPlaylists()
+        var serverPlaylistIds = Set<String>()
+
+        for playlist in playlists {
+            serverPlaylistIds.insert(playlist.id)
+
+            // Fetch full playlist with song entries
+            let detail = try await client.getPlaylist(id: playlist.id)
+            upsertPlaylist(detail, context: context)
+        }
+
+        // Remove playlists no longer on server
+        let allLocal = try context.fetch(FetchDescriptor<CachedPlaylist>())
+        for local in allLocal where !serverPlaylistIds.contains(local.id) {
+            context.delete(local)
+        }
+
+        try context.save()
+        syncLog.info("Synced \(playlists.count) playlists with entries")
+    }
+
+    private func upsertPlaylist(_ playlist: Playlist, context: ModelContext) {
+        let playlistId = playlist.id
+        var descriptor = FetchDescriptor<CachedPlaylist>(
+            predicate: #Predicate { $0.id == playlistId }
+        )
+        descriptor.fetchLimit = 1
+
+        let cached: CachedPlaylist
+        if let existing = try? context.fetch(descriptor).first {
+            existing.name = playlist.name
+            existing.songCount = playlist.songCount
+            existing.duration = playlist.duration
+            existing.coverArtId = playlist.coverArt
+            existing.owner = playlist.owner
+            existing.isPublic = playlist.isPublic ?? false
+            existing.cachedAt = Date()
+            cached = existing
+        } else {
+            cached = CachedPlaylist(from: playlist)
+            context.insert(cached)
+        }
+
+        // Sync playlist entries (ordered song references)
+        // Remove old entries
+        for entry in cached.entries {
+            context.delete(entry)
+        }
+
+        // Add current entries in order
+        if let songs = playlist.entry {
+            for (index, song) in songs.enumerated() {
+                let entry = CachedPlaylistEntry(songId: song.id, order: index)
+                entry.playlist = cached
+                context.insert(entry)
+            }
+        }
+    }
+
+    // MARK: - Cover Art Prefetch
+
+    private func prefetchCoverArt(client: SubsonicClient, context: ModelContext) async {
+        syncProgress = "Prefetching cover art…"
+
+        // Collect all unique coverArtIds from albums (albums cover most songs too)
+        var coverArtIds = Set<String>()
+
+        let albums = (try? context.fetch(FetchDescriptor<CachedAlbum>())) ?? []
+        for album in albums {
+            if let id = album.coverArtId { coverArtIds.insert(id) }
+        }
+
+        let artists = (try? context.fetch(FetchDescriptor<CachedArtist>())) ?? []
+        for artist in artists {
+            if let id = artist.coverArtId { coverArtIds.insert(id) }
+        }
+
+        let total = coverArtIds.count
+        guard total > 0 else { return }
+        syncLog.info("Prefetching \(total) cover art images")
+
+        let pipeline = ImagePipeline.shared
+
+        // Pre-compute URLs on the main actor (SubsonicClient is @MainActor)
+        let urlMap: [(String, URL)] = coverArtIds.map { id in
+            (id, client.coverArtURL(id: id, size: 600))
+        }
+
+        var fetched = 0
+
+        // Process in batches of 10 concurrent requests
+        let batchSize = 10
+        for batchStart in stride(from: 0, to: urlMap.count, by: batchSize) {
+            let batch = urlMap[batchStart..<min(batchStart + batchSize, urlMap.count)]
+            await withTaskGroup(of: Void.self) { group in
+                for (_, url) in batch {
+                    group.addTask {
+                        let request = ImageRequest(url: url)
+                        if pipeline.cache.containsCachedImage(for: request) { return }
+                        _ = try? await pipeline.image(for: request)
+                    }
+                }
+            }
+            fetched += batch.count
+            syncProgress = "Prefetching cover art… \(fetched)/\(total)"
+        }
+
+        syncLog.info("Cover art prefetch complete: \(fetched) processed")
+    }
+}

--- a/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
+++ b/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
@@ -511,7 +511,7 @@ final class LibrarySyncManager {
         let details = try await withThrowingTaskGroup(of: Playlist.self, returning: [Playlist].self) { group in
             var results: [Playlist] = []
             var inflight = 0
-            let maxConcurrency = 5
+            let maxConcurrency = 2
 
             for playlist in playlists {
                 if inflight >= maxConcurrency {

--- a/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
+++ b/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
@@ -580,6 +580,13 @@ final class LibrarySyncManager {
 
     // MARK: - Cover Art Prefetch
 
+    /// Warm the in-memory image cache on startup by loading all known cover art.
+    /// Images already in memory are skipped; images in disk cache load instantly.
+    func warmImageCache(client: SubsonicClient, container: ModelContainer) async {
+        let context = ModelContext(container)
+        await prefetchCoverArt(client: client, context: context)
+    }
+
     private func prefetchCoverArt(client: SubsonicClient, context: ModelContext) async {
         syncProgress = "Prefetching cover art…"
 

--- a/Vibrdrome/Core/Persistence/Models/CachedAlbum.swift
+++ b/Vibrdrome/Core/Persistence/Models/CachedAlbum.swift
@@ -13,6 +13,9 @@ final class CachedAlbum {
     var songCount: Int?
     var duration: Int?
     var isStarred: Bool = false
+    var created: String?
+    var userRating: Int = 0
+    var label: String?
     var cachedAt: Date = Date()
 
     var songs: [CachedSong] = []
@@ -28,5 +31,47 @@ final class CachedAlbum {
         self.songCount = album.songCount
         self.duration = album.duration
         self.isStarred = album.starred != nil
+        self.created = album.created
+        self.userRating = album.userRating ?? 0
+        self.label = album.label
+    }
+
+    /// Update existing record with fresh server data.
+    func update(from album: Album) {
+        name = album.name
+        artistName = album.artist
+        artistId = album.artistId
+        coverArtId = album.coverArt
+        year = album.year
+        genre = album.genre
+        songCount = album.songCount
+        duration = album.duration
+        isStarred = album.starred != nil
+        created = album.created
+        userRating = album.userRating ?? 0
+        label = album.label
+        cachedAt = Date()
+    }
+
+    /// Convert back to an Album value type for view compatibility.
+    func toAlbum() -> Album {
+        Album(
+            id: id,
+            name: name,
+            artist: artistName,
+            artistId: artistId,
+            coverArt: coverArtId,
+            songCount: songCount,
+            duration: duration,
+            year: year,
+            genre: genre,
+            starred: isStarred ? "true" : nil,
+            created: created,
+            userRating: userRating > 0 ? userRating : nil,
+            song: nil,
+            replayGain: nil,
+            musicBrainzId: nil,
+            recordLabels: label.map { [RecordLabel(name: $0)] }
+        )
     }
 }

--- a/Vibrdrome/Core/Persistence/Models/CachedArtist.swift
+++ b/Vibrdrome/Core/Persistence/Models/CachedArtist.swift
@@ -17,4 +17,15 @@ final class CachedArtist {
         self.albumCount = artist.albumCount
         self.isStarred = artist.starred != nil
     }
+
+    func toArtist() -> Artist {
+        Artist(
+            id: id,
+            name: name,
+            coverArt: coverArtId,
+            albumCount: albumCount,
+            starred: isStarred ? "true" : nil,
+            album: nil
+        )
+    }
 }

--- a/Vibrdrome/Core/Persistence/Models/CachedPlaylist.swift
+++ b/Vibrdrome/Core/Persistence/Models/CachedPlaylist.swift
@@ -10,6 +10,7 @@ final class CachedPlaylist {
     var coverArtId: String?
     var owner: String?
     var isPublic: Bool = false
+    var changed: String?
     var cachedAt: Date = Date()
 
     var entries: [CachedPlaylistEntry] = []
@@ -22,5 +23,21 @@ final class CachedPlaylist {
         self.coverArtId = playlist.coverArt
         self.owner = playlist.owner
         self.isPublic = playlist.isPublic ?? false
+        self.changed = playlist.changed
+    }
+
+    func toPlaylist() -> Playlist {
+        Playlist(
+            id: id,
+            name: name,
+            songCount: songCount,
+            duration: duration,
+            created: nil,
+            changed: changed,
+            coverArt: coverArtId,
+            owner: owner,
+            isPublic: isPublic,
+            entry: nil
+        )
     }
 }

--- a/Vibrdrome/Core/Persistence/Models/CachedPlaylist.swift
+++ b/Vibrdrome/Core/Persistence/Models/CachedPlaylist.swift
@@ -13,7 +13,7 @@ final class CachedPlaylist {
     var changed: String?
     var cachedAt: Date = Date()
 
-    var entries: [CachedPlaylistEntry] = []
+    @Relationship(deleteRule: .cascade) var entries: [CachedPlaylistEntry] = []
 
     init(from playlist: Playlist) {
         self.id = playlist.id

--- a/Vibrdrome/Core/Persistence/Models/CachedPlaylist.swift
+++ b/Vibrdrome/Core/Persistence/Models/CachedPlaylist.swift
@@ -12,6 +12,8 @@ final class CachedPlaylist {
     var isPublic: Bool = false
     var cachedAt: Date = Date()
 
+    var entries: [CachedPlaylistEntry] = []
+
     init(from playlist: Playlist) {
         self.id = playlist.id
         self.name = playlist.name

--- a/Vibrdrome/Core/Persistence/Models/CachedPlaylistEntry.swift
+++ b/Vibrdrome/Core/Persistence/Models/CachedPlaylistEntry.swift
@@ -1,0 +1,15 @@
+import Foundation
+import SwiftData
+
+@Model
+final class CachedPlaylistEntry {
+    var songId: String
+    var order: Int
+
+    @Relationship(inverse: \CachedPlaylist.entries) var playlist: CachedPlaylist?
+
+    init(songId: String, order: Int) {
+        self.songId = songId
+        self.order = order
+    }
+}

--- a/Vibrdrome/Core/Persistence/Models/CachedPlaylistEntry.swift
+++ b/Vibrdrome/Core/Persistence/Models/CachedPlaylistEntry.swift
@@ -6,7 +6,7 @@ final class CachedPlaylistEntry {
     var songId: String
     var order: Int
 
-    @Relationship(inverse: \CachedPlaylist.entries) var playlist: CachedPlaylist?
+    var playlist: CachedPlaylist?
 
     init(songId: String, order: Int) {
         self.songId = songId

--- a/Vibrdrome/Core/Persistence/Models/SyncHistory.swift
+++ b/Vibrdrome/Core/Persistence/Models/SyncHistory.swift
@@ -1,0 +1,52 @@
+import Foundation
+import SwiftData
+
+@Model
+final class SyncHistory {
+    var syncDate: Date = Date()
+    /// "full", "incremental", "background"
+    var syncType: String = "full"
+    var durationSeconds: Double = 0
+    var albumsAdded: Int = 0
+    var albumsUpdated: Int = 0
+    var albumsRemoved: Int = 0
+    var artistsAdded: Int = 0
+    var artistsUpdated: Int = 0
+    var artistsRemoved: Int = 0
+    var songsAdded: Int = 0
+    var songsUpdated: Int = 0
+    var songsRemoved: Int = 0
+    var playlistsSynced: Int = 0
+    var conflictsDetected: Int = 0
+    var conflictsResolved: Int = 0
+    var errorMessage: String?
+    var succeeded: Bool = true
+
+    init(syncType: String) {
+        self.syncType = syncType
+        self.syncDate = Date()
+    }
+
+    var totalChanges: Int {
+        albumsAdded + albumsUpdated + albumsRemoved +
+        artistsAdded + artistsUpdated + artistsRemoved +
+        songsAdded + songsUpdated + songsRemoved
+    }
+
+    var summary: String {
+        if !succeeded, let error = errorMessage {
+            return "Failed: \(error)"
+        }
+        if totalChanges == 0 {
+            return "No changes"
+        }
+        var parts: [String] = []
+        let added = albumsAdded + artistsAdded + songsAdded
+        let updated = albumsUpdated + artistsUpdated + songsUpdated
+        let removed = albumsRemoved + artistsRemoved + songsRemoved
+        if added > 0 { parts.append("+\(added)") }
+        if updated > 0 { parts.append("~\(updated)") }
+        if removed > 0 { parts.append("-\(removed)") }
+        return parts.joined(separator: " ")
+    }
+}

--- a/Vibrdrome/Core/Persistence/PersistenceController.swift
+++ b/Vibrdrome/Core/Persistence/PersistenceController.swift
@@ -30,6 +30,7 @@ final class PersistenceController {
             OfflinePlaylist.self,
             PendingAction.self,
             SavedQueue.self,
+            SyncHistory.self,
         ])
 
         let config = ModelConfiguration(

--- a/Vibrdrome/Core/Persistence/PersistenceController.swift
+++ b/Vibrdrome/Core/Persistence/PersistenceController.swift
@@ -23,6 +23,7 @@ final class PersistenceController {
             CachedAlbum.self,
             CachedSong.self,
             CachedPlaylist.self,
+            CachedPlaylistEntry.self,
             DownloadedSong.self,
             PlayHistory.self,
             ServerConfig.self,

--- a/Vibrdrome/Features/Library/AlbumDetailView.swift
+++ b/Vibrdrome/Features/Library/AlbumDetailView.swift
@@ -1,10 +1,12 @@
 import SwiftUI
+import SwiftData
 import NukeUI
 
 struct AlbumDetailView: View {
     let albumId: String
 
     @Environment(AppState.self) private var appState
+    @Environment(\.modelContext) private var modelContext
     @State private var album: Album?
     @State private var albumNotes: String?
     @State private var showFullNotes = false
@@ -581,7 +583,33 @@ struct AlbumDetailView: View {
     }
 
     private func loadAlbum() async {
-        isLoading = true
+        // Show cached album header instantly if available
+        if album == nil {
+            let aid = albumId
+            let descriptor = FetchDescriptor<CachedAlbum>(
+                predicate: #Predicate { $0.id == aid }
+            )
+            if let cached = try? modelContext.fetch(descriptor).first {
+                var preview = cached.toAlbum()
+                // Attach cached songs if available
+                let songs = cached.songs
+                    .sorted { ($0.discNumber ?? 0, $0.track ?? 0) < ($1.discNumber ?? 0, $1.track ?? 0) }
+                    .map { $0.toSong() }
+                if !songs.isEmpty {
+                    preview = Album(
+                        id: preview.id, name: preview.name, artist: preview.artist,
+                        artistId: preview.artistId, coverArt: preview.coverArt,
+                        songCount: preview.songCount, duration: preview.duration,
+                        year: preview.year, genre: preview.genre, starred: preview.starred,
+                        created: preview.created, userRating: preview.userRating,
+                        song: songs, replayGain: nil, musicBrainzId: nil,
+                        recordLabels: nil
+                    )
+                }
+                album = preview
+            }
+        }
+        isLoading = album == nil
         error = nil
         defer { isLoading = false }
         do {

--- a/Vibrdrome/Features/Library/AlbumsView.swift
+++ b/Vibrdrome/Features/Library/AlbumsView.swift
@@ -13,6 +13,7 @@ struct AlbumsView: View {
     @Environment(\.modelContext) private var modelContext
     @State private var albums: [Album] = []
     @State private var localFilteredAlbums: [Album]?
+    @State private var filterTask: Task<Void, Never>?
     @State private var isLoading = true
     @State private var error: String?
     @State private var hasMore = true
@@ -181,13 +182,13 @@ struct AlbumsView: View {
             await loadAlbums()
         }
         #if os(macOS)
-        .onChange(of: appState.albumFilter.isFavorited) { applyLocalFilters() }
-        .onChange(of: appState.albumFilter.isRated) { applyLocalFilters() }
-        .onChange(of: appState.albumFilter.isRecentlyPlayed) { applyLocalFilters() }
-        .onChange(of: appState.albumFilter.selectedArtistIds) { applyLocalFilters() }
-        .onChange(of: appState.albumFilter.selectedGenres) { applyLocalFilters() }
-        .onChange(of: appState.albumFilter.selectedLabels) { applyLocalFilters() }
-        .onChange(of: appState.albumFilter.year) { applyLocalFilters() }
+        .onChange(of: appState.albumFilter.isFavorited) { debouncedApplyLocalFilters() }
+        .onChange(of: appState.albumFilter.isRated) { debouncedApplyLocalFilters() }
+        .onChange(of: appState.albumFilter.isRecentlyPlayed) { debouncedApplyLocalFilters() }
+        .onChange(of: appState.albumFilter.selectedArtistIds) { debouncedApplyLocalFilters() }
+        .onChange(of: appState.albumFilter.selectedGenres) { debouncedApplyLocalFilters() }
+        .onChange(of: appState.albumFilter.selectedLabels) { debouncedApplyLocalFilters() }
+        .onChange(of: appState.albumFilter.year) { debouncedApplyLocalFilters() }
         #endif
     }
 
@@ -362,6 +363,15 @@ struct AlbumsView: View {
     }
 
     #if os(macOS)
+    private func debouncedApplyLocalFilters() {
+        filterTask?.cancel()
+        filterTask = Task {
+            try? await Task.sleep(for: .milliseconds(150))
+            guard !Task.isCancelled else { return }
+            applyLocalFilters()
+        }
+    }
+
     private func applyLocalFilters() {
         let filter = appState.albumFilter
         guard filter.isActive else {
@@ -370,14 +380,19 @@ struct AlbumsView: View {
         }
 
         do {
-            var descriptor = FetchDescriptor<CachedAlbum>()
-            descriptor.sortBy = [SortDescriptor(\.name)]
-            let allAlbums = try modelContext.fetch(descriptor)
-
             let recentlyPlayedAlbumIds = recentlyPlayedIds(for: filter)
-            let filtered = allAlbums.filter { albumMatchesFilter($0, filter: filter, recentIds: recentlyPlayedAlbumIds) }
+            let allAlbums: [Album]
+            if let cachedAlbums = appState.libraryCache.albums {
+                allAlbums = cachedAlbums
+            } else {
+                var descriptor = FetchDescriptor<CachedAlbum>()
+                descriptor.sortBy = [SortDescriptor(\.name)]
+                allAlbums = try modelContext.fetch(descriptor).map { $0.toAlbum() }
+            }
 
-            localFilteredAlbums = filtered.map { $0.toAlbum() }
+            localFilteredAlbums = allAlbums.filter {
+                albumMatchesFilter($0, filter: filter, recentIds: recentlyPlayedAlbumIds)
+            }
         } catch {
             Logger(subsystem: "com.vibrdrome.app", category: "Albums")
                 .error("Failed to apply local filters: \(error)")
@@ -396,10 +411,10 @@ struct AlbumsView: View {
     }
 
     private func albumMatchesFilter(
-        _ album: CachedAlbum, filter: LibraryFilter, recentIds: Set<String>?
+        _ album: Album, filter: LibraryFilter, recentIds: Set<String>?
     ) -> Bool {
-        guard filter.isFavorited.matches(album.isStarred) else { return false }
-        guard filter.isRated.matches(album.userRating != 0) else { return false }
+        guard filter.isFavorited.matches(album.starred != nil) else { return false }
+        guard filter.isRated.matches((album.userRating ?? 0) != 0) else { return false }
         if let recentIds, !recentIds.contains(album.id) { return false }
         if !filter.selectedArtistIds.isEmpty {
             guard let artistId = album.artistId, filter.selectedArtistIds.contains(artistId) else {

--- a/Vibrdrome/Features/Library/AlbumsView.swift
+++ b/Vibrdrome/Features/Library/AlbumsView.swift
@@ -24,6 +24,8 @@ struct AlbumsView: View {
     @State private var cachedFilteredAlbums: [Album] = []
     @State private var scrollLoadTask: Task<Void, Never>?
     @State private var pendingPageTarget: Int = 0
+    @State private var visibleIndices: Set<Int> = []
+    @State private var restoredScrollIndex: Int?
     private let pageSize = 40
 
     enum AlbumSortOption: String, CaseIterable {
@@ -48,6 +50,27 @@ struct AlbumsView: View {
 
     private var effectiveListType: AlbumListType {
         activeListType ?? listType
+    }
+
+    private var cacheKey: String {
+        "\(listType.rawValue)_\(genre ?? "")_\(fromYear ?? 0)_\(toYear ?? 0)"
+    }
+
+    init(listType: AlbumListType, title: String = "Albums", genre: String? = nil, fromYear: Int? = nil, toYear: Int? = nil) {
+        self.listType = listType
+        self.title = title
+        self.genre = genre
+        self.fromYear = fromYear
+        self.toYear = toYear
+
+        let key = "\(listType.rawValue)_\(genre ?? "")_\(fromYear ?? 0)_\(toYear ?? 0)"
+        if let snapshot = AppState.shared.albumsViewSnapshots[key] {
+            _albums = State(initialValue: snapshot.albums)
+            _hasMore = State(initialValue: snapshot.hasMore)
+            _isLoading = State(initialValue: false)
+            _cachedFilteredAlbums = State(initialValue: snapshot.albums)
+            _restoredScrollIndex = State(initialValue: snapshot.scrollIndex)
+        }
     }
 
     private func computeFilteredAlbums() -> [Album] {
@@ -173,8 +196,13 @@ struct AlbumsView: View {
                 }
             }
         }
+        .navigationDestination(for: AlbumNavItem.self) { item in
+            AlbumDetailView(albumId: item.id)
+        }
         .task {
-            await loadAlbums()
+            if albums.isEmpty {
+                await loadAlbums()
+            }
             #if os(macOS)
             applyLocalFilters()
             #endif
@@ -182,6 +210,7 @@ struct AlbumsView: View {
         }
         .onChange(of: searchText) { recomputeFilteredAlbums() }
         .onChange(of: clientSideSort) { recomputeFilteredAlbums() }
+        .onDisappear { saveSnapshot() }
         .refreshable {
             albums = []
             hasMore = true
@@ -201,55 +230,67 @@ struct AlbumsView: View {
     // MARK: - List view
 
     private var albumList: some View {
-        List {
-            ForEach(0..<totalItemCount, id: \.self) { index in
-                Group {
-                    if index < cachedFilteredAlbums.count {
-                        let album = cachedFilteredAlbums[index]
-                        NavigationLink {
-                            AlbumDetailView(albumId: album.id)
-                        } label: {
-                            AlbumCard(album: album)
+        ScrollViewReader { proxy in
+            List {
+                ForEach(0..<totalItemCount, id: \.self) { index in
+                    Group {
+                        if index < cachedFilteredAlbums.count {
+                            let album = cachedFilteredAlbums[index]
+                            NavigationLink(value: AlbumNavItem(id: album.id)) {
+                                AlbumCard(album: album)
+                            }
+                            .accessibilityIdentifier("albumRow_\(album.id)")
+                            .contextMenu { rowContextMenu(for: album) }
+                        } else {
+                            albumListPlaceholder
                         }
-                        .accessibilityIdentifier("albumRow_\(album.id)")
-                        .contextMenu { rowContextMenu(for: album) }
-                    } else {
-                        albumListPlaceholder
                     }
+                    .id(index)
+                    .onAppear {
+                        visibleIndices.insert(index)
+                        triggerLoadIfNeeded(at: index)
+                    }
+                    .onDisappear { visibleIndices.remove(index) }
                 }
-                .onAppear { triggerLoadIfNeeded(at: index) }
             }
+            .listStyle(.plain)
+            .onAppear { restoreScroll(proxy: proxy) }
         }
-        .listStyle(.plain)
     }
 
     // MARK: - Grid view
 
     private var albumGrid: some View {
-        ScrollView {
-            LazyVGrid(columns: [
-                GridItem(.adaptive(minimum: 170, maximum: 220), spacing: 16)
-            ], spacing: 20) {
-                ForEach(0..<totalItemCount, id: \.self) { index in
-                    Group {
-                        if index < cachedFilteredAlbums.count {
-                            let album = cachedFilteredAlbums[index]
-                            NavigationLink {
-                                AlbumDetailView(albumId: album.id)
-                            } label: {
-                                albumGridCard(album)
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVGrid(columns: [
+                    GridItem(.adaptive(minimum: 170, maximum: 220), spacing: 16)
+                ], spacing: 20) {
+                    ForEach(0..<totalItemCount, id: \.self) { index in
+                        Group {
+                            if index < cachedFilteredAlbums.count {
+                                let album = cachedFilteredAlbums[index]
+                                NavigationLink(value: AlbumNavItem(id: album.id)) {
+                                    albumGridCard(album)
+                                }
+                                .buttonStyle(.plain)
+                                .accessibilityIdentifier("albumCard_\(album.id)")
+                                .contextMenu { rowContextMenu(for: album) }
+                            } else {
+                                albumGridPlaceholder
                             }
-                            .buttonStyle(.plain)
-                            .accessibilityIdentifier("albumCard_\(album.id)")
-                            .contextMenu { rowContextMenu(for: album) }
-                        } else {
-                            albumGridPlaceholder
                         }
+                        .id(index)
+                        .onAppear {
+                            visibleIndices.insert(index)
+                            triggerLoadIfNeeded(at: index)
+                        }
+                        .onDisappear { visibleIndices.remove(index) }
                     }
-                    .onAppear { triggerLoadIfNeeded(at: index) }
                 }
+                .padding(16)
             }
-            .padding(16)
+            .onAppear { restoreScroll(proxy: proxy) }
         }
     }
 
@@ -401,6 +442,7 @@ struct AlbumsView: View {
             albums = result
             hasMore = result.count >= pageSize
             recomputeFilteredAlbums()
+            saveSnapshot()
         } catch {
             if albums.isEmpty {
                 self.error = ErrorPresenter.userMessage(for: error)
@@ -432,10 +474,24 @@ struct AlbumsView: View {
             }
         }
         recomputeFilteredAlbums()
+        saveSnapshot()
     }
 
     private func recomputeFilteredAlbums() {
         cachedFilteredAlbums = computeFilteredAlbums()
+    }
+
+    private func saveSnapshot() {
+        appState.albumsViewSnapshots[cacheKey] = AppState.AlbumsViewSnapshot(
+            albums: albums, hasMore: hasMore, scrollIndex: visibleIndices.min()
+        )
+    }
+
+    private func restoreScroll(proxy: ScrollViewProxy) {
+        if let target = restoredScrollIndex, target > 0, target < cachedFilteredAlbums.count {
+            proxy.scrollTo(target, anchor: .top)
+            restoredScrollIndex = nil
+        }
     }
 
     #if os(macOS)

--- a/Vibrdrome/Features/Library/AlbumsView.swift
+++ b/Vibrdrome/Features/Library/AlbumsView.swift
@@ -20,7 +20,6 @@ struct AlbumsView: View {
     @State private var activeListType: AlbumListType?
     @State private var clientSideSort: AlbumSortOption?
     @AppStorage("albumsViewStyle") private var showAsList = false
-    @AppStorage(UserDefaultsKeys.gridColumnsPerRow) private var gridColumns = 2
     private let pageSize = 40
 
     enum AlbumSortOption: String, CaseIterable {
@@ -220,13 +219,11 @@ struct AlbumsView: View {
 
     // MARK: - Grid view
 
-    private var gridItems: [GridItem] {
-        Array(repeating: GridItem(.flexible(), spacing: 16), count: max(2, min(4, gridColumns)))
-    }
-
     private var albumGrid: some View {
         ScrollView {
-            LazyVGrid(columns: gridItems, spacing: 20) {
+            LazyVGrid(columns: [
+                GridItem(.adaptive(minimum: 170, maximum: 220), spacing: 16)
+            ], spacing: 20) {
                 ForEach(filteredAlbums) { album in
                     NavigationLink {
                         AlbumDetailView(albumId: album.id)
@@ -250,9 +247,11 @@ struct AlbumsView: View {
 
     private func albumGridCard(_ album: Album) -> some View {
         VStack(alignment: .leading, spacing: 6) {
-            AlbumArtView(coverArtId: album.coverArt, size: Theme.albumCardSize, cornerRadius: 10)
-                .frame(maxWidth: .infinity)
-                .shadow(color: .black.opacity(0.15), radius: 6, y: 3)
+            GeometryReader { geo in
+                AlbumArtView(coverArtId: album.coverArt, size: geo.size.width, cornerRadius: 10)
+            }
+            .aspectRatio(1, contentMode: .fit)
+            .shadow(color: .black.opacity(0.15), radius: 6, y: 3)
 
             Text(album.name)
                 .font(.subheadline)

--- a/Vibrdrome/Features/Library/AlbumsView.swift
+++ b/Vibrdrome/Features/Library/AlbumsView.swift
@@ -202,30 +202,22 @@ struct AlbumsView: View {
 
     private var albumList: some View {
         List {
-            ForEach(cachedFilteredAlbums) { album in
-                NavigationLink {
-                    AlbumDetailView(albumId: album.id)
-                } label: {
-                    AlbumCard(album: album)
+            ForEach(0..<totalItemCount, id: \.self) { index in
+                Group {
+                    if index < cachedFilteredAlbums.count {
+                        let album = cachedFilteredAlbums[index]
+                        NavigationLink {
+                            AlbumDetailView(albumId: album.id)
+                        } label: {
+                            AlbumCard(album: album)
+                        }
+                        .accessibilityIdentifier("albumRow_\(album.id)")
+                        .contextMenu { rowContextMenu(for: album) }
+                    } else {
+                        albumListPlaceholder
+                    }
                 }
-                .accessibilityIdentifier("albumRow_\(album.id)")
-                .contextMenu { rowContextMenu(for: album) }
-                .onAppear { paginateIfNeeded(album) }
-            }
-
-            if remainingPlaceholderCount > 0 {
-                ForEach(0..<remainingPlaceholderCount, id: \.self) { index in
-                    albumListPlaceholder
-                        .onAppear { scheduleScrollLoad(placeholderIndex: index) }
-                }
-            }
-
-            if isLoading && !albums.isEmpty {
-                HStack {
-                    Spacer()
-                    ProgressView()
-                    Spacer()
-                }
+                .onAppear { triggerLoadIfNeeded(at: index) }
             }
         }
         .listStyle(.plain)
@@ -238,31 +230,26 @@ struct AlbumsView: View {
             LazyVGrid(columns: [
                 GridItem(.adaptive(minimum: 170, maximum: 220), spacing: 16)
             ], spacing: 20) {
-                ForEach(cachedFilteredAlbums) { album in
-                    NavigationLink {
-                        AlbumDetailView(albumId: album.id)
-                    } label: {
-                        albumGridCard(album)
+                ForEach(0..<totalItemCount, id: \.self) { index in
+                    Group {
+                        if index < cachedFilteredAlbums.count {
+                            let album = cachedFilteredAlbums[index]
+                            NavigationLink {
+                                AlbumDetailView(albumId: album.id)
+                            } label: {
+                                albumGridCard(album)
+                            }
+                            .buttonStyle(.plain)
+                            .accessibilityIdentifier("albumCard_\(album.id)")
+                            .contextMenu { rowContextMenu(for: album) }
+                        } else {
+                            albumGridPlaceholder
+                        }
                     }
-                    .buttonStyle(.plain)
-                    .accessibilityIdentifier("albumCard_\(album.id)")
-                    .contextMenu { rowContextMenu(for: album) }
-                    .onAppear { paginateIfNeeded(album) }
-                }
-
-                if remainingPlaceholderCount > 0 {
-                    ForEach(0..<remainingPlaceholderCount, id: \.self) { index in
-                        albumGridPlaceholder
-                            .onAppear { scheduleScrollLoad(placeholderIndex: index) }
-                    }
+                    .onAppear { triggerLoadIfNeeded(at: index) }
                 }
             }
             .padding(16)
-
-            if isLoading && !albums.isEmpty {
-                ProgressView()
-                    .padding()
-            }
         }
     }
 
@@ -364,30 +351,30 @@ struct AlbumsView: View {
         }
     }
 
-    private var remainingPlaceholderCount: Int {
-        guard hasMore, localFilteredAlbums == nil, searchText.isEmpty else { return 0 }
-        guard let totalCount = appState.libraryCache.albums?.count else { return 0 }
-        return max(0, totalCount - albums.count)
+    private var totalItemCount: Int {
+        guard localFilteredAlbums == nil, searchText.isEmpty else { return cachedFilteredAlbums.count }
+        guard hasMore, let totalCount = appState.libraryCache.albums?.count else { return cachedFilteredAlbums.count }
+        return max(cachedFilteredAlbums.count, totalCount)
     }
 
-    private func paginateIfNeeded(_ album: Album) {
-        guard localFilteredAlbums == nil, hasMore, !isLoading else { return }
-        guard let index = albums.firstIndex(where: { $0.id == album.id }) else { return }
-        let prefetchThreshold = max(albums.count - 30, 0)
-        if index >= prefetchThreshold {
-            pendingPageTarget = max(pendingPageTarget, albums.count + pageSize)
-            Task { await loadPages() }
-        }
-    }
-
-    private func scheduleScrollLoad(placeholderIndex: Int) {
-        guard hasMore else { return }
-        pendingPageTarget = max(pendingPageTarget, albums.count + placeholderIndex + pageSize)
-        scrollLoadTask?.cancel()
-        scrollLoadTask = Task {
-            try? await Task.sleep(for: .milliseconds(150))
-            guard !Task.isCancelled else { return }
-            await loadPages()
+    private func triggerLoadIfNeeded(at index: Int) {
+        guard localFilteredAlbums == nil, hasMore else { return }
+        if index >= cachedFilteredAlbums.count {
+            // Scrolled into placeholder territory — always update target, debounce the load
+            pendingPageTarget = max(pendingPageTarget, albums.count + (index - cachedFilteredAlbums.count) + pageSize)
+            scrollLoadTask?.cancel()
+            scrollLoadTask = Task {
+                try? await Task.sleep(for: .milliseconds(150))
+                guard !Task.isCancelled else { return }
+                await loadPages()
+            }
+        } else if !isLoading {
+            // Near end of loaded items — prefetch immediately
+            let prefetchThreshold = max(cachedFilteredAlbums.count - 30, 0)
+            if index >= prefetchThreshold {
+                pendingPageTarget = max(pendingPageTarget, albums.count + pageSize)
+                Task { await loadPages() }
+            }
         }
     }
 

--- a/Vibrdrome/Features/Library/AlbumsView.swift
+++ b/Vibrdrome/Features/Library/AlbumsView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import SwiftData
 import os.log
 
 struct AlbumsView: View {
@@ -9,7 +10,9 @@ struct AlbumsView: View {
     var toYear: Int?
 
     @Environment(AppState.self) private var appState
+    @Environment(\.modelContext) private var modelContext
     @State private var albums: [Album] = []
+    @State private var localFilteredAlbums: [Album]?
     @State private var isLoading = true
     @State private var error: String?
     @State private var hasMore = true
@@ -45,7 +48,8 @@ struct AlbumsView: View {
     }
 
     private var filteredAlbums: [Album] {
-        var result = albums
+        let source = localFilteredAlbums ?? albums
+        var result = source
         if !searchText.isEmpty {
             result = result.filter {
                 $0.name.localizedCaseInsensitiveContains(searchText) ||
@@ -100,6 +104,23 @@ struct AlbumsView: View {
             }
         }
         .toolbar {
+            #if os(macOS)
+            ToolbarItem(placement: .automatic) {
+                Button {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        if appState.activeSidePanel == .albumFilters {
+                            appState.activeSidePanel = nil
+                        } else {
+                            appState.activeSidePanel = .albumFilters
+                        }
+                    }
+                } label: {
+                    Image(systemName: appState.albumFilter.isActive ? "line.3.horizontal.decrease.circle.fill" : "line.3.horizontal.decrease.circle")
+                }
+                .accessibilityLabel("Album Filters")
+                .accessibilityIdentifier("albumFilterToggle")
+            }
+            #endif
             ToolbarItem(placement: .automatic) {
                 Button {
                     withAnimation(.easeInOut(duration: 0.2)) {
@@ -149,12 +170,26 @@ struct AlbumsView: View {
                 }
             }
         }
-        .task { await loadAlbums() }
+        .task {
+            await loadAlbums()
+            #if os(macOS)
+            applyLocalFilters()
+            #endif
+        }
         .refreshable {
             albums = []
             hasMore = true
             await loadAlbums()
         }
+        #if os(macOS)
+        .onChange(of: appState.albumFilter.isFavorited) { applyLocalFilters() }
+        .onChange(of: appState.albumFilter.isRated) { applyLocalFilters() }
+        .onChange(of: appState.albumFilter.isRecentlyPlayed) { applyLocalFilters() }
+        .onChange(of: appState.albumFilter.selectedArtistIds) { applyLocalFilters() }
+        .onChange(of: appState.albumFilter.selectedGenres) { applyLocalFilters() }
+        .onChange(of: appState.albumFilter.selectedLabels) { applyLocalFilters() }
+        .onChange(of: appState.albumFilter.year) { applyLocalFilters() }
+        #endif
     }
 
     // MARK: - List view
@@ -279,6 +314,7 @@ struct AlbumsView: View {
     }
 
     private func paginateIfNeeded(_ album: Album) {
+        guard localFilteredAlbums == nil else { return }
         if album.id == albums.last?.id && hasMore {
             Task { await loadMore() }
         }
@@ -325,4 +361,86 @@ struct AlbumsView: View {
             hasMore = false
         }
     }
+
+    #if os(macOS)
+    private func applyLocalFilters() {
+        let filter = appState.albumFilter
+        guard filter.isActive else {
+            localFilteredAlbums = nil
+            return
+        }
+
+        do {
+            var descriptor = FetchDescriptor<CachedAlbum>()
+            descriptor.sortBy = [SortDescriptor(\.name)]
+            let allAlbums = try modelContext.fetch(descriptor)
+
+            // Pre-compute recently played album IDs if needed
+            var recentlyPlayedAlbumIds: Set<String>?
+            if filter.isRecentlyPlayed {
+                let cutoff = Calendar.current.date(byAdding: .day, value: -30, to: Date()) ?? Date()
+                let songDescriptor = FetchDescriptor<CachedSong>(
+                    predicate: #Predicate { $0.lastPlayed != nil && $0.lastPlayed! > cutoff }
+                )
+                let recentSongs = (try? modelContext.fetch(songDescriptor)) ?? []
+                recentlyPlayedAlbumIds = Set(recentSongs.compactMap(\.albumId))
+            }
+
+            let filtered = allAlbums.filter { album in
+                // Favorited filter
+                switch filter.isFavorited {
+                case .yes: if !album.isStarred { return false }
+                case .no: if album.isStarred { return false }
+                case .none: break
+                }
+
+                // Rated filter
+                switch filter.isRated {
+                case .yes: if album.userRating == 0 { return false }
+                case .no: if album.userRating != 0 { return false }
+                case .none: break
+                }
+
+                // Recently played filter
+                if let recentIds = recentlyPlayedAlbumIds {
+                    if !recentIds.contains(album.id) { return false }
+                }
+
+                // Artist filter
+                if !filter.selectedArtistIds.isEmpty {
+                    guard let artistId = album.artistId, filter.selectedArtistIds.contains(artistId) else {
+                        return false
+                    }
+                }
+
+                // Genre filter
+                if !filter.selectedGenres.isEmpty {
+                    guard let genre = album.genre, filter.selectedGenres.contains(genre) else {
+                        return false
+                    }
+                }
+
+                // Label filter
+                if !filter.selectedLabels.isEmpty {
+                    guard let albumLabel = album.label, filter.selectedLabels.contains(albumLabel) else {
+                        return false
+                    }
+                }
+
+                // Year filter
+                if let yearFilter = filter.year {
+                    guard album.year == yearFilter else { return false }
+                }
+
+                return true
+            }
+
+            localFilteredAlbums = filtered.map { $0.toAlbum() }
+        } catch {
+            Logger(subsystem: "com.vibrdrome.app", category: "Albums")
+                .error("Failed to apply local filters: \(error)")
+            localFilteredAlbums = nil
+        }
+    }
+    #endif
 }

--- a/Vibrdrome/Features/Library/AlbumsView.swift
+++ b/Vibrdrome/Features/Library/AlbumsView.swift
@@ -396,46 +396,30 @@ struct AlbumsView: View {
         return Set(recentSongs.compactMap(\.albumId))
     }
 
-    // swiftlint:disable:next cyclomatic_complexity
     private func albumMatchesFilter(
         _ album: CachedAlbum, filter: LibraryFilter, recentIds: Set<String>?
     ) -> Bool {
-        switch filter.isFavorited {
-        case .yes: if !album.isStarred { return false }
-        case .no: if album.isStarred { return false }
-        case .none: break
-        }
-
-        switch filter.isRated {
-        case .yes: if album.userRating == 0 { return false }
-        case .no: if album.userRating != 0 { return false }
-        case .none: break
-        }
-
+        guard filter.isFavorited.matches(album.isStarred) else { return false }
+        guard filter.isRated.matches(album.userRating != 0) else { return false }
         if let recentIds, !recentIds.contains(album.id) { return false }
-
         if !filter.selectedArtistIds.isEmpty {
             guard let artistId = album.artistId, filter.selectedArtistIds.contains(artistId) else {
                 return false
             }
         }
-
         if !filter.selectedGenres.isEmpty {
             guard let genre = album.genre, filter.selectedGenres.contains(genre) else {
                 return false
             }
         }
-
         if !filter.selectedLabels.isEmpty {
             guard let albumLabel = album.label, filter.selectedLabels.contains(albumLabel) else {
                 return false
             }
         }
-
         if let yearFilter = filter.year {
             guard album.year == yearFilter else { return false }
         }
-
         return true
     }
     #endif

--- a/Vibrdrome/Features/Library/AlbumsView.swift
+++ b/Vibrdrome/Features/Library/AlbumsView.swift
@@ -375,65 +375,8 @@ struct AlbumsView: View {
             descriptor.sortBy = [SortDescriptor(\.name)]
             let allAlbums = try modelContext.fetch(descriptor)
 
-            // Pre-compute recently played album IDs if needed
-            var recentlyPlayedAlbumIds: Set<String>?
-            if filter.isRecentlyPlayed {
-                let cutoff = Calendar.current.date(byAdding: .day, value: -30, to: Date()) ?? Date()
-                let songDescriptor = FetchDescriptor<CachedSong>(
-                    predicate: #Predicate { $0.lastPlayed != nil && $0.lastPlayed! > cutoff }
-                )
-                let recentSongs = (try? modelContext.fetch(songDescriptor)) ?? []
-                recentlyPlayedAlbumIds = Set(recentSongs.compactMap(\.albumId))
-            }
-
-            let filtered = allAlbums.filter { album in
-                // Favorited filter
-                switch filter.isFavorited {
-                case .yes: if !album.isStarred { return false }
-                case .no: if album.isStarred { return false }
-                case .none: break
-                }
-
-                // Rated filter
-                switch filter.isRated {
-                case .yes: if album.userRating == 0 { return false }
-                case .no: if album.userRating != 0 { return false }
-                case .none: break
-                }
-
-                // Recently played filter
-                if let recentIds = recentlyPlayedAlbumIds {
-                    if !recentIds.contains(album.id) { return false }
-                }
-
-                // Artist filter
-                if !filter.selectedArtistIds.isEmpty {
-                    guard let artistId = album.artistId, filter.selectedArtistIds.contains(artistId) else {
-                        return false
-                    }
-                }
-
-                // Genre filter
-                if !filter.selectedGenres.isEmpty {
-                    guard let genre = album.genre, filter.selectedGenres.contains(genre) else {
-                        return false
-                    }
-                }
-
-                // Label filter
-                if !filter.selectedLabels.isEmpty {
-                    guard let albumLabel = album.label, filter.selectedLabels.contains(albumLabel) else {
-                        return false
-                    }
-                }
-
-                // Year filter
-                if let yearFilter = filter.year {
-                    guard album.year == yearFilter else { return false }
-                }
-
-                return true
-            }
+            let recentlyPlayedAlbumIds = recentlyPlayedIds(for: filter)
+            let filtered = allAlbums.filter { albumMatchesFilter($0, filter: filter, recentIds: recentlyPlayedAlbumIds) }
 
             localFilteredAlbums = filtered.map { $0.toAlbum() }
         } catch {
@@ -441,6 +384,59 @@ struct AlbumsView: View {
                 .error("Failed to apply local filters: \(error)")
             localFilteredAlbums = nil
         }
+    }
+
+    private func recentlyPlayedIds(for filter: LibraryFilter) -> Set<String>? {
+        guard filter.isRecentlyPlayed else { return nil }
+        let cutoff = Calendar.current.date(byAdding: .day, value: -30, to: Date()) ?? Date()
+        let songDescriptor = FetchDescriptor<CachedSong>(
+            predicate: #Predicate { $0.lastPlayed != nil && $0.lastPlayed! > cutoff }
+        )
+        let recentSongs = (try? modelContext.fetch(songDescriptor)) ?? []
+        return Set(recentSongs.compactMap(\.albumId))
+    }
+
+    // swiftlint:disable:next cyclomatic_complexity
+    private func albumMatchesFilter(
+        _ album: CachedAlbum, filter: LibraryFilter, recentIds: Set<String>?
+    ) -> Bool {
+        switch filter.isFavorited {
+        case .yes: if !album.isStarred { return false }
+        case .no: if album.isStarred { return false }
+        case .none: break
+        }
+
+        switch filter.isRated {
+        case .yes: if album.userRating == 0 { return false }
+        case .no: if album.userRating != 0 { return false }
+        case .none: break
+        }
+
+        if let recentIds, !recentIds.contains(album.id) { return false }
+
+        if !filter.selectedArtistIds.isEmpty {
+            guard let artistId = album.artistId, filter.selectedArtistIds.contains(artistId) else {
+                return false
+            }
+        }
+
+        if !filter.selectedGenres.isEmpty {
+            guard let genre = album.genre, filter.selectedGenres.contains(genre) else {
+                return false
+            }
+        }
+
+        if !filter.selectedLabels.isEmpty {
+            guard let albumLabel = album.label, filter.selectedLabels.contains(albumLabel) else {
+                return false
+            }
+        }
+
+        if let yearFilter = filter.year {
+            guard album.year == yearFilter else { return false }
+        }
+
+        return true
     }
     #endif
 }

--- a/Vibrdrome/Features/Library/AlbumsView.swift
+++ b/Vibrdrome/Features/Library/AlbumsView.swift
@@ -21,6 +21,7 @@ struct AlbumsView: View {
     @State private var activeListType: AlbumListType?
     @State private var clientSideSort: AlbumSortOption?
     @AppStorage("albumsViewStyle") private var showAsList = false
+    @State private var cachedFilteredAlbums: [Album] = []
     private let pageSize = 40
 
     enum AlbumSortOption: String, CaseIterable {
@@ -47,7 +48,7 @@ struct AlbumsView: View {
         activeListType ?? listType
     }
 
-    private var filteredAlbums: [Album] {
+    private func computeFilteredAlbums() -> [Album] {
         let source = localFilteredAlbums ?? albums
         var result = source
         if !searchText.isEmpty {
@@ -175,7 +176,10 @@ struct AlbumsView: View {
             #if os(macOS)
             applyLocalFilters()
             #endif
+            recomputeFilteredAlbums()
         }
+        .onChange(of: searchText) { recomputeFilteredAlbums() }
+        .onChange(of: clientSideSort) { recomputeFilteredAlbums() }
         .refreshable {
             albums = []
             hasMore = true
@@ -196,7 +200,7 @@ struct AlbumsView: View {
 
     private var albumList: some View {
         List {
-            ForEach(filteredAlbums) { album in
+            ForEach(cachedFilteredAlbums) { album in
                 NavigationLink {
                     AlbumDetailView(albumId: album.id)
                 } label: {
@@ -225,7 +229,7 @@ struct AlbumsView: View {
             LazyVGrid(columns: [
                 GridItem(.adaptive(minimum: 170, maximum: 220), spacing: 16)
             ], spacing: 20) {
-                ForEach(filteredAlbums) { album in
+                ForEach(cachedFilteredAlbums) { album in
                     NavigationLink {
                         AlbumDetailView(albumId: album.id)
                     } label: {
@@ -340,6 +344,7 @@ struct AlbumsView: View {
                 fromYear: fromYear, toYear: toYear)
             albums = result
             hasMore = result.count >= pageSize
+            recomputeFilteredAlbums()
         } catch {
             if albums.isEmpty {
                 self.error = ErrorPresenter.userMessage(for: error)
@@ -357,9 +362,14 @@ struct AlbumsView: View {
                 fromYear: fromYear, toYear: toYear)
             albums.append(contentsOf: result)
             hasMore = result.count >= pageSize
+            recomputeFilteredAlbums()
         } catch {
             hasMore = false
         }
+    }
+
+    private func recomputeFilteredAlbums() {
+        cachedFilteredAlbums = computeFilteredAlbums()
     }
 
     #if os(macOS)
@@ -376,6 +386,7 @@ struct AlbumsView: View {
         let filter = appState.albumFilter
         guard filter.isActive else {
             localFilteredAlbums = nil
+            recomputeFilteredAlbums()
             return
         }
 
@@ -399,6 +410,7 @@ struct AlbumsView: View {
                     selectedArtistNames: selectedArtistNames
                 )
             }
+            recomputeFilteredAlbums()
         } catch {
             Logger(subsystem: "com.vibrdrome.app", category: "Albums")
                 .error("Failed to apply local filters: \(error)")

--- a/Vibrdrome/Features/Library/AlbumsView.swift
+++ b/Vibrdrome/Features/Library/AlbumsView.swift
@@ -381,6 +381,7 @@ struct AlbumsView: View {
 
         do {
             let recentlyPlayedAlbumIds = recentlyPlayedIds(for: filter)
+            let selectedArtistNames = selectedArtistNames(for: filter)
             let allAlbums: [Album]
             if let cachedAlbums = appState.libraryCache.albums {
                 allAlbums = cachedAlbums
@@ -391,13 +392,27 @@ struct AlbumsView: View {
             }
 
             localFilteredAlbums = allAlbums.filter {
-                albumMatchesFilter($0, filter: filter, recentIds: recentlyPlayedAlbumIds)
+                albumMatchesFilter(
+                    $0,
+                    filter: filter,
+                    recentIds: recentlyPlayedAlbumIds,
+                    selectedArtistNames: selectedArtistNames
+                )
             }
         } catch {
             Logger(subsystem: "com.vibrdrome.app", category: "Albums")
                 .error("Failed to apply local filters: \(error)")
             localFilteredAlbums = nil
         }
+    }
+
+    private func selectedArtistNames(for filter: LibraryFilter) -> Set<String> {
+        guard !filter.selectedArtistIds.isEmpty else { return [] }
+        let descriptor = FetchDescriptor<CachedArtist>()
+        let cachedArtists = (try? modelContext.fetch(descriptor)) ?? []
+        return Set(cachedArtists.compactMap { artist in
+            filter.selectedArtistIds.contains(artist.id) ? artist.name : nil
+        })
     }
 
     private func recentlyPlayedIds(for filter: LibraryFilter) -> Set<String>? {
@@ -411,13 +426,18 @@ struct AlbumsView: View {
     }
 
     private func albumMatchesFilter(
-        _ album: Album, filter: LibraryFilter, recentIds: Set<String>?
+        _ album: Album,
+        filter: LibraryFilter,
+        recentIds: Set<String>?,
+        selectedArtistNames: Set<String>
     ) -> Bool {
         guard filter.isFavorited.matches(album.starred != nil) else { return false }
         guard filter.isRated.matches((album.userRating ?? 0) != 0) else { return false }
         if let recentIds, !recentIds.contains(album.id) { return false }
         if !filter.selectedArtistIds.isEmpty {
-            guard let artistId = album.artistId, filter.selectedArtistIds.contains(artistId) else {
+            let matchesById = album.artistId.map { filter.selectedArtistIds.contains($0) } ?? false
+            let matchesByName = album.artist.map { selectedArtistNames.contains($0) } ?? false
+            guard matchesById || matchesByName else {
                 return false
             }
         }

--- a/Vibrdrome/Features/Library/AlbumsView.swift
+++ b/Vibrdrome/Features/Library/AlbumsView.swift
@@ -22,6 +22,8 @@ struct AlbumsView: View {
     @State private var clientSideSort: AlbumSortOption?
     @AppStorage("albumsViewStyle") private var showAsList = false
     @State private var cachedFilteredAlbums: [Album] = []
+    @State private var scrollLoadTask: Task<Void, Never>?
+    @State private var pendingPageTarget: Int = 0
     private let pageSize = 40
 
     enum AlbumSortOption: String, CaseIterable {
@@ -211,6 +213,13 @@ struct AlbumsView: View {
                 .onAppear { paginateIfNeeded(album) }
             }
 
+            if remainingPlaceholderCount > 0 {
+                ForEach(0..<remainingPlaceholderCount, id: \.self) { index in
+                    albumListPlaceholder
+                        .onAppear { scheduleScrollLoad(placeholderIndex: index) }
+                }
+            }
+
             if isLoading && !albums.isEmpty {
                 HStack {
                     Spacer()
@@ -239,6 +248,13 @@ struct AlbumsView: View {
                     .accessibilityIdentifier("albumCard_\(album.id)")
                     .contextMenu { rowContextMenu(for: album) }
                     .onAppear { paginateIfNeeded(album) }
+                }
+
+                if remainingPlaceholderCount > 0 {
+                    ForEach(0..<remainingPlaceholderCount, id: \.self) { index in
+                        albumGridPlaceholder
+                            .onAppear { scheduleScrollLoad(placeholderIndex: index) }
+                    }
                 }
             }
             .padding(16)
@@ -317,14 +333,67 @@ struct AlbumsView: View {
         }
     }
 
+    private var albumListPlaceholder: some View {
+        HStack(spacing: 12) {
+            RoundedRectangle(cornerRadius: 6)
+                .fill(.quaternary)
+                .frame(width: 56, height: 56)
+            VStack(alignment: .leading, spacing: 4) {
+                RoundedRectangle(cornerRadius: 3)
+                    .fill(.quaternary)
+                    .frame(width: 120, height: 14)
+                RoundedRectangle(cornerRadius: 3)
+                    .fill(.quaternary)
+                    .frame(width: 80, height: 12)
+            }
+            Spacer()
+        }
+    }
+
+    private var albumGridPlaceholder: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            RoundedRectangle(cornerRadius: 10)
+                .fill(.quaternary)
+                .aspectRatio(1, contentMode: .fit)
+            RoundedRectangle(cornerRadius: 3)
+                .fill(.quaternary)
+                .frame(height: 14)
+            RoundedRectangle(cornerRadius: 3)
+                .fill(.quaternary)
+                .frame(width: 80, height: 12)
+        }
+    }
+
+    private var remainingPlaceholderCount: Int {
+        guard hasMore, localFilteredAlbums == nil, searchText.isEmpty else { return 0 }
+        guard let totalCount = appState.libraryCache.albums?.count else { return 0 }
+        return max(0, totalCount - albums.count)
+    }
+
     private func paginateIfNeeded(_ album: Album) {
-        guard localFilteredAlbums == nil else { return }
-        if album.id == albums.last?.id && hasMore {
-            Task { await loadMore() }
+        guard localFilteredAlbums == nil, hasMore, !isLoading else { return }
+        guard let index = albums.firstIndex(where: { $0.id == album.id }) else { return }
+        let prefetchThreshold = max(albums.count - 30, 0)
+        if index >= prefetchThreshold {
+            pendingPageTarget = max(pendingPageTarget, albums.count + pageSize)
+            Task { await loadPages() }
+        }
+    }
+
+    private func scheduleScrollLoad(placeholderIndex: Int) {
+        guard hasMore else { return }
+        pendingPageTarget = max(pendingPageTarget, albums.count + placeholderIndex + pageSize)
+        scrollLoadTask?.cancel()
+        scrollLoadTask = Task {
+            try? await Task.sleep(for: .milliseconds(150))
+            guard !Task.isCancelled else { return }
+            await loadPages()
         }
     }
 
     private func loadAlbums() async {
+        scrollLoadTask?.cancel()
+        pendingPageTarget = 0
         let client = appState.subsonicClient
         let sortType = effectiveListType
         let endpoint = SubsonicEndpoint.getAlbumList2(
@@ -352,20 +421,30 @@ struct AlbumsView: View {
         }
     }
 
-    private func loadMore() async {
-        guard !isLoading else { return }
+    private func loadPages() async {
+        guard !isLoading, hasMore else { return }
         isLoading = true
-        defer { isLoading = false }
-        do {
-            let result = try await appState.subsonicClient.getAlbumList(
-                type: effectiveListType, size: pageSize, offset: albums.count, genre: genre,
-                fromYear: fromYear, toYear: toYear)
-            albums.append(contentsOf: result)
-            hasMore = result.count >= pageSize
-            recomputeFilteredAlbums()
-        } catch {
-            hasMore = false
+        defer {
+            isLoading = false
+            // If target moved while loading, schedule another batch
+            if albums.count < pendingPageTarget, hasMore {
+                scrollLoadTask?.cancel()
+                scrollLoadTask = Task { await loadPages() }
+            }
         }
+        while albums.count < pendingPageTarget, hasMore, !Task.isCancelled {
+            do {
+                let result = try await appState.subsonicClient.getAlbumList(
+                    type: effectiveListType, size: pageSize, offset: albums.count, genre: genre,
+                    fromYear: fromYear, toYear: toYear)
+                albums.append(contentsOf: result)
+                hasMore = result.count >= pageSize
+            } catch {
+                hasMore = false
+                break
+            }
+        }
+        recomputeFilteredAlbums()
     }
 
     private func recomputeFilteredAlbums() {

--- a/Vibrdrome/Features/Library/ArtistDetailView.swift
+++ b/Vibrdrome/Features/Library/ArtistDetailView.swift
@@ -1,9 +1,11 @@
 import SwiftUI
+import SwiftData
 
 struct ArtistDetailView: View {
     let artistId: String
 
     @Environment(AppState.self) private var appState
+    @Environment(\.modelContext) private var modelContext
     @State private var artist: Artist?
     @State private var topSongs: [Song] = []
     @State private var similarArtists: [Artist] = []
@@ -151,7 +153,30 @@ struct ArtistDetailView: View {
     }
 
     private func loadArtist() async {
-        isLoading = true
+        // Show cached artist with album list instantly
+        if artist == nil {
+            let aid = artistId
+            let artistDesc = FetchDescriptor<CachedArtist>(
+                predicate: #Predicate { $0.id == aid }
+            )
+            if let cached = try? modelContext.fetch(artistDesc).first {
+                // Find this artist's albums in the cache
+                let albumDesc = FetchDescriptor<CachedAlbum>(
+                    predicate: #Predicate<CachedAlbum> { $0.artistId == aid },
+                    sortBy: [SortDescriptor(\CachedAlbum.year, order: .reverse)]
+                )
+                let cachedAlbums = (try? modelContext.fetch(albumDesc)) ?? []
+                let albums = cachedAlbums.map { $0.toAlbum() }
+                artist = Artist(
+                    id: cached.id, name: cached.name,
+                    coverArt: cached.coverArtId,
+                    albumCount: cached.albumCount,
+                    starred: cached.isStarred ? "true" : nil,
+                    album: albums.isEmpty ? nil : albums
+                )
+            }
+        }
+        isLoading = artist == nil
         error = nil
         defer { isLoading = false }
         do {

--- a/Vibrdrome/Features/Library/ArtistsView.swift
+++ b/Vibrdrome/Features/Library/ArtistsView.swift
@@ -1,8 +1,12 @@
 import SwiftUI
+import SwiftData
+import os.log
 
 struct ArtistsView: View {
     @Environment(AppState.self) private var appState
+    @Environment(\.modelContext) private var modelContext
     @State private var indexes: [ArtistIndex] = []
+    @State private var localFilteredArtists: [Artist]?
     @State private var isLoading = true
     @State private var error: String?
     @State private var searchText = ""
@@ -21,6 +25,19 @@ struct ArtistsView: View {
     }
 
     private var filteredIndexes: [(id: String, name: String, artists: [Artist])] {
+        // When local filters are active, use flat filtered list (no index grouping)
+        if let filtered = localFilteredArtists {
+            let source: [Artist]
+            if searchText.isEmpty {
+                source = filtered
+            } else {
+                source = filtered.filter { $0.name.localizedCaseInsensitiveContains(searchText) }
+            }
+            let sorted = sortReversed ? source.reversed() : Array(source)
+            guard !sorted.isEmpty else { return [] }
+            return [("filtered", "Results", sorted)]
+        }
+
         var raw: [(id: String, name: String, artists: [Artist])]
         if searchText.isEmpty {
             raw = indexes.map { (id: $0.id, name: $0.name, artists: $0.artist ?? []) }
@@ -94,6 +111,23 @@ struct ArtistsView: View {
             }
         }
         .toolbar {
+            #if os(macOS)
+            ToolbarItem(placement: .automatic) {
+                Button {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        if appState.activeSidePanel == .artistFilters {
+                            appState.activeSidePanel = nil
+                        } else {
+                            appState.activeSidePanel = .artistFilters
+                        }
+                    }
+                } label: {
+                    Image(systemName: appState.artistFilter.isActive ? "line.3.horizontal.decrease.circle.fill" : "line.3.horizontal.decrease.circle")
+                }
+                .accessibilityLabel("Artist Filters")
+                .accessibilityIdentifier("artistFilterToggle")
+            }
+            #endif
             ToolbarItem(placement: .automatic) {
                 Button {
                     withAnimation(.easeInOut(duration: 0.2)) {
@@ -138,8 +172,17 @@ struct ArtistsView: View {
                 }
             }
         }
-        .task { await loadArtists() }
+        .task {
+            await loadArtists()
+            #if os(macOS)
+            applyLocalFilters()
+            #endif
+        }
         .refreshable { await loadArtists() }
+        #if os(macOS)
+        .onChange(of: appState.artistFilter.isFavorited) { applyLocalFilters() }
+        .onChange(of: appState.artistFilter.selectedGenres) { applyLocalFilters() }
+        #endif
     }
 
     // MARK: - List view
@@ -268,4 +311,66 @@ struct ArtistsView: View {
             }
         }
     }
+
+    #if os(macOS)
+    private func applyLocalFilters() {
+        let filter = appState.artistFilter
+        guard filter.isActive else {
+            localFilteredArtists = nil
+            return
+        }
+
+        do {
+            var descriptor = FetchDescriptor<CachedArtist>()
+            descriptor.sortBy = [SortDescriptor(\.name)]
+            let allArtists = try modelContext.fetch(descriptor)
+
+            // Pre-compute artist IDs that have albums matching selected genres
+            var artistIdsWithMatchingGenres: Set<String>?
+            if !filter.selectedGenres.isEmpty {
+                let albumDescriptor = FetchDescriptor<CachedAlbum>()
+                let allAlbums = try modelContext.fetch(albumDescriptor)
+                var ids = Set<String>()
+                for album in allAlbums {
+                    if let genre = album.genre, filter.selectedGenres.contains(genre),
+                       let artistId = album.artistId {
+                        ids.insert(artistId)
+                    }
+                }
+                artistIdsWithMatchingGenres = ids
+            }
+
+            let filtered = allArtists.filter { artist in
+                // Favorited filter
+                switch filter.isFavorited {
+                case .yes: if !artist.isStarred { return false }
+                case .no: if artist.isStarred { return false }
+                case .none: break
+                }
+
+                // Genre filter (via album lookup)
+                if let matchIds = artistIdsWithMatchingGenres {
+                    if !matchIds.contains(artist.id) { return false }
+                }
+
+                return true
+            }
+
+            localFilteredArtists = filtered.map { cached in
+                Artist(
+                    id: cached.id,
+                    name: cached.name,
+                    coverArt: cached.coverArtId,
+                    albumCount: cached.albumCount,
+                    starred: cached.isStarred ? "true" : nil,
+                    album: nil
+                )
+            }
+        } catch {
+            Logger(subsystem: "com.vibrdrome.app", category: "Artists")
+                .error("Failed to apply local filters: \(error)")
+            localFilteredArtists = nil
+        }
+    }
+    #endif
 }

--- a/Vibrdrome/Features/Library/ArtistsView.swift
+++ b/Vibrdrome/Features/Library/ArtistsView.swift
@@ -13,6 +13,7 @@ struct ArtistsView: View {
     @State private var searchText = ""
     @State private var sortReversed = false
     @AppStorage("artistsViewStyle") private var showAsList = true
+    @State private var cachedFilteredIndexes: [(id: String, name: String, artists: [Artist])] = []
 
     enum ArtistSortOption: String, CaseIterable {
         case nameAZ, nameZA
@@ -24,7 +25,7 @@ struct ArtistsView: View {
         }
     }
 
-    private var filteredIndexes: [(id: String, name: String, artists: [Artist])] {
+    private func computeFilteredIndexes() -> [(id: String, name: String, artists: [Artist])] {
         // When local filters are active, use flat filtered list (no index grouping)
         if let filtered = localFilteredArtists {
             let source: [Artist]
@@ -177,7 +178,10 @@ struct ArtistsView: View {
             #if os(macOS)
             applyLocalFilters()
             #endif
+            recomputeFilteredIndexes()
         }
+        .onChange(of: searchText) { recomputeFilteredIndexes() }
+        .onChange(of: sortReversed) { recomputeFilteredIndexes() }
         .refreshable { await loadArtists() }
         #if os(macOS)
         .onChange(of: appState.artistFilter.isFavorited) { debouncedApplyLocalFilters() }
@@ -190,7 +194,7 @@ struct ArtistsView: View {
     private var artistList: some View {
         ScrollViewReader { proxy in
             List {
-                ForEach(filteredIndexes, id: \.id) { index in
+                ForEach(cachedFilteredIndexes, id: \.id) { index in
                     Section(header: Text(index.name).id(index.name)) {
                         ForEach(index.artists) { artist in
                             NavigationLink {
@@ -213,7 +217,7 @@ struct ArtistsView: View {
 
     private func sectionIndex(proxy: ScrollViewProxy) -> some View {
         VStack(spacing: 1) {
-            ForEach(filteredIndexes, id: \.id) { index in
+            ForEach(cachedFilteredIndexes, id: \.id) { index in
                 let label = sectionIndexLabel(index.name)
                 Text(label)
                     .font(.system(size: 11, weight: .bold, design: .rounded))
@@ -239,7 +243,7 @@ struct ArtistsView: View {
     private var artistGrid: some View {
         ScrollView {
             LazyVStack(alignment: .leading, spacing: 24, pinnedViews: [.sectionHeaders]) {
-                ForEach(filteredIndexes, id: \.id) { index in
+                ForEach(cachedFilteredIndexes, id: \.id) { index in
                     Section {
                         LazyVGrid(columns: [
                             GridItem(.adaptive(minimum: 130, maximum: 170), spacing: 16)
@@ -309,11 +313,16 @@ struct ArtistsView: View {
         defer { isLoading = false }
         do {
             indexes = try await client.getArtists()
+            recomputeFilteredIndexes()
         } catch {
             if indexes.isEmpty {
                 self.error = ErrorPresenter.userMessage(for: error)
             }
         }
+    }
+
+    private func recomputeFilteredIndexes() {
+        cachedFilteredIndexes = computeFilteredIndexes()
     }
 
     #if os(macOS)
@@ -330,6 +339,7 @@ struct ArtistsView: View {
         let filter = appState.artistFilter
         guard filter.isActive else {
             localFilteredArtists = nil
+            recomputeFilteredIndexes()
             return
         }
 
@@ -380,6 +390,7 @@ struct ArtistsView: View {
             }
 
             localFilteredArtists = filtered
+            recomputeFilteredIndexes()
         } catch {
             Logger(subsystem: "com.vibrdrome.app", category: "Artists")
                 .error("Failed to apply local filters: \(error)")

--- a/Vibrdrome/Features/Library/ArtistsView.swift
+++ b/Vibrdrome/Features/Library/ArtistsView.swift
@@ -7,6 +7,7 @@ struct ArtistsView: View {
     @Environment(\.modelContext) private var modelContext
     @State private var indexes: [ArtistIndex] = []
     @State private var localFilteredArtists: [Artist]?
+    @State private var filterTask: Task<Void, Never>?
     @State private var isLoading = true
     @State private var error: String?
     @State private var searchText = ""
@@ -179,8 +180,8 @@ struct ArtistsView: View {
         }
         .refreshable { await loadArtists() }
         #if os(macOS)
-        .onChange(of: appState.artistFilter.isFavorited) { applyLocalFilters() }
-        .onChange(of: appState.artistFilter.selectedGenres) { applyLocalFilters() }
+        .onChange(of: appState.artistFilter.isFavorited) { debouncedApplyLocalFilters() }
+        .onChange(of: appState.artistFilter.selectedGenres) { debouncedApplyLocalFilters() }
         #endif
     }
 
@@ -316,6 +317,15 @@ struct ArtistsView: View {
     }
 
     #if os(macOS)
+    private func debouncedApplyLocalFilters() {
+        filterTask?.cancel()
+        filterTask = Task {
+            try? await Task.sleep(for: .milliseconds(150))
+            guard !Task.isCancelled else { return }
+            applyLocalFilters()
+        }
+    }
+
     private func applyLocalFilters() {
         let filter = appState.artistFilter
         guard filter.isActive else {
@@ -324,15 +334,25 @@ struct ArtistsView: View {
         }
 
         do {
-            var descriptor = FetchDescriptor<CachedArtist>()
-            descriptor.sortBy = [SortDescriptor(\.name)]
-            let allArtists = try modelContext.fetch(descriptor)
+            let allArtists: [Artist]
+            if let cachedArtists = appState.libraryCache.artists {
+                allArtists = cachedArtists
+            } else {
+                var descriptor = FetchDescriptor<CachedArtist>()
+                descriptor.sortBy = [SortDescriptor(\.name)]
+                allArtists = try modelContext.fetch(descriptor).map { $0.toArtist() }
+            }
 
             // Pre-compute artist IDs that have albums matching selected genres
             var artistIdsWithMatchingGenres: Set<String>?
             if !filter.selectedGenres.isEmpty {
-                let albumDescriptor = FetchDescriptor<CachedAlbum>()
-                let allAlbums = try modelContext.fetch(albumDescriptor)
+                let allAlbums: [Album]
+                if let cachedAlbums = appState.libraryCache.albums {
+                    allAlbums = cachedAlbums
+                } else {
+                    let albumDescriptor = FetchDescriptor<CachedAlbum>()
+                    allAlbums = try modelContext.fetch(albumDescriptor).map { $0.toAlbum() }
+                }
                 var ids = Set<String>()
                 for album in allAlbums {
                     if let genre = album.genre, filter.selectedGenres.contains(genre),
@@ -346,8 +366,8 @@ struct ArtistsView: View {
             let filtered = allArtists.filter { artist in
                 // Favorited filter
                 switch filter.isFavorited {
-                case .yes: if !artist.isStarred { return false }
-                case .no: if artist.isStarred { return false }
+                case .yes: if artist.starred == nil { return false }
+                case .no: if artist.starred != nil { return false }
                 case .none: break
                 }
 
@@ -359,16 +379,7 @@ struct ArtistsView: View {
                 return true
             }
 
-            localFilteredArtists = filtered.map { cached in
-                Artist(
-                    id: cached.id,
-                    name: cached.name,
-                    coverArt: cached.coverArtId,
-                    albumCount: cached.albumCount,
-                    starred: cached.isStarred ? "true" : nil,
-                    album: nil
-                )
-            }
+            localFilteredArtists = filtered
         } catch {
             Logger(subsystem: "com.vibrdrome.app", category: "Artists")
                 .error("Failed to apply local filters: \(error)")

--- a/Vibrdrome/Features/Library/ArtistsView.swift
+++ b/Vibrdrome/Features/Library/ArtistsView.swift
@@ -12,7 +12,6 @@ struct ArtistsView: View {
     @State private var searchText = ""
     @State private var sortReversed = false
     @AppStorage("artistsViewStyle") private var showAsList = true
-    @AppStorage(UserDefaultsKeys.gridColumnsPerRow) private var gridColumns = 2
 
     enum ArtistSortOption: String, CaseIterable {
         case nameAZ, nameZA
@@ -241,8 +240,9 @@ struct ArtistsView: View {
             LazyVStack(alignment: .leading, spacing: 24, pinnedViews: [.sectionHeaders]) {
                 ForEach(filteredIndexes, id: \.id) { index in
                     Section {
-                        LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 16),
-                                                 count: max(2, min(4, gridColumns))), spacing: 20) {
+                        LazyVGrid(columns: [
+                            GridItem(.adaptive(minimum: 130, maximum: 170), spacing: 16)
+                        ], spacing: 20) {
                             ForEach(index.artists) { artist in
                                 NavigationLink {
                                     ArtistDetailView(artistId: artist.id)
@@ -271,11 +271,14 @@ struct ArtistsView: View {
 
     private func artistGridCard(_ artist: Artist) -> some View {
         VStack(spacing: 8) {
-            AlbumArtView(
-                coverArtId: artist.coverArt,
-                size: Theme.artistBubbleSize,
-                cornerRadius: Theme.artistBubbleSize / 2
-            )
+            GeometryReader { geo in
+                AlbumArtView(
+                    coverArtId: artist.coverArt,
+                    size: geo.size.width,
+                    cornerRadius: geo.size.width / 2
+                )
+            }
+            .aspectRatio(1, contentMode: .fit)
             .shadow(color: .black.opacity(0.15), radius: 6, y: 3)
 
             Text(artist.name)

--- a/Vibrdrome/Features/Library/FavoritesView.swift
+++ b/Vibrdrome/Features/Library/FavoritesView.swift
@@ -1,29 +1,33 @@
 import SwiftUI
+import SwiftData
 
 struct FavoritesView: View {
     @Environment(AppState.self) private var appState
-    @State private var starred: Starred2?
-    @State private var isLoading = true
-    @State private var error: String?
+    @Query(filter: #Predicate<CachedArtist> { $0.isStarred }, sort: \CachedArtist.name)
+    private var starredArtists: [CachedArtist]
+    @Query(filter: #Predicate<CachedAlbum> { $0.isStarred }, sort: \CachedAlbum.name)
+    private var starredAlbums: [CachedAlbum]
+    @Query(filter: #Predicate<CachedSong> { $0.isStarred }, sort: \CachedSong.title)
+    private var starredSongs: [CachedSong]
     @State private var searchText = ""
     @State private var selectedSongs = Set<String>()
     @State private var isSelecting = false
     @State private var showBatchAddToPlaylist = false
 
     private var filteredArtists: [Artist] {
-        guard let artists = starred?.artist else { return [] }
+        let artists = starredArtists.map { $0.toArtist() }
         if searchText.isEmpty { return artists }
         return artists.filter { $0.name.localizedCaseInsensitiveContains(searchText) }
     }
 
     private var filteredAlbums: [Album] {
-        guard let albums = starred?.album else { return [] }
+        let albums = starredAlbums.map { $0.toAlbum() }
         if searchText.isEmpty { return albums }
         return albums.filter { $0.name.localizedCaseInsensitiveContains(searchText) }
     }
 
     private var filteredSongs: [Song] {
-        guard let songs = starred?.song else { return [] }
+        let songs = starredSongs.map { $0.toSong() }
         if searchText.isEmpty { return songs }
         return songs.filter {
             $0.title.localizedCaseInsensitiveContains(searchText) ||
@@ -33,7 +37,7 @@ struct FavoritesView: View {
 
     var body: some View {
         List {
-            if starred != nil {
+            if !isEmpty {
                 // Starred Artists
                 if !filteredArtists.isEmpty {
                     Section("Artists") {
@@ -145,18 +149,7 @@ struct FavoritesView: View {
         .navigationBarTitleDisplayMode(.inline)
         #endif
         .overlay {
-            if isLoading && starred == nil {
-                ProgressView("Loading favorites...")
-            } else if let error, starred == nil {
-                ContentUnavailableView {
-                    Label("Error", systemImage: "exclamationmark.triangle")
-                } description: {
-                    Text(error)
-                } actions: {
-                    Button("Retry") { Task { await loadStarred() } }
-                        .buttonStyle(.bordered)
-                }
-            } else if !isLoading && isEmpty {
+            if isEmpty {
                 ContentUnavailableView {
                     Label("No Favorites", systemImage: "heart")
                 } description: {
@@ -179,7 +172,7 @@ struct FavoritesView: View {
             }
             #if os(macOS)
             ToolbarItem {
-                Button { Task { await loadStarred() } } label: {
+                Button { Task { await LibrarySyncManager.shared.syncIfStale() } } label: {
                     Label("Refresh", systemImage: "arrow.clockwise")
                 }
             }
@@ -189,8 +182,7 @@ struct FavoritesView: View {
             AddToPlaylistView(songIds: Array(selectedSongs))
                 .environment(appState)
         }
-        .task { await loadStarred() }
-        .refreshable { await loadStarred() }
+        .refreshable { await LibrarySyncManager.shared.syncIfStale() }
     }
 
     private func toggleSelection(_ songId: String) {
@@ -211,20 +203,6 @@ struct FavoritesView: View {
     }
 
     private var isEmpty: Bool {
-        guard let starred else { return true }
-        return (starred.artist?.isEmpty ?? true) &&
-               (starred.album?.isEmpty ?? true) &&
-               (starred.song?.isEmpty ?? true)
-    }
-
-    private func loadStarred() async {
-        isLoading = true
-        error = nil
-        defer { isLoading = false }
-        do {
-            starred = try await appState.subsonicClient.getStarred()
-        } catch {
-            self.error = ErrorPresenter.userMessage(for: error)
-        }
+        starredArtists.isEmpty && starredAlbums.isEmpty && starredSongs.isEmpty
     }
 }

--- a/Vibrdrome/Features/Library/FavoritesView.swift
+++ b/Vibrdrome/Features/Library/FavoritesView.swift
@@ -149,7 +149,13 @@ struct FavoritesView: View {
         .navigationBarTitleDisplayMode(.inline)
         #endif
         .overlay {
-            if isEmpty {
+            if appState.librarySyncManager.lastSyncDate == nil && isEmpty {
+                ContentUnavailableView {
+                    Label("Loading Favorites", systemImage: "heart")
+                } description: {
+                    Text("Syncing your library...")
+                }
+            } else if isEmpty {
                 ContentUnavailableView {
                     Label("No Favorites", systemImage: "heart")
                 } description: {

--- a/Vibrdrome/Features/Library/FavoritesView.swift
+++ b/Vibrdrome/Features/Library/FavoritesView.swift
@@ -13,20 +13,23 @@ struct FavoritesView: View {
     @State private var selectedSongs = Set<String>()
     @State private var isSelecting = false
     @State private var showBatchAddToPlaylist = false
+    @State private var cachedFilteredArtists: [Artist] = []
+    @State private var cachedFilteredAlbums: [Album] = []
+    @State private var cachedFilteredSongs: [Song] = []
 
-    private var filteredArtists: [Artist] {
+    private func computeFilteredArtists() -> [Artist] {
         let artists = starredArtists.map { $0.toArtist() }
         if searchText.isEmpty { return artists }
         return artists.filter { $0.name.localizedCaseInsensitiveContains(searchText) }
     }
 
-    private var filteredAlbums: [Album] {
+    private func computeFilteredAlbums() -> [Album] {
         let albums = starredAlbums.map { $0.toAlbum() }
         if searchText.isEmpty { return albums }
         return albums.filter { $0.name.localizedCaseInsensitiveContains(searchText) }
     }
 
-    private var filteredSongs: [Song] {
+    private func computeFilteredSongs() -> [Song] {
         let songs = starredSongs.map { $0.toSong() }
         if searchText.isEmpty { return songs }
         return songs.filter {
@@ -39,9 +42,9 @@ struct FavoritesView: View {
         List {
             if !isEmpty {
                 // Starred Artists
-                if !filteredArtists.isEmpty {
+                if !cachedFilteredArtists.isEmpty {
                     Section("Artists") {
-                        ForEach(filteredArtists) { artist in
+                        ForEach(cachedFilteredArtists) { artist in
                             NavigationLink {
                                 ArtistDetailView(artistId: artist.id)
                             } label: {
@@ -53,9 +56,9 @@ struct FavoritesView: View {
                 }
 
                 // Starred Albums
-                if !filteredAlbums.isEmpty {
+                if !cachedFilteredAlbums.isEmpty {
                     Section("Albums") {
-                        ForEach(filteredAlbums) { album in
+                        ForEach(cachedFilteredAlbums) { album in
                             NavigationLink {
                                 AlbumDetailView(albumId: album.id)
                             } label: {
@@ -67,11 +70,11 @@ struct FavoritesView: View {
                 }
 
                 // Starred Songs
-                if !filteredSongs.isEmpty {
+                if !cachedFilteredSongs.isEmpty {
                     Section("Songs") {
                         HStack(spacing: 12) {
                             Button {
-                                AudioEngine.shared.play(song: filteredSongs[0], from: filteredSongs, at: 0)
+                                AudioEngine.shared.play(song: cachedFilteredSongs[0], from: cachedFilteredSongs, at: 0)
                             } label: {
                                 Label("Play All", systemImage: "play.fill")
                                     .font(.subheadline)
@@ -83,7 +86,7 @@ struct FavoritesView: View {
                             .accessibilityIdentifier("favPlayAllButton")
 
                             Button {
-                                let shuffled = filteredSongs.shuffled()
+                                let shuffled = cachedFilteredSongs.shuffled()
                                 AudioEngine.shared.play(song: shuffled[0], from: shuffled, at: 0)
                             } label: {
                                 Label("Shuffle", systemImage: "shuffle")
@@ -97,7 +100,7 @@ struct FavoritesView: View {
                         }
                         .listRowSeparator(.hidden)
 
-                        ForEach(Array(filteredSongs.enumerated()), id: \.element.id) { index, song in
+                        ForEach(Array(cachedFilteredSongs.enumerated()), id: \.element.id) { index, song in
                             HStack(spacing: 0) {
                                 if isSelecting {
                                     Button {
@@ -114,13 +117,13 @@ struct FavoritesView: View {
                                 }
 
                                 TrackRow(song: song, showTrackNumber: false)
-                                    .trackContextMenu(song: song, queue: filteredSongs, index: index)
+                                    .trackContextMenu(song: song, queue: cachedFilteredSongs, index: index)
                                     .accessibilityIdentifier("favSongRow_\(song.id)")
                                     .onTapGesture {
                                         if isSelecting {
                                             toggleSelection(song.id)
                                         } else {
-                                            AudioEngine.shared.play(song: song, from: filteredSongs, at: index)
+                                            AudioEngine.shared.play(song: song, from: cachedFilteredSongs, at: index)
                                         }
                                     }
                             }
@@ -128,7 +131,7 @@ struct FavoritesView: View {
 
                         // Batch action bar
                         if isSelecting && !selectedSongs.isEmpty {
-                            favoritesBatchActionBar(songs: filteredSongs)
+                            favoritesBatchActionBar(songs: cachedFilteredSongs)
                                 .listRowSeparator(.hidden)
                         }
                     }
@@ -189,6 +192,17 @@ struct FavoritesView: View {
                 .environment(appState)
         }
         .refreshable { await LibrarySyncManager.shared.syncIfStale() }
+        .onChange(of: searchText) { recomputeFilteredLists() }
+        .onChange(of: starredArtists) { recomputeFilteredLists() }
+        .onChange(of: starredAlbums) { recomputeFilteredLists() }
+        .onChange(of: starredSongs) { recomputeFilteredLists() }
+        .onAppear { recomputeFilteredLists() }
+    }
+
+    private func recomputeFilteredLists() {
+        cachedFilteredArtists = computeFilteredArtists()
+        cachedFilteredAlbums = computeFilteredAlbums()
+        cachedFilteredSongs = computeFilteredSongs()
     }
 
     private func toggleSelection(_ songId: String) {

--- a/Vibrdrome/Features/Library/GenresView.swift
+++ b/Vibrdrome/Features/Library/GenresView.swift
@@ -1,7 +1,9 @@
+import SwiftData
 import SwiftUI
 
 struct GenresView: View {
     @Environment(AppState.self) private var appState
+    @Environment(\.modelContext) private var modelContext
     @State private var genres: [Genre] = []
     @State private var isLoading = true
     @State private var error: String?
@@ -193,7 +195,16 @@ struct GenresView: View {
 
     private func loadGenres() async {
         let client = appState.subsonicClient
-        // Show cached data instantly
+
+        // Try local SwiftData first — derive genres from cached songs
+        if genres.isEmpty {
+            let localGenres = deriveGenresFromCache()
+            if !localGenres.isEmpty {
+                genres = localGenres
+            }
+        }
+
+        // Show cached API response if no local data
         if genres.isEmpty,
            let cached = await client.cachedResponse(for: .getGenres, ttl: 3600) {
             genres = (cached.genres?.genre ?? [])
@@ -207,10 +218,32 @@ struct GenresView: View {
                 .sorted { $0.value.localizedCaseInsensitiveCompare($1.value) == .orderedAscending }
             await loadGenreArt(client: client)
         } catch {
-            if genres.isEmpty {
+            // If network fails but we have local data, load art from cache
+            if !genres.isEmpty {
+                await loadGenreArt(client: client)
+            } else {
                 self.error = ErrorPresenter.userMessage(for: error)
             }
         }
+    }
+
+    private func deriveGenresFromCache() -> [Genre] {
+        let allSongs = (try? modelContext.fetch(FetchDescriptor<CachedSong>())) ?? []
+        var genreMap: [String: (albumIds: Set<String>, songCount: Int)] = [:]
+
+        for song in allSongs {
+            guard let genre = song.genre, !genre.isEmpty else { continue }
+            var entry = genreMap[genre] ?? (albumIds: Set<String>(), songCount: 0)
+            entry.songCount += 1
+            if let albumId = song.albumId {
+                entry.albumIds.insert(albumId)
+            }
+            genreMap[genre] = entry
+        }
+
+        return genreMap.map { key, value in
+            Genre(songCount: value.songCount, albumCount: value.albumIds.count, value: key)
+        }.sorted { $0.value.localizedCaseInsensitiveCompare($1.value) == .orderedAscending }
     }
 
     private func loadGenreArt(client: SubsonicClient) async {

--- a/Vibrdrome/Features/Library/GenresView.swift
+++ b/Vibrdrome/Features/Library/GenresView.swift
@@ -230,21 +230,19 @@ struct GenresView: View {
     }
 
     private func deriveGenresFromCache() -> [Genre] {
-        let allSongs = (try? modelContext.fetch(FetchDescriptor<CachedSong>())) ?? []
-        var genreMap: [String: (albumIds: Set<String>, songCount: Int)] = [:]
+        // Use albums (much fewer records) to derive genre counts
+        let allAlbums = (try? modelContext.fetch(FetchDescriptor<CachedAlbum>())) ?? []
+        var genreAlbumCount: [String: Int] = [:]
+        var genreSongCount: [String: Int] = [:]
 
-        for song in allSongs {
-            guard let genre = song.genre, !genre.isEmpty else { continue }
-            var entry = genreMap[genre] ?? (albumIds: Set<String>(), songCount: 0)
-            entry.songCount += 1
-            if let albumId = song.albumId {
-                entry.albumIds.insert(albumId)
-            }
-            genreMap[genre] = entry
+        for album in allAlbums {
+            guard let genre = album.genre, !genre.isEmpty else { continue }
+            genreAlbumCount[genre, default: 0] += 1
+            genreSongCount[genre, default: 0] += album.songCount ?? 0
         }
 
-        return genreMap.map { key, value in
-            Genre(songCount: value.songCount, albumCount: value.albumIds.count, value: key)
+        return genreAlbumCount.map { key, albumCount in
+            Genre(songCount: genreSongCount[key] ?? 0, albumCount: albumCount, value: key)
         }.sorted { $0.value.localizedCaseInsensitiveCompare($1.value) == .orderedAscending }
     }
 

--- a/Vibrdrome/Features/Library/GenresView.swift
+++ b/Vibrdrome/Features/Library/GenresView.swift
@@ -11,7 +11,6 @@ struct GenresView: View {
     @State private var searchText = ""
     @State private var sortBy: GenreSortOption = .name
     @AppStorage("genresViewStyle") private var showAsList = true
-    @AppStorage(UserDefaultsKeys.gridColumnsPerRow) private var gridColumns = 2
 
     enum GenreSortOption: String, CaseIterable {
         case name, songCount
@@ -154,8 +153,9 @@ struct GenresView: View {
 
     private var genreGrid: some View {
         ScrollView {
-            LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 16),
-                                     count: max(2, min(4, gridColumns))), spacing: 20) {
+            LazyVGrid(columns: [
+                GridItem(.adaptive(minimum: 160, maximum: 220), spacing: 16)
+            ], spacing: 20) {
                 ForEach(filteredGenres) { genre in
                     NavigationLink {
                         AlbumsView(listType: .byGenre, title: genre.value, genre: genre.value)
@@ -172,12 +172,14 @@ struct GenresView: View {
 
     private func genreCard(_ genre: Genre) -> some View {
         VStack(alignment: .leading, spacing: 8) {
-            AlbumArtView(
-                coverArtId: genreArt[genre.value],
-                size: Theme.albumCardSize,
-                cornerRadius: 10
-            )
-            .frame(maxWidth: .infinity)
+            GeometryReader { geo in
+                AlbumArtView(
+                    coverArtId: genreArt[genre.value],
+                    size: geo.size.width,
+                    cornerRadius: 10
+                )
+            }
+            .aspectRatio(1, contentMode: .fit)
             .shadow(color: .black.opacity(0.15), radius: 6, y: 3)
 
             Text(genre.value)

--- a/Vibrdrome/Features/Library/GenresView.swift
+++ b/Vibrdrome/Features/Library/GenresView.swift
@@ -11,6 +11,7 @@ struct GenresView: View {
     @State private var searchText = ""
     @State private var sortBy: GenreSortOption = .name
     @AppStorage("genresViewStyle") private var showAsList = true
+    @State private var cachedFilteredGenres: [Genre] = []
 
     enum GenreSortOption: String, CaseIterable {
         case name, songCount
@@ -22,7 +23,7 @@ struct GenresView: View {
         }
     }
 
-    private var filteredGenres: [Genre] {
+    private func computeFilteredGenres() -> [Genre] {
         let base: [Genre]
         if searchText.isEmpty {
             base = genres
@@ -117,13 +118,15 @@ struct GenresView: View {
             }
         }
         .task { await loadGenres() }
+        .onChange(of: searchText) { recomputeFilteredGenres() }
+        .onChange(of: sortBy) { recomputeFilteredGenres() }
         .refreshable { await loadGenres() }
     }
 
     // MARK: - List view
 
     private var genreList: some View {
-        List(filteredGenres) { genre in
+        List(cachedFilteredGenres) { genre in
             NavigationLink {
                 AlbumsView(listType: .byGenre, title: genre.value, genre: genre.value)
             } label: {
@@ -156,7 +159,7 @@ struct GenresView: View {
             LazyVGrid(columns: [
                 GridItem(.adaptive(minimum: 160, maximum: 220), spacing: 16)
             ], spacing: 20) {
-                ForEach(filteredGenres) { genre in
+                ForEach(cachedFilteredGenres) { genre in
                     NavigationLink {
                         AlbumsView(listType: .byGenre, title: genre.value, genre: genre.value)
                     } label: {
@@ -195,6 +198,10 @@ struct GenresView: View {
         }
     }
 
+    private func recomputeFilteredGenres() {
+        cachedFilteredGenres = computeFilteredGenres()
+    }
+
     private func loadGenres() async {
         let client = appState.subsonicClient
 
@@ -203,6 +210,7 @@ struct GenresView: View {
             let localGenres = deriveGenresFromCache()
             if !localGenres.isEmpty {
                 genres = localGenres
+                recomputeFilteredGenres()
             }
         }
 
@@ -211,6 +219,7 @@ struct GenresView: View {
            let cached = await client.cachedResponse(for: .getGenres, ttl: 3600) {
             genres = (cached.genres?.genre ?? [])
                 .sorted { $0.value.localizedCaseInsensitiveCompare($1.value) == .orderedAscending }
+            recomputeFilteredGenres()
         }
         isLoading = genres.isEmpty
         error = nil
@@ -218,6 +227,7 @@ struct GenresView: View {
         do {
             genres = try await client.getGenres()
                 .sorted { $0.value.localizedCaseInsensitiveCompare($1.value) == .orderedAscending }
+            recomputeFilteredGenres()
             await loadGenreArt(client: client)
         } catch {
             // If network fails but we have local data, load art from cache

--- a/Vibrdrome/Features/Library/LibraryFilterSidebarView.swift
+++ b/Vibrdrome/Features/Library/LibraryFilterSidebarView.swift
@@ -1,0 +1,393 @@
+#if os(macOS)
+import SwiftUI
+import SwiftData
+
+/// Which entity type the filter sidebar is controlling.
+enum FilterContext {
+    case album, artist, song
+}
+
+/// Feishin-style filter sidebar shown as a macOS side panel.
+/// Adapts its controls based on the entity type being filtered.
+struct LibraryFilterSidebarView: View {
+    let context: FilterContext
+
+    @Environment(AppState.self) private var appState
+    @Environment(\.modelContext) private var modelContext
+    @Query(sort: \CachedArtist.name) private var artists: [CachedArtist]
+    @State private var genres: [String] = []
+    @State private var labels: [String] = []
+
+    private var filter: LibraryFilter {
+        switch context {
+        case .album: appState.albumFilter
+        case .artist: appState.artistFilter
+        case .song: appState.songFilter
+        }
+    }
+
+    private var panelTitle: String {
+        switch context {
+        case .album: "Album Filters"
+        case .artist: "Artist Filters"
+        case .song: "Song Filters"
+        }
+    }
+
+    var body: some View {
+        SidePanelContainer(title: panelTitle, onClose: {
+            appState.activeSidePanel = nil
+        }) {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    headerButtons
+
+                    if appState.librarySyncManager.lastSyncDate == nil {
+                        syncRequiredView
+                    } else {
+                        filterControls
+                    }
+                }
+                .padding(14)
+            }
+        }
+        .task { loadCachedMetadata() }
+    }
+
+    // MARK: - Header
+
+    @ViewBuilder
+    private var headerButtons: some View {
+        HStack {
+            if filter.isActive {
+                Text("\(filter.activeFilterCount) active")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            Button("Reset") {
+                filter.reset()
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(Color.accentColor)
+            .font(.subheadline)
+            .disabled(!filter.isActive)
+        }
+    }
+
+    // MARK: - Sync Required
+
+    @ViewBuilder
+    private var syncRequiredView: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "arrow.triangle.2.circlepath")
+                .font(.largeTitle)
+                .foregroundStyle(.secondary)
+            Text("Library sync required")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            Text("Sync your library to enable filtering.")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+                .multilineTextAlignment(.center)
+            Button("Sync Now") {
+                Task {
+                    await appState.librarySyncManager.sync(
+                        client: appState.subsonicClient,
+                        container: PersistenceController.shared.container
+                    )
+                    loadCachedMetadata()
+                }
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.small)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 20)
+    }
+
+    // MARK: - Filter Controls
+
+    @ViewBuilder
+    private var filterControls: some View {
+        if let progress = appState.librarySyncManager.syncProgress {
+            HStack(spacing: 6) {
+                ProgressView()
+                    .controlSize(.small)
+                Text(progress)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+
+        @Bindable var state = appState
+
+        // Favorited — all contexts
+        favoritedControl
+
+        // Rated — album and song only
+        if context == .album || context == .song {
+            ratedControl
+        }
+
+        // Recently played — album and song only
+        if context == .album || context == .song {
+            recentlyPlayedControl
+        }
+
+        Divider()
+
+        // Artist multi-select — album and song only
+        if context == .album || context == .song {
+            artistMultiSelect
+            Divider()
+        }
+
+        // Genre multi-select — all contexts
+        genreMultiSelect
+
+        // Label multi-select — album only
+        if context == .album {
+            Divider()
+            labelMultiSelect
+        }
+
+        // Year filter — album and song only
+        if context == .album || context == .song {
+            Divider()
+            yearFilter
+        }
+    }
+
+    // MARK: - Boolean Filter Controls
+
+    @ViewBuilder
+    private var favoritedControl: some View {
+        @Bindable var state = appState
+        switch context {
+        case .album: TriStateFilterControl(label: "Is favorited", value: $state.albumFilter.isFavorited)
+        case .artist: TriStateFilterControl(label: "Is favorited", value: $state.artistFilter.isFavorited)
+        case .song: TriStateFilterControl(label: "Is favorited", value: $state.songFilter.isFavorited)
+        }
+    }
+
+    @ViewBuilder
+    private var ratedControl: some View {
+        @Bindable var state = appState
+        switch context {
+        case .album: TriStateFilterControl(label: "Is rated", value: $state.albumFilter.isRated)
+        case .song: TriStateFilterControl(label: "Is rated", value: $state.songFilter.isRated)
+        case .artist: EmptyView()
+        }
+    }
+
+    @ViewBuilder
+    private var recentlyPlayedControl: some View {
+        @Bindable var state = appState
+        HStack {
+            Text("Is recently played")
+                .font(.subheadline)
+                .fontWeight(.medium)
+            Spacer()
+            switch context {
+            case .album:
+                Toggle("", isOn: $state.albumFilter.isRecentlyPlayed)
+                    .labelsHidden().toggleStyle(.switch).controlSize(.small)
+            case .song:
+                Toggle("", isOn: $state.songFilter.isRecentlyPlayed)
+                    .labelsHidden().toggleStyle(.switch).controlSize(.small)
+            case .artist:
+                EmptyView()
+            }
+        }
+    }
+
+    // MARK: - Artist Multi-Select
+
+    @ViewBuilder
+    private var artistMultiSelect: some View {
+        @Bindable var state = appState
+        switch context {
+        case .album:
+            FilterMultiSelectList(
+                title: "Artists", items: artists,
+                selectedIds: $state.albumFilter.selectedArtistIds,
+                id: \.id, label: \.name,
+                subtitle: { a in a.albumCount.map { "\($0) album\($0 == 1 ? "" : "s")" } },
+                imageId: { $0.coverArtId }
+            )
+        case .song:
+            FilterMultiSelectList(
+                title: "Artists", items: artists,
+                selectedIds: $state.songFilter.selectedArtistIds,
+                id: \.id, label: \.name,
+                subtitle: { a in a.albumCount.map { "\($0) album\($0 == 1 ? "" : "s")" } },
+                imageId: { $0.coverArtId }
+            )
+        case .artist:
+            EmptyView()
+        }
+    }
+
+    // MARK: - Genre Multi-Select
+
+    @ViewBuilder
+    private var genreMultiSelect: some View {
+        @Bindable var state = appState
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text("Genres")
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                Spacer()
+                if !filter.selectedGenres.isEmpty {
+                    Text("\(filter.selectedGenres.count)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            switch context {
+            case .album:
+                StringFilterList(items: genres, selectedItems: $state.albumFilter.selectedGenres, placeholder: "Search genres…")
+            case .artist:
+                StringFilterList(items: genres, selectedItems: $state.artistFilter.selectedGenres, placeholder: "Search genres…")
+            case .song:
+                StringFilterList(items: genres, selectedItems: $state.songFilter.selectedGenres, placeholder: "Search genres…")
+            }
+        }
+    }
+
+    // MARK: - Label Multi-Select
+
+    @ViewBuilder
+    private var labelMultiSelect: some View {
+        @Bindable var state = appState
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text("Labels")
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                Spacer()
+                if !filter.selectedLabels.isEmpty {
+                    Text("\(filter.selectedLabels.count)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            StringFilterList(items: labels, selectedItems: $state.albumFilter.selectedLabels, placeholder: "Search labels…")
+        }
+    }
+
+    // MARK: - Year Filter
+
+    @ViewBuilder
+    private var yearFilter: some View {
+        @Bindable var state = appState
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Year")
+                .font(.subheadline)
+                .fontWeight(.medium)
+            HStack {
+                switch context {
+                case .album:
+                    TextField("e.g. 2024", value: $state.albumFilter.year, format: .number)
+                        .textFieldStyle(.roundedBorder).font(.caption)
+                case .song:
+                    TextField("e.g. 2024", value: $state.songFilter.year, format: .number)
+                        .textFieldStyle(.roundedBorder).font(.caption)
+                case .artist:
+                    EmptyView()
+                }
+                if filter.year != nil {
+                    Button {
+                        filter.year = nil
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func loadCachedMetadata() {
+        // Genres from albums (artists inherit album genres) or songs
+        let genreSet: Set<String>
+        if context == .song {
+            let songDescriptor = FetchDescriptor<CachedSong>()
+            let songs = (try? modelContext.fetch(songDescriptor)) ?? []
+            genreSet = Set(songs.compactMap(\.genre)).subtracting([""])
+        } else {
+            let descriptor = FetchDescriptor<CachedAlbum>()
+            let albums = (try? modelContext.fetch(descriptor)) ?? []
+            genreSet = Set(albums.compactMap(\.genre)).subtracting([""])
+
+            if context == .album {
+                let labelSet = Set(albums.compactMap(\.label)).subtracting([""])
+                labels = labelSet.sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
+            }
+        }
+        genres = genreSet.sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
+    }
+}
+
+// MARK: - Reusable String Filter List
+
+struct StringFilterList: View {
+    let items: [String]
+    @Binding var selectedItems: Set<String>
+    var placeholder: String = "Search…"
+    @State private var searchText = ""
+
+    private var filteredItems: [String] {
+        if searchText.isEmpty { return items }
+        return items.filter { $0.localizedCaseInsensitiveContains(searchText) }
+    }
+
+    var body: some View {
+        TextField(placeholder, text: $searchText)
+            .textFieldStyle(.roundedBorder)
+            .font(.caption)
+
+        ScrollView {
+            LazyVStack(spacing: 0) {
+                ForEach(filteredItems, id: \.self) { item in
+                    let isSelected = selectedItems.contains(item)
+                    Button {
+                        if isSelected {
+                            selectedItems.remove(item)
+                        } else {
+                            selectedItems.insert(item)
+                        }
+                    } label: {
+                        HStack {
+                            Text(item)
+                                .font(.caption)
+                                .lineLimit(1)
+                            Spacer()
+                            if isSelected {
+                                Image(systemName: "checkmark")
+                                    .font(.caption)
+                                    .foregroundStyle(Color.accentColor)
+                            }
+                        }
+                        .padding(.vertical, 4)
+                        .padding(.horizontal, 6)
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .background(isSelected ? Color.accentColor.opacity(0.1) : Color.clear)
+                }
+            }
+        }
+        .frame(height: 160)
+        .background(Color(nsColor: .controlBackgroundColor).opacity(0.5))
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+    }
+}
+#endif

--- a/Vibrdrome/Features/Library/LibraryView.swift
+++ b/Vibrdrome/Features/Library/LibraryView.swift
@@ -1,8 +1,10 @@
+import SwiftData
 import SwiftUI
 import NukeUI
 
 struct LibraryView: View {
     @Environment(AppState.self) private var appState
+    @Environment(\.modelContext) private var modelContext
     @Binding var navPath: NavigationPath
     @State private var recentAlbums: [Album] = []
     @State private var frequentAlbums: [Album] = []
@@ -617,18 +619,22 @@ struct LibraryView: View {
     private func fetchSections(client: SubsonicClient, skipCache: Bool = false) async {
         let folder = folderId
 
-        // Show cached data instantly (only for unfiltered/default)
+        // Show local cache data instantly (Recently Added + Starred from SwiftData)
         if folder == nil, !skipCache {
-            if let cached = await client.cachedResponse(
-                for: .getAlbumList2(type: .newest, size: 10, offset: 0), ttl: 300) {
-                recentAlbums = cached.albumList2?.album ?? []
+            if recentAlbums.isEmpty {
+                var desc = FetchDescriptor<CachedAlbum>(sortBy: [SortDescriptor(\CachedAlbum.created, order: .reverse)])
+                desc.fetchLimit = 10
+                if let cached = try? modelContext.fetch(desc), !cached.isEmpty {
+                    recentAlbums = cached.map { $0.toAlbum() }
+                }
             }
-            if let cached = await client.cachedResponse(
-                for: .getAlbumList2(type: .frequent, size: 10, offset: 0), ttl: 900) {
-                frequentAlbums = cached.albumList2?.album ?? []
-            }
-            if let cached = await client.cachedResponse(for: .getStarred2(), ttl: 300) {
-                if var songs = cached.starred2?.song, !songs.isEmpty {
+            if starredSongs.isEmpty {
+                let starredDesc = FetchDescriptor<CachedSong>(
+                    predicate: #Predicate<CachedSong> { $0.isStarred },
+                    sortBy: [SortDescriptor(\CachedSong.title)]
+                )
+                if let fetched = try? modelContext.fetch(starredDesc), !fetched.isEmpty {
+                    var songs = fetched.map { $0.toSong() }
                     songs.shuffle()
                     starredSongs = Array(songs.prefix(15))
                 }

--- a/Vibrdrome/Features/Library/PlayHistoryView.swift
+++ b/Vibrdrome/Features/Library/PlayHistoryView.swift
@@ -4,18 +4,22 @@ import SwiftData
 struct PlayHistoryView: View {
     @Environment(\.modelContext) private var modelContext
     @Query(sort: \PlayHistory.playedAt, order: .reverse) private var allPlays: [PlayHistory]
+    @State private var cachedTodayCount: Int = 0
+    @State private var cachedWeekCount: Int = 0
+    @State private var cachedTopArtists: [(String, Int)] = []
+    @State private var cachedTopAlbums: [(String, String?, Int)] = []
 
     var body: some View {
         List {
-            if !todayPlays.isEmpty {
+            if cachedTodayCount > 0 {
                 statsSection
             }
 
-            if !topArtists.isEmpty {
+            if !cachedTopArtists.isEmpty {
                 topArtistsSection
             }
 
-            if !topAlbums.isEmpty {
+            if !cachedTopAlbums.isEmpty {
                 topAlbumsSection
             }
 
@@ -39,40 +43,35 @@ struct PlayHistoryView: View {
                 }
             }
         }
+        .onChange(of: allPlays) { recomputeStats() }
+        .onAppear { recomputeStats() }
     }
 
     // MARK: - Computed Data
 
-    private var todayPlays: [PlayHistory] {
-        allPlays.filter { Calendar.current.isDateInToday($0.playedAt) }
-    }
-
-    private var weekPlays: [PlayHistory] {
+    private func recomputeStats() {
         let weekAgo = Calendar.current.date(byAdding: .day, value: -7, to: .now) ?? .now
-        return allPlays.filter { $0.playedAt >= weekAgo }
-    }
+        let weekPlays = allPlays.filter { $0.playedAt >= weekAgo }
 
-    private var topArtists: [(String, Int)] {
-        let week = weekPlays
-        var counts: [String: Int] = [:]
-        for play in week {
+        cachedTodayCount = allPlays.filter { Calendar.current.isDateInToday($0.playedAt) }.count
+        cachedWeekCount = weekPlays.count
+
+        var artistCounts: [String: Int] = [:]
+        for play in weekPlays {
             if let artist = play.artistName {
-                counts[artist, default: 0] += 1
+                artistCounts[artist, default: 0] += 1
             }
         }
-        return counts.sorted { $0.value > $1.value }.prefix(5).map { ($0.key, $0.value) }
-    }
+        cachedTopArtists = artistCounts.sorted { $0.value > $1.value }.prefix(5).map { ($0.key, $0.value) }
 
-    private var topAlbums: [(String, String?, Int)] {
-        let week = weekPlays
-        var counts: [String: (artist: String?, count: Int)] = [:]
-        for play in week {
+        var albumCounts: [String: (artist: String?, count: Int)] = [:]
+        for play in weekPlays {
             if let album = play.albumName {
-                let existing = counts[album]
-                counts[album] = (play.artistName, (existing?.count ?? 0) + 1)
+                let existing = albumCounts[album]
+                albumCounts[album] = (play.artistName, (existing?.count ?? 0) + 1)
             }
         }
-        return counts.sorted { $0.value.count > $1.value.count }
+        cachedTopAlbums = albumCounts.sorted { $0.value.count > $1.value.count }
             .prefix(5)
             .map { ($0.key, $0.value.artist, $0.value.count) }
     }
@@ -82,8 +81,8 @@ struct PlayHistoryView: View {
     private var statsSection: some View {
         Section {
             HStack(spacing: 24) {
-                statBadge(value: todayPlays.count, label: "Today")
-                statBadge(value: weekPlays.count, label: "This Week")
+                statBadge(value: cachedTodayCount, label: "Today")
+                statBadge(value: cachedWeekCount, label: "This Week")
                 statBadge(value: allPlays.count, label: "All Time")
             }
             .frame(maxWidth: .infinity)
@@ -106,7 +105,7 @@ struct PlayHistoryView: View {
 
     private var topArtistsSection: some View {
         Section("Top Artists This Week") {
-            ForEach(topArtists, id: \.0) { artist, count in
+            ForEach(cachedTopArtists, id: \.0) { artist, count in
                 HStack {
                     Text(artist)
                         .font(.body)
@@ -121,7 +120,7 @@ struct PlayHistoryView: View {
 
     private var topAlbumsSection: some View {
         Section("Top Albums This Week") {
-            ForEach(topAlbums, id: \.0) { album, artist, count in
+            ForEach(cachedTopAlbums, id: \.0) { album, artist, count in
                 HStack {
                     VStack(alignment: .leading, spacing: 2) {
                         Text(album)

--- a/Vibrdrome/Features/Library/SidebarContentView.swift
+++ b/Vibrdrome/Features/Library/SidebarContentView.swift
@@ -114,29 +114,28 @@ struct SidebarContentView: View {
             .navigationTitle("Vibrdrome")
         } detail: {
             #if os(macOS)
-            HStack(spacing: 0) {
-                NavigationStack(path: $detailPath) {
-                    detailView
-                        .navigationDestination(for: SidebarNavRoute.self) { route in
-                            switch route {
-                            case .album(let id):
-                                AlbumDetailView(albumId: id)
-                            case .artist(let id):
-                                ArtistDetailView(artistId: id)
-                            case .song(let id):
-                                SongDetailView(songId: id)
-                            }
+            NavigationStack(path: $detailPath) {
+                detailView
+                    .navigationDestination(for: SidebarNavRoute.self) { route in
+                        switch route {
+                        case .album(let id):
+                            AlbumDetailView(albumId: id)
+                        case .artist(let id):
+                            ArtistDetailView(artistId: id)
+                        case .song(let id):
+                            SongDetailView(songId: id)
                         }
-                }
-
+                    }
+            }
+            .inspector(isPresented: Binding(
+                get: { appState.activeSidePanel != nil },
+                set: { if !$0 { appState.activeSidePanel = nil } }
+            )) {
                 if let panel = appState.activeSidePanel {
-                    Divider()
                     sidePanelView(for: panel)
-                        .frame(width: sidePanelWidth)
-                        .transition(.move(edge: .trailing).combined(with: .opacity))
                 }
             }
-            .animation(.easeInOut(duration: 0.2), value: appState.activeSidePanel)
+            .inspectorColumnWidth(min: 280, ideal: sidePanelWidth, max: 500)
             #else
             NavigationStack(path: $detailPath) {
                 detailView
@@ -254,6 +253,12 @@ struct SidebarContentView: View {
             LyricsPanelView()
         case .artistInfo:
             ArtistInfoPanelView()
+        case .albumFilters:
+            LibraryFilterSidebarView(context: .album)
+        case .artistFilters:
+            LibraryFilterSidebarView(context: .artist)
+        case .songFilters:
+            LibraryFilterSidebarView(context: .song)
         }
     }
     #endif

--- a/Vibrdrome/Features/Library/SidebarContentView.swift
+++ b/Vibrdrome/Features/Library/SidebarContentView.swift
@@ -114,18 +114,21 @@ struct SidebarContentView: View {
             .navigationTitle("Vibrdrome")
         } detail: {
             #if os(macOS)
-            NavigationStack(path: $detailPath) {
-                detailView
-                    .navigationDestination(for: SidebarNavRoute.self) { route in
-                        switch route {
-                        case .album(let id):
-                            AlbumDetailView(albumId: id)
-                        case .artist(let id):
-                            ArtistDetailView(artistId: id)
-                        case .song(let id):
-                            SongDetailView(songId: id)
+            GeometryReader { geometry in
+                NavigationStack(path: $detailPath) {
+                    detailView
+                        .navigationDestination(for: SidebarNavRoute.self) { route in
+                            switch route {
+                            case .album(let id):
+                                AlbumDetailView(albumId: id)
+                            case .artist(let id):
+                                ArtistDetailView(artistId: id)
+                            case .song(let id):
+                                SongDetailView(songId: id)
+                            }
                         }
-                    }
+                }
+                .environment(\.contentWidth, geometry.size.width)
             }
             .inspector(isPresented: Binding(
                 get: { appState.activeSidePanel != nil },

--- a/Vibrdrome/Features/Library/SidebarContentView.swift
+++ b/Vibrdrome/Features/Library/SidebarContentView.swift
@@ -159,6 +159,22 @@ struct SidebarContentView: View {
             if !detailPath.isEmpty {
                 detailPath = NavigationPath()
             }
+            #if os(macOS)
+            // Auto-switch filter panel when a filter panel is already open
+            if let panel = appState.activeSidePanel,
+               panel == .albumFilters || panel == .artistFilters || panel == .songFilters {
+                switch SidebarItem(rawValue: selectionRaw) {
+                case .albums, .recentlyAdded, .mostPlayed, .recentlyPlayed:
+                    appState.activeSidePanel = .albumFilters
+                case .artists:
+                    appState.activeSidePanel = .artistFilters
+                case .songs:
+                    appState.activeSidePanel = .songFilters
+                default:
+                    appState.activeSidePanel = nil
+                }
+            }
+            #endif
         }
         .onChange(of: appState.pendingNavigation) { _, newValue in
             guard let nav = newValue else { return }

--- a/Vibrdrome/Features/Library/SongsView.swift
+++ b/Vibrdrome/Features/Library/SongsView.swift
@@ -22,6 +22,7 @@ struct SongsView: View {
     @AppStorage(UserDefaultsKeys.showAlbumArtInLists) private var showAlbumArtInLists: Bool = true
     @AppStorage("songsViewStyle") private var showAsList = true
     @State private var sortBy: SongSortOption = .title
+    @State private var cachedDisplayedSongs: [Song] = []
 
     private let pageSize = 500
 
@@ -51,7 +52,7 @@ struct SongsView: View {
         filterYear != nil || filterGenre != nil || filterArtist != nil
     }
 
-    private var displayedSongs: [Song] {
+    private func computeDisplayedSongs() -> [Song] {
         var base: [Song]
         #if os(macOS)
         base = localFilteredSongs ?? (searchText.count >= 2 ? searchResults : songs)
@@ -104,6 +105,7 @@ struct SongsView: View {
         .onChange(of: searchText) { _, query in
             guard query.count >= 2 else {
                 searchResults = []
+                recomputeDisplayedSongs()
                 return
             }
             isSearching = true
@@ -114,6 +116,7 @@ struct SongsView: View {
                     let result = try await appState.subsonicClient.search(
                         query: query, artistCount: 0, albumCount: 0, songCount: 50)
                     searchResults = result.song ?? []
+                    recomputeDisplayedSongs()
                 } catch {}
                 isSearching = false
             }
@@ -248,7 +251,12 @@ struct SongsView: View {
             #if os(macOS)
             applyLocalFilters()
             #endif
+            recomputeDisplayedSongs()
         }
+        .onChange(of: sortBy) { recomputeDisplayedSongs() }
+        .onChange(of: filterYear) { recomputeDisplayedSongs() }
+        .onChange(of: filterGenre) { recomputeDisplayedSongs() }
+        .onChange(of: filterArtist) { recomputeDisplayedSongs() }
         .onChange(of: appState.libraryCache.generation) { _, _ in
             refreshTitleSongCount()
         }
@@ -400,16 +408,16 @@ struct SongsView: View {
                     .listRowInsets(EdgeInsets(top: 4, leading: 16, bottom: 4, trailing: 16))
             }
 
-            if !displayedSongs.isEmpty {
+            if !cachedDisplayedSongs.isEmpty {
                 playShuffleBar
                     .listRowSeparator(.hidden)
             }
 
-            ForEach(Array(displayedSongs.enumerated()), id: \.element.id) { index, song in
+            ForEach(Array(cachedDisplayedSongs.enumerated()), id: \.element.id) { index, song in
                 songRow(song)
                     .contentShape(Rectangle())
                     .onTapGesture {
-                        AudioEngine.shared.play(song: song, from: displayedSongs, at: index)
+                        AudioEngine.shared.play(song: song, from: cachedDisplayedSongs, at: index)
                     }
                     .accessibilityIdentifier("songRow_\(song.id)")
                     .trackContextMenu(song: song)
@@ -427,6 +435,7 @@ struct SongsView: View {
                     Spacer()
                 }
             }
+
         }
     }
 
@@ -440,7 +449,7 @@ struct SongsView: View {
                         .padding(.horizontal, 16)
                 }
 
-                if !displayedSongs.isEmpty {
+                if !cachedDisplayedSongs.isEmpty {
                     playShuffleBar
                         .padding(.horizontal, 16)
                 }
@@ -448,11 +457,11 @@ struct SongsView: View {
                 LazyVGrid(columns: [
                     GridItem(.adaptive(minimum: 160, maximum: 200), spacing: 16)
                 ], spacing: 20) {
-                    ForEach(Array(displayedSongs.enumerated()), id: \.element.id) { index, song in
+                    ForEach(Array(cachedDisplayedSongs.enumerated()), id: \.element.id) { index, song in
                         songCard(song)
                             .contentShape(Rectangle())
                             .onTapGesture {
-                                AudioEngine.shared.play(song: song, from: displayedSongs, at: index)
+                                AudioEngine.shared.play(song: song, from: cachedDisplayedSongs, at: index)
                             }
                             .accessibilityIdentifier("songCard_\(song.id)")
                             .trackContextMenu(song: song)
@@ -468,6 +477,7 @@ struct SongsView: View {
                 if isLoading {
                     ProgressView().padding()
                 }
+
             }
         }
     }
@@ -475,7 +485,7 @@ struct SongsView: View {
     private var playShuffleBar: some View {
         HStack(spacing: 12) {
             Button {
-                let songs = displayedSongs
+                let songs = cachedDisplayedSongs
                 AudioEngine.shared.play(song: songs[0], from: songs, at: 0)
             } label: {
                 Label("Play All", systemImage: "play.fill")
@@ -488,7 +498,7 @@ struct SongsView: View {
             .accessibilityIdentifier("songsPlayAllButton")
 
             Button {
-                let shuffled = displayedSongs.shuffled()
+                let shuffled = cachedDisplayedSongs.shuffled()
                 AudioEngine.shared.play(song: shuffled[0], from: shuffled, at: 0)
             } label: {
                 Label("Shuffle", systemImage: "shuffle")
@@ -559,6 +569,7 @@ struct SongsView: View {
             songs = result.song ?? []
             hasMore = (result.song?.count ?? 0) >= pageSize
             refreshTitleSongCount()
+            recomputeDisplayedSongs()
         } catch {}
     }
 
@@ -575,6 +586,7 @@ struct SongsView: View {
             songs.append(contentsOf: newSongs)
             hasMore = newSongs.count >= pageSize
             refreshTitleSongCount()
+            recomputeDisplayedSongs()
         } catch {}
     }
 
@@ -595,8 +607,12 @@ struct SongsView: View {
 
     private func shouldLoadMore(at index: Int) -> Bool {
         guard localFilteredSongs == nil, searchText.isEmpty, hasMore, !isLoading else { return false }
-        let prefetchThreshold = max(displayedSongs.count - 10, 0)
+        let prefetchThreshold = max(cachedDisplayedSongs.count - 10, 0)
         return index >= prefetchThreshold
+    }
+
+    private func recomputeDisplayedSongs() {
+        cachedDisplayedSongs = computeDisplayedSongs()
     }
 
     #if os(macOS)
@@ -613,6 +629,7 @@ struct SongsView: View {
         let filter = appState.songFilter
         guard filter.isActive else {
             localFilteredSongs = nil
+            recomputeDisplayedSongs()
             return
         }
 
@@ -628,6 +645,7 @@ struct SongsView: View {
 
             let recentSongIds = recentlyPlayedSongIds(for: filter)
             localFilteredSongs = allSongs.filter { songMatchesFilter($0, filter: filter, recentIds: recentSongIds) }
+            recomputeDisplayedSongs()
         } catch {
             Logger(subsystem: "com.vibrdrome.app", category: "Songs")
                 .error("Failed to apply local filters: \(error)")

--- a/Vibrdrome/Features/Library/SongsView.swift
+++ b/Vibrdrome/Features/Library/SongsView.swift
@@ -595,44 +595,29 @@ struct SongsView: View {
         }
     }
 
-    // swiftlint:disable:next cyclomatic_complexity
     private func songMatchesFilter(
         _ song: CachedSong, filter: LibraryFilter, recentCutoff: Date?
     ) -> Bool {
-        switch filter.isFavorited {
-        case .yes: if !song.isStarred { return false }
-        case .no: if song.isStarred { return false }
-        case .none: break
-        }
-
-        switch filter.isRated {
-        case .yes: if song.rating == 0 { return false }
-        case .no: if song.rating != 0 { return false }
-        case .none: break
-        }
-
+        guard filter.isFavorited.matches(song.isStarred) else { return false }
+        guard filter.isRated.matches(song.rating != 0) else { return false }
         if let cutoff = recentCutoff {
             guard let lastPlayed = song.lastPlayed, lastPlayed > cutoff else {
                 return false
             }
         }
-
         if !filter.selectedArtistIds.isEmpty {
             guard let artistId = song.artistId, filter.selectedArtistIds.contains(artistId) else {
                 return false
             }
         }
-
         if !filter.selectedGenres.isEmpty {
             guard let genre = song.genre, filter.selectedGenres.contains(genre) else {
                 return false
             }
         }
-
         if let yearFilter = filter.year {
             guard song.year == yearFilter else { return false }
         }
-
         return true
     }
     #endif

--- a/Vibrdrome/Features/Library/SongsView.swift
+++ b/Vibrdrome/Features/Library/SongsView.swift
@@ -8,6 +8,7 @@ struct SongsView: View {
     @Environment(\.modelContext) private var modelContext
     @State private var songs: [Song] = []
     @State private var localFilteredSongs: [Song]?
+    @State private var filterTask: Task<Void, Never>?
     @State private var isLoading = true
     @State private var hasMore = false
     @State private var searchText = ""
@@ -247,12 +248,12 @@ struct SongsView: View {
             #endif
         }
         #if os(macOS)
-        .onChange(of: appState.songFilter.isFavorited) { applyLocalFilters() }
-        .onChange(of: appState.songFilter.isRated) { applyLocalFilters() }
-        .onChange(of: appState.songFilter.isRecentlyPlayed) { applyLocalFilters() }
-        .onChange(of: appState.songFilter.selectedArtistIds) { applyLocalFilters() }
-        .onChange(of: appState.songFilter.selectedGenres) { applyLocalFilters() }
-        .onChange(of: appState.songFilter.year) { applyLocalFilters() }
+        .onChange(of: appState.songFilter.isFavorited) { debouncedApplyLocalFilters() }
+        .onChange(of: appState.songFilter.isRated) { debouncedApplyLocalFilters() }
+        .onChange(of: appState.songFilter.isRecentlyPlayed) { debouncedApplyLocalFilters() }
+        .onChange(of: appState.songFilter.selectedArtistIds) { debouncedApplyLocalFilters() }
+        .onChange(of: appState.songFilter.selectedGenres) { debouncedApplyLocalFilters() }
+        .onChange(of: appState.songFilter.year) { debouncedApplyLocalFilters() }
         #endif
     }
 
@@ -408,7 +409,7 @@ struct SongsView: View {
                     .accessibilityIdentifier("songRow_\(song.id)")
                     .trackContextMenu(song: song)
                     .onAppear {
-                        if localFilteredSongs == nil && searchText.isEmpty && hasMore && !isLoading && song.id == songs.last?.id {
+                        if shouldLoadMore(at: index) {
                             Task { await loadMore() }
                         }
                     }
@@ -451,7 +452,7 @@ struct SongsView: View {
                             .accessibilityIdentifier("songCard_\(song.id)")
                             .trackContextMenu(song: song)
                             .onAppear {
-                                if localFilteredSongs == nil && searchText.isEmpty && hasMore && !isLoading && song.id == songs.last?.id {
+                                if shouldLoadMore(at: index) {
                                     Task { await loadMore() }
                                 }
                             }
@@ -570,7 +571,22 @@ struct SongsView: View {
         } catch {}
     }
 
+    private func shouldLoadMore(at index: Int) -> Bool {
+        guard localFilteredSongs == nil, searchText.isEmpty, hasMore, !isLoading else { return false }
+        let prefetchThreshold = max(displayedSongs.count - 10, 0)
+        return index >= prefetchThreshold
+    }
+
     #if os(macOS)
+    private func debouncedApplyLocalFilters() {
+        filterTask?.cancel()
+        filterTask = Task {
+            try? await Task.sleep(for: .milliseconds(150))
+            guard !Task.isCancelled else { return }
+            applyLocalFilters()
+        }
+    }
+
     private func applyLocalFilters() {
         let filter = appState.songFilter
         guard filter.isActive else {
@@ -579,17 +595,17 @@ struct SongsView: View {
         }
 
         do {
-            var descriptor = FetchDescriptor<CachedSong>()
-            descriptor.sortBy = [SortDescriptor(\.title)]
-            let allSongs = try modelContext.fetch(descriptor)
+            let allSongs: [Song]
+            if let cachedSongs = appState.libraryCache.songs {
+                allSongs = cachedSongs
+            } else {
+                var descriptor = FetchDescriptor<CachedSong>()
+                descriptor.sortBy = [SortDescriptor(\.title)]
+                allSongs = try modelContext.fetch(descriptor).map { $0.toSong() }
+            }
 
-            let recentCutoff: Date? = filter.isRecentlyPlayed
-                ? Calendar.current.date(byAdding: .day, value: -30, to: Date())
-                : nil
-
-            let filtered = allSongs.filter { songMatchesFilter($0, filter: filter, recentCutoff: recentCutoff) }
-
-            localFilteredSongs = filtered.map { $0.toSong() }
+            let recentSongIds = recentlyPlayedSongIds(for: filter)
+            localFilteredSongs = allSongs.filter { songMatchesFilter($0, filter: filter, recentIds: recentSongIds) }
         } catch {
             Logger(subsystem: "com.vibrdrome.app", category: "Songs")
                 .error("Failed to apply local filters: \(error)")
@@ -597,16 +613,22 @@ struct SongsView: View {
         }
     }
 
+    private func recentlyPlayedSongIds(for filter: LibraryFilter) -> Set<String>? {
+        guard filter.isRecentlyPlayed else { return nil }
+        let cutoff = Calendar.current.date(byAdding: .day, value: -30, to: Date()) ?? Date()
+        let descriptor = FetchDescriptor<CachedSong>(
+            predicate: #Predicate { $0.lastPlayed != nil && $0.lastPlayed! > cutoff }
+        )
+        let recentSongs = (try? modelContext.fetch(descriptor)) ?? []
+        return Set(recentSongs.map(\.id))
+    }
+
     private func songMatchesFilter(
-        _ song: CachedSong, filter: LibraryFilter, recentCutoff: Date?
+        _ song: Song, filter: LibraryFilter, recentIds: Set<String>?
     ) -> Bool {
-        guard filter.isFavorited.matches(song.isStarred) else { return false }
-        guard filter.isRated.matches(song.rating != 0) else { return false }
-        if let cutoff = recentCutoff {
-            guard let lastPlayed = song.lastPlayed, lastPlayed > cutoff else {
-                return false
-            }
-        }
+        guard filter.isFavorited.matches(song.starred != nil) else { return false }
+        guard filter.isRated.matches((song.userRating ?? 0) != 0) else { return false }
+        if let recentIds, !recentIds.contains(song.id) { return false }
         if !filter.selectedArtistIds.isEmpty {
             guard let artistId = song.artistId, filter.selectedArtistIds.contains(artistId) else {
                 return false

--- a/Vibrdrome/Features/Library/SongsView.swift
+++ b/Vibrdrome/Features/Library/SongsView.swift
@@ -7,6 +7,7 @@ struct SongsView: View {
     @Environment(AppState.self) private var appState
     @Environment(\.modelContext) private var modelContext
     @State private var songs: [Song] = []
+    @State private var titleSongCount: Int?
     @State private var localFilteredSongs: [Song]?
     @State private var filterTask: Task<Void, Never>?
     @State private var isLoading = true
@@ -91,7 +92,7 @@ struct SongsView: View {
                 songGrid
             }
         }
-        .navigationTitle(songs.isEmpty ? "Songs" : "Songs (\(songs.count))")
+        .navigationTitle(titleSongCount.map { "Songs (\($0))" } ?? "Songs")
         #if os(iOS)
         .navigationBarTitleDisplayMode(.inline)
         #endif
@@ -243,9 +244,13 @@ struct SongsView: View {
         .task {
             await loadSongs()
             await loadGenres()
+            refreshTitleSongCount()
             #if os(macOS)
             applyLocalFilters()
             #endif
+        }
+        .onChange(of: appState.libraryCache.generation) { _, _ in
+            refreshTitleSongCount()
         }
         #if os(macOS)
         .onChange(of: appState.songFilter.isFavorited) { debouncedApplyLocalFilters() }
@@ -553,6 +558,7 @@ struct SongsView: View {
             )
             songs = result.song ?? []
             hasMore = (result.song?.count ?? 0) >= pageSize
+            refreshTitleSongCount()
         } catch {}
     }
 
@@ -568,7 +574,23 @@ struct SongsView: View {
             let newSongs = result.song ?? []
             songs.append(contentsOf: newSongs)
             hasMore = newSongs.count >= pageSize
+            refreshTitleSongCount()
         } catch {}
+    }
+
+    private func refreshTitleSongCount() {
+        if let cachedSongs = appState.libraryCache.songs, !cachedSongs.isEmpty {
+            titleSongCount = cachedSongs.count
+            return
+        }
+
+        let descriptor = FetchDescriptor<CachedSong>()
+        if let cachedCount = try? modelContext.fetchCount(descriptor), cachedCount > 0 {
+            titleSongCount = cachedCount
+            return
+        }
+
+        titleSongCount = songs.isEmpty ? nil : songs.count
     }
 
     private func shouldLoadMore(at index: Int) -> Bool {

--- a/Vibrdrome/Features/Library/SongsView.swift
+++ b/Vibrdrome/Features/Library/SongsView.swift
@@ -23,6 +23,8 @@ struct SongsView: View {
     @AppStorage("songsViewStyle") private var showAsList = true
     @State private var sortBy: SongSortOption = .title
     @State private var cachedDisplayedSongs: [Song] = []
+    @State private var scrollLoadTask: Task<Void, Never>?
+    @State private var pendingPageTarget: Int = 0
 
     private let pageSize = 500
 
@@ -423,9 +425,17 @@ struct SongsView: View {
                     .trackContextMenu(song: song)
                     .onAppear {
                         if shouldLoadMore(at: index) {
-                            Task { await loadMore() }
+                            pendingPageTarget = max(pendingPageTarget, songs.count + pageSize)
+                            Task { await loadPages() }
                         }
                     }
+            }
+
+            if remainingPlaceholderCount > 0 {
+                ForEach(0..<remainingPlaceholderCount, id: \.self) { placeholderIndex in
+                    songListPlaceholder
+                        .onAppear { scheduleScrollLoad(placeholderIndex: placeholderIndex) }
+                }
             }
 
             if isLoading {
@@ -467,9 +477,17 @@ struct SongsView: View {
                             .trackContextMenu(song: song)
                             .onAppear {
                                 if shouldLoadMore(at: index) {
-                                    Task { await loadMore() }
+                                    pendingPageTarget = max(pendingPageTarget, songs.count + pageSize)
+                                    Task { await loadPages() }
                                 }
                             }
+                    }
+
+                    if remainingPlaceholderCount > 0 {
+                        ForEach(0..<remainingPlaceholderCount, id: \.self) { placeholderIndex in
+                            songGridPlaceholder
+                                .onAppear { scheduleScrollLoad(placeholderIndex: placeholderIndex) }
+                        }
                     }
                 }
                 .padding(16)
@@ -559,6 +577,8 @@ struct SongsView: View {
     }
 
     private func loadSongs() async {
+        scrollLoadTask?.cancel()
+        pendingPageTarget = 0
         isLoading = true
         songs = []
         defer { isLoading = false }
@@ -573,21 +593,43 @@ struct SongsView: View {
         } catch {}
     }
 
-    private func loadMore() async {
+    private func loadPages() async {
         guard hasMore, !isLoading else { return }
         isLoading = true
-        defer { isLoading = false }
-        do {
-            let result = try await appState.subsonicClient.search(
-                query: "", artistCount: 0, albumCount: 0,
-                songCount: pageSize, songOffset: songs.count
-            )
-            let newSongs = result.song ?? []
-            songs.append(contentsOf: newSongs)
-            hasMore = newSongs.count >= pageSize
-            refreshTitleSongCount()
-            recomputeDisplayedSongs()
-        } catch {}
+        defer {
+            isLoading = false
+            if songs.count < pendingPageTarget, hasMore {
+                scrollLoadTask?.cancel()
+                scrollLoadTask = Task { await loadPages() }
+            }
+        }
+        while songs.count < pendingPageTarget, hasMore, !Task.isCancelled {
+            do {
+                let result = try await appState.subsonicClient.search(
+                    query: "", artistCount: 0, albumCount: 0,
+                    songCount: pageSize, songOffset: songs.count
+                )
+                let newSongs = result.song ?? []
+                songs.append(contentsOf: newSongs)
+                hasMore = newSongs.count >= pageSize
+            } catch {
+                hasMore = false
+                break
+            }
+        }
+        refreshTitleSongCount()
+        recomputeDisplayedSongs()
+    }
+
+    private func scheduleScrollLoad(placeholderIndex: Int) {
+        guard hasMore else { return }
+        pendingPageTarget = max(pendingPageTarget, songs.count + placeholderIndex + pageSize)
+        scrollLoadTask?.cancel()
+        scrollLoadTask = Task {
+            try? await Task.sleep(for: .milliseconds(150))
+            guard !Task.isCancelled else { return }
+            await loadPages()
+        }
     }
 
     private func refreshTitleSongCount() {
@@ -603,6 +645,43 @@ struct SongsView: View {
         }
 
         titleSongCount = songs.isEmpty ? nil : songs.count
+    }
+
+    private var songListPlaceholder: some View {
+        HStack(spacing: 12) {
+            RoundedRectangle(cornerRadius: 4)
+                .fill(.quaternary)
+                .frame(width: 40, height: 40)
+            VStack(alignment: .leading, spacing: 4) {
+                RoundedRectangle(cornerRadius: 3)
+                    .fill(.quaternary)
+                    .frame(width: 140, height: 14)
+                RoundedRectangle(cornerRadius: 3)
+                    .fill(.quaternary)
+                    .frame(width: 100, height: 12)
+            }
+            Spacer()
+        }
+    }
+
+    private var songGridPlaceholder: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            RoundedRectangle(cornerRadius: 10)
+                .fill(.quaternary)
+                .aspectRatio(1, contentMode: .fit)
+            RoundedRectangle(cornerRadius: 3)
+                .fill(.quaternary)
+                .frame(height: 14)
+            RoundedRectangle(cornerRadius: 3)
+                .fill(.quaternary)
+                .frame(width: 80, height: 12)
+        }
+    }
+
+    private var remainingPlaceholderCount: Int {
+        guard hasMore, localFilteredSongs == nil, searchText.isEmpty else { return 0 }
+        guard let totalCount = appState.libraryCache.songs?.count else { return 0 }
+        return max(0, totalCount - songs.count)
     }
 
     private func shouldLoadMore(at index: Int) -> Bool {

--- a/Vibrdrome/Features/Library/SongsView.swift
+++ b/Vibrdrome/Features/Library/SongsView.swift
@@ -581,54 +581,11 @@ struct SongsView: View {
             descriptor.sortBy = [SortDescriptor(\.title)]
             let allSongs = try modelContext.fetch(descriptor)
 
-            // Pre-compute recently played cutoff if needed
             let recentCutoff: Date? = filter.isRecentlyPlayed
                 ? Calendar.current.date(byAdding: .day, value: -30, to: Date())
                 : nil
 
-            let filtered = allSongs.filter { song in
-                // Favorited filter
-                switch filter.isFavorited {
-                case .yes: if !song.isStarred { return false }
-                case .no: if song.isStarred { return false }
-                case .none: break
-                }
-
-                // Rated filter
-                switch filter.isRated {
-                case .yes: if song.rating == 0 { return false }
-                case .no: if song.rating != 0 { return false }
-                case .none: break
-                }
-
-                // Recently played filter
-                if let cutoff = recentCutoff {
-                    guard let lastPlayed = song.lastPlayed, lastPlayed > cutoff else {
-                        return false
-                    }
-                }
-
-                // Artist filter
-                if !filter.selectedArtistIds.isEmpty {
-                    guard let artistId = song.artistId, filter.selectedArtistIds.contains(artistId) else {
-                        return false
-                    }
-                }
-
-                // Genre filter
-                if !filter.selectedGenres.isEmpty {
-                    guard let genre = song.genre, filter.selectedGenres.contains(genre) else {
-                        return false
-                    }
-                }
-
-                // Year filter
-                if let yearFilter = filter.year {
-                    guard song.year == yearFilter else { return false }
-                }
-
-                return true
-            }
+            let filtered = allSongs.filter { songMatchesFilter($0, filter: filter, recentCutoff: recentCutoff) }
 
             localFilteredSongs = filtered.map { $0.toSong() }
         } catch {
@@ -636,6 +593,47 @@ struct SongsView: View {
                 .error("Failed to apply local filters: \(error)")
             localFilteredSongs = nil
         }
+    }
+
+    // swiftlint:disable:next cyclomatic_complexity
+    private func songMatchesFilter(
+        _ song: CachedSong, filter: LibraryFilter, recentCutoff: Date?
+    ) -> Bool {
+        switch filter.isFavorited {
+        case .yes: if !song.isStarred { return false }
+        case .no: if song.isStarred { return false }
+        case .none: break
+        }
+
+        switch filter.isRated {
+        case .yes: if song.rating == 0 { return false }
+        case .no: if song.rating != 0 { return false }
+        case .none: break
+        }
+
+        if let cutoff = recentCutoff {
+            guard let lastPlayed = song.lastPlayed, lastPlayed > cutoff else {
+                return false
+            }
+        }
+
+        if !filter.selectedArtistIds.isEmpty {
+            guard let artistId = song.artistId, filter.selectedArtistIds.contains(artistId) else {
+                return false
+            }
+        }
+
+        if !filter.selectedGenres.isEmpty {
+            guard let genre = song.genre, filter.selectedGenres.contains(genre) else {
+                return false
+            }
+        }
+
+        if let yearFilter = filter.year {
+            guard song.year == yearFilter else { return false }
+        }
+
+        return true
     }
     #endif
 }

--- a/Vibrdrome/Features/Library/SongsView.swift
+++ b/Vibrdrome/Features/Library/SongsView.swift
@@ -1,9 +1,13 @@
 import NukeUI
 import SwiftUI
+import SwiftData
+import os.log
 
 struct SongsView: View {
     @Environment(AppState.self) private var appState
+    @Environment(\.modelContext) private var modelContext
     @State private var songs: [Song] = []
+    @State private var localFilteredSongs: [Song]?
     @State private var isLoading = true
     @State private var hasMore = false
     @State private var searchText = ""
@@ -47,7 +51,12 @@ struct SongsView: View {
     }
 
     private var displayedSongs: [Song] {
-        var base = searchText.count >= 2 ? searchResults : songs
+        var base: [Song]
+        #if os(macOS)
+        base = localFilteredSongs ?? (searchText.count >= 2 ? searchResults : songs)
+        #else
+        base = searchText.count >= 2 ? searchResults : songs
+        #endif
         if let filterYear {
             base = base.filter { $0.year == filterYear }
         }
@@ -109,6 +118,23 @@ struct SongsView: View {
             }
         }
         .toolbar {
+            #if os(macOS)
+            ToolbarItem(placement: .automatic) {
+                Button {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        if appState.activeSidePanel == .songFilters {
+                            appState.activeSidePanel = nil
+                        } else {
+                            appState.activeSidePanel = .songFilters
+                        }
+                    }
+                } label: {
+                    Image(systemName: appState.songFilter.isActive ? "line.3.horizontal.decrease.circle.fill" : "line.3.horizontal.decrease.circle")
+                }
+                .accessibilityLabel("Song Filters")
+                .accessibilityIdentifier("songFilterToggle")
+            }
+            #endif
             ToolbarItem(placement: .automatic) {
                 Button {
                     withAnimation(.easeInOut(duration: 0.2)) {
@@ -217,7 +243,18 @@ struct SongsView: View {
         .task {
             await loadSongs()
             await loadGenres()
+            #if os(macOS)
+            applyLocalFilters()
+            #endif
         }
+        #if os(macOS)
+        .onChange(of: appState.songFilter.isFavorited) { applyLocalFilters() }
+        .onChange(of: appState.songFilter.isRated) { applyLocalFilters() }
+        .onChange(of: appState.songFilter.isRecentlyPlayed) { applyLocalFilters() }
+        .onChange(of: appState.songFilter.selectedArtistIds) { applyLocalFilters() }
+        .onChange(of: appState.songFilter.selectedGenres) { applyLocalFilters() }
+        .onChange(of: appState.songFilter.year) { applyLocalFilters() }
+        #endif
     }
 
     // MARK: - Active Filter Chips
@@ -372,7 +409,7 @@ struct SongsView: View {
                     .accessibilityIdentifier("songRow_\(song.id)")
                     .trackContextMenu(song: song)
                     .onAppear {
-                        if searchText.isEmpty && hasMore && !isLoading && song.id == songs.last?.id {
+                        if localFilteredSongs == nil && searchText.isEmpty && hasMore && !isLoading && song.id == songs.last?.id {
                             Task { await loadMore() }
                         }
                     }
@@ -414,7 +451,7 @@ struct SongsView: View {
                             .accessibilityIdentifier("songCard_\(song.id)")
                             .trackContextMenu(song: song)
                             .onAppear {
-                                if searchText.isEmpty && hasMore && !isLoading && song.id == songs.last?.id {
+                                if localFilteredSongs == nil && searchText.isEmpty && hasMore && !isLoading && song.id == songs.last?.id {
                                     Task { await loadMore() }
                                 }
                             }
@@ -530,4 +567,75 @@ struct SongsView: View {
             hasMore = newSongs.count >= pageSize
         } catch {}
     }
+
+    #if os(macOS)
+    private func applyLocalFilters() {
+        let filter = appState.songFilter
+        guard filter.isActive else {
+            localFilteredSongs = nil
+            return
+        }
+
+        do {
+            var descriptor = FetchDescriptor<CachedSong>()
+            descriptor.sortBy = [SortDescriptor(\.title)]
+            let allSongs = try modelContext.fetch(descriptor)
+
+            // Pre-compute recently played cutoff if needed
+            let recentCutoff: Date? = filter.isRecentlyPlayed
+                ? Calendar.current.date(byAdding: .day, value: -30, to: Date())
+                : nil
+
+            let filtered = allSongs.filter { song in
+                // Favorited filter
+                switch filter.isFavorited {
+                case .yes: if !song.isStarred { return false }
+                case .no: if song.isStarred { return false }
+                case .none: break
+                }
+
+                // Rated filter
+                switch filter.isRated {
+                case .yes: if song.rating == 0 { return false }
+                case .no: if song.rating != 0 { return false }
+                case .none: break
+                }
+
+                // Recently played filter
+                if let cutoff = recentCutoff {
+                    guard let lastPlayed = song.lastPlayed, lastPlayed > cutoff else {
+                        return false
+                    }
+                }
+
+                // Artist filter
+                if !filter.selectedArtistIds.isEmpty {
+                    guard let artistId = song.artistId, filter.selectedArtistIds.contains(artistId) else {
+                        return false
+                    }
+                }
+
+                // Genre filter
+                if !filter.selectedGenres.isEmpty {
+                    guard let genre = song.genre, filter.selectedGenres.contains(genre) else {
+                        return false
+                    }
+                }
+
+                // Year filter
+                if let yearFilter = filter.year {
+                    guard song.year == yearFilter else { return false }
+                }
+
+                return true
+            }
+
+            localFilteredSongs = filtered.map { $0.toSong() }
+        } catch {
+            Logger(subsystem: "com.vibrdrome.app", category: "Songs")
+                .error("Failed to apply local filters: \(error)")
+            localFilteredSongs = nil
+        }
+    }
+    #endif
 }

--- a/Vibrdrome/Features/Library/SongsView.swift
+++ b/Vibrdrome/Features/Library/SongsView.swift
@@ -19,7 +19,6 @@ struct SongsView: View {
     @State private var filterArtist: String?
     @AppStorage(UserDefaultsKeys.showAlbumArtInLists) private var showAlbumArtInLists: Bool = true
     @AppStorage("songsViewStyle") private var showAsList = true
-    @AppStorage(UserDefaultsKeys.gridColumnsPerRow) private var gridColumns = 2
     @State private var sortBy: SongSortOption = .title
 
     private let pageSize = 500
@@ -440,8 +439,9 @@ struct SongsView: View {
                         .padding(.horizontal, 16)
                 }
 
-                LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 16),
-                                         count: max(2, min(4, gridColumns))), spacing: 20) {
+                LazyVGrid(columns: [
+                    GridItem(.adaptive(minimum: 160, maximum: 200), spacing: 16)
+                ], spacing: 20) {
                     ForEach(Array(displayedSongs.enumerated()), id: \.element.id) { index, song in
                         songCard(song)
                             .contentShape(Rectangle())
@@ -498,9 +498,11 @@ struct SongsView: View {
 
     private func songCard(_ song: Song) -> some View {
         VStack(alignment: .leading, spacing: 6) {
-            AlbumArtView(coverArtId: song.coverArt, size: 160, cornerRadius: 10)
-                .frame(maxWidth: .infinity)
-                .shadow(color: .black.opacity(0.15), radius: 6, y: 3)
+            GeometryReader { geo in
+                AlbumArtView(coverArtId: song.coverArt, size: geo.size.width, cornerRadius: 10)
+            }
+            .aspectRatio(1, contentMode: .fit)
+            .shadow(color: .black.opacity(0.15), radius: 6, y: 3)
 
             Button {
                 appState.pendingNavigation = .song(id: song.id)

--- a/Vibrdrome/Features/Library/SongsView.swift
+++ b/Vibrdrome/Features/Library/SongsView.swift
@@ -415,37 +415,23 @@ struct SongsView: View {
                     .listRowSeparator(.hidden)
             }
 
-            ForEach(Array(cachedDisplayedSongs.enumerated()), id: \.element.id) { index, song in
-                songRow(song)
-                    .contentShape(Rectangle())
-                    .onTapGesture {
-                        AudioEngine.shared.play(song: song, from: cachedDisplayedSongs, at: index)
+            ForEach(0..<totalItemCount, id: \.self) { index in
+                Group {
+                    if index < cachedDisplayedSongs.count {
+                        let song = cachedDisplayedSongs[index]
+                        songRow(song)
+                            .contentShape(Rectangle())
+                            .onTapGesture {
+                                AudioEngine.shared.play(song: song, from: cachedDisplayedSongs, at: index)
+                            }
+                            .accessibilityIdentifier("songRow_\(song.id)")
+                            .trackContextMenu(song: song)
+                    } else {
+                        songListPlaceholder
                     }
-                    .accessibilityIdentifier("songRow_\(song.id)")
-                    .trackContextMenu(song: song)
-                    .onAppear {
-                        if shouldLoadMore(at: index) {
-                            pendingPageTarget = max(pendingPageTarget, songs.count + pageSize)
-                            Task { await loadPages() }
-                        }
-                    }
-            }
-
-            if remainingPlaceholderCount > 0 {
-                ForEach(0..<remainingPlaceholderCount, id: \.self) { placeholderIndex in
-                    songListPlaceholder
-                        .onAppear { scheduleScrollLoad(placeholderIndex: placeholderIndex) }
                 }
+                .onAppear { triggerLoadIfNeeded(at: index) }
             }
-
-            if isLoading {
-                HStack {
-                    Spacer()
-                    ProgressView()
-                    Spacer()
-                }
-            }
-
         }
     }
 
@@ -467,35 +453,25 @@ struct SongsView: View {
                 LazyVGrid(columns: [
                     GridItem(.adaptive(minimum: 160, maximum: 200), spacing: 16)
                 ], spacing: 20) {
-                    ForEach(Array(cachedDisplayedSongs.enumerated()), id: \.element.id) { index, song in
-                        songCard(song)
-                            .contentShape(Rectangle())
-                            .onTapGesture {
-                                AudioEngine.shared.play(song: song, from: cachedDisplayedSongs, at: index)
+                    ForEach(0..<totalItemCount, id: \.self) { index in
+                        Group {
+                            if index < cachedDisplayedSongs.count {
+                                let song = cachedDisplayedSongs[index]
+                                songCard(song)
+                                    .contentShape(Rectangle())
+                                    .onTapGesture {
+                                        AudioEngine.shared.play(song: song, from: cachedDisplayedSongs, at: index)
+                                    }
+                                    .accessibilityIdentifier("songCard_\(song.id)")
+                                    .trackContextMenu(song: song)
+                            } else {
+                                songGridPlaceholder
                             }
-                            .accessibilityIdentifier("songCard_\(song.id)")
-                            .trackContextMenu(song: song)
-                            .onAppear {
-                                if shouldLoadMore(at: index) {
-                                    pendingPageTarget = max(pendingPageTarget, songs.count + pageSize)
-                                    Task { await loadPages() }
-                                }
-                            }
-                    }
-
-                    if remainingPlaceholderCount > 0 {
-                        ForEach(0..<remainingPlaceholderCount, id: \.self) { placeholderIndex in
-                            songGridPlaceholder
-                                .onAppear { scheduleScrollLoad(placeholderIndex: placeholderIndex) }
                         }
+                        .onAppear { triggerLoadIfNeeded(at: index) }
                     }
                 }
                 .padding(16)
-
-                if isLoading {
-                    ProgressView().padding()
-                }
-
             }
         }
     }
@@ -596,39 +572,32 @@ struct SongsView: View {
     private func loadPages() async {
         guard hasMore, !isLoading else { return }
         isLoading = true
-        defer {
-            isLoading = false
-            if songs.count < pendingPageTarget, hasMore {
-                scrollLoadTask?.cancel()
-                scrollLoadTask = Task { await loadPages() }
-            }
-        }
-        while songs.count < pendingPageTarget, hasMore, !Task.isCancelled {
+        // Accumulate into local array to avoid multiple @State updates triggering re-renders
+        var accumulated = songs
+        var stillHasMore = hasMore
+        while accumulated.count < pendingPageTarget, stillHasMore, !Task.isCancelled {
             do {
                 let result = try await appState.subsonicClient.search(
                     query: "", artistCount: 0, albumCount: 0,
-                    songCount: pageSize, songOffset: songs.count
+                    songCount: pageSize, songOffset: accumulated.count
                 )
                 let newSongs = result.song ?? []
-                songs.append(contentsOf: newSongs)
-                hasMore = newSongs.count >= pageSize
+                accumulated.append(contentsOf: newSongs)
+                stillHasMore = newSongs.count >= pageSize
             } catch {
-                hasMore = false
+                stillHasMore = false
                 break
             }
         }
-        refreshTitleSongCount()
+        // Single state update instead of one per page
+        songs = accumulated
+        hasMore = stillHasMore
+        isLoading = false
         recomputeDisplayedSongs()
-    }
-
-    private func scheduleScrollLoad(placeholderIndex: Int) {
-        guard hasMore else { return }
-        pendingPageTarget = max(pendingPageTarget, songs.count + placeholderIndex + pageSize)
-        scrollLoadTask?.cancel()
-        scrollLoadTask = Task {
-            try? await Task.sleep(for: .milliseconds(150))
-            guard !Task.isCancelled else { return }
-            await loadPages()
+        refreshTitleSongCount()
+        if songs.count < pendingPageTarget, hasMore {
+            scrollLoadTask?.cancel()
+            scrollLoadTask = Task { await loadPages() }
         }
     }
 
@@ -678,16 +647,31 @@ struct SongsView: View {
         }
     }
 
-    private var remainingPlaceholderCount: Int {
-        guard hasMore, localFilteredSongs == nil, searchText.isEmpty else { return 0 }
-        guard let totalCount = appState.libraryCache.songs?.count else { return 0 }
-        return max(0, totalCount - songs.count)
+    private var totalItemCount: Int {
+        guard localFilteredSongs == nil, searchText.isEmpty else { return cachedDisplayedSongs.count }
+        guard hasMore, let totalCount = appState.libraryCache.songs?.count else { return cachedDisplayedSongs.count }
+        return max(songs.count, totalCount)
     }
 
-    private func shouldLoadMore(at index: Int) -> Bool {
-        guard localFilteredSongs == nil, searchText.isEmpty, hasMore, !isLoading else { return false }
-        let prefetchThreshold = max(cachedDisplayedSongs.count - 10, 0)
-        return index >= prefetchThreshold
+    private func triggerLoadIfNeeded(at index: Int) {
+        guard localFilteredSongs == nil, searchText.isEmpty, hasMore else { return }
+        if index >= songs.count {
+            // Scrolled into placeholder territory — always update target, debounce the load
+            pendingPageTarget = max(pendingPageTarget, songs.count + (index - songs.count) + pageSize)
+            scrollLoadTask?.cancel()
+            scrollLoadTask = Task {
+                try? await Task.sleep(for: .milliseconds(150))
+                guard !Task.isCancelled else { return }
+                await loadPages()
+            }
+        } else if !isLoading {
+            // Near end of loaded items — prefetch immediately
+            let prefetchThreshold = max(songs.count - 10, 0)
+            if index >= prefetchThreshold {
+                pendingPageTarget = max(pendingPageTarget, songs.count + pageSize)
+                Task { await loadPages() }
+            }
+        }
     }
 
     private func recomputeDisplayedSongs() {

--- a/Vibrdrome/Features/Playlists/PlaylistDetailView.swift
+++ b/Vibrdrome/Features/Playlists/PlaylistDetailView.swift
@@ -5,6 +5,7 @@ struct PlaylistDetailView: View {
     let playlistId: String
 
     @Environment(AppState.self) private var appState
+    @Environment(\.modelContext) private var modelContext
     @State private var playlist: Playlist?
     @State private var isLoading = true
     @State private var error: String?
@@ -303,14 +304,53 @@ struct PlaylistDetailView: View {
     }
 
     private func loadPlaylist() async {
-        isLoading = true
+        // Show cached playlist data instantly while fetching fresh
+        if playlist == nil {
+            playlist = loadCachedPlaylist()
+        }
+        isLoading = playlist == nil
         error = nil
         defer { isLoading = false }
         do {
             playlist = try await appState.subsonicClient.getPlaylist(id: playlistId)
         } catch {
-            self.error = ErrorPresenter.userMessage(for: error)
+            if playlist == nil {
+                self.error = ErrorPresenter.userMessage(for: error)
+            }
         }
+    }
+
+    private func loadCachedPlaylist() -> Playlist? {
+        let pid = playlistId
+        var descriptor = FetchDescriptor<CachedPlaylist>(
+            predicate: #Predicate { $0.id == pid }
+        )
+        descriptor.fetchLimit = 1
+        guard let cached = try? modelContext.fetch(descriptor).first else { return nil }
+
+        // Resolve entries to songs via CachedSong
+        let sortedEntries = cached.entries.sorted { $0.order < $1.order }
+        let songs: [Song] = sortedEntries.compactMap { entry in
+            let sid = entry.songId
+            var songDesc = FetchDescriptor<CachedSong>(
+                predicate: #Predicate { $0.id == sid }
+            )
+            songDesc.fetchLimit = 1
+            return try? modelContext.fetch(songDesc).first?.toSong()
+        }
+
+        return Playlist(
+            id: cached.id,
+            name: cached.name,
+            songCount: cached.songCount,
+            duration: cached.duration,
+            created: nil,
+            changed: nil,
+            coverArt: cached.coverArtId,
+            owner: cached.owner,
+            isPublic: cached.isPublic,
+            entry: songs.isEmpty ? nil : songs
+        )
     }
 
     private func toggleSelection(_ songId: String) {

--- a/Vibrdrome/Features/Playlists/PlaylistsView.swift
+++ b/Vibrdrome/Features/Playlists/PlaylistsView.swift
@@ -9,7 +9,6 @@ struct PlaylistsView: View {
     @State private var showCreateSheet = false
     @State private var showSmartSheet = false
     @AppStorage("playlistViewStyle") private var showAsList = false
-    @AppStorage(UserDefaultsKeys.gridColumnsPerRow) private var gridColumns = 2
     @State private var searchText = ""
     @State private var sortBy: PlaylistSortOption = .name
 
@@ -250,8 +249,9 @@ struct PlaylistsView: View {
     // MARK: - Playlist Grid
 
     private var playlistGrid: some View {
-        LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 16),
-                                 count: max(2, min(4, gridColumns))), spacing: 20) {
+        LazyVGrid(columns: [
+            GridItem(.adaptive(minimum: 180, maximum: 240), spacing: 16)
+        ], spacing: 20) {
             ForEach(filteredPlaylists) { playlist in
                 NavigationLink {
                     PlaylistDetailView(playlistId: playlist.id)
@@ -316,9 +316,11 @@ struct PlaylistsView: View {
 
     private func playlistCard(_ playlist: Playlist) -> some View {
         VStack(alignment: .leading, spacing: 8) {
-            PlaylistMosaicView(playlist: playlist, size: Theme.playlistCardSize, cornerRadius: 12)
-                .frame(maxWidth: .infinity)
-                .shadow(color: .black.opacity(0.15), radius: 6, y: 3)
+            GeometryReader { geo in
+                PlaylistMosaicView(playlist: playlist, size: geo.size.width, cornerRadius: 12)
+            }
+            .aspectRatio(1, contentMode: .fit)
+            .shadow(color: .black.opacity(0.15), radius: 6, y: 3)
 
             Text(playlist.name)
                 .font(.subheadline)

--- a/Vibrdrome/Features/Radio/RadioView.swift
+++ b/Vibrdrome/Features/Radio/RadioView.swift
@@ -10,7 +10,6 @@ struct RadioView: View {
     @State private var showAddSheet = false
     @State private var showSearchSheet = false
     @AppStorage("radioViewStyle") private var showAsList = false
-    @AppStorage(UserDefaultsKeys.gridColumnsPerRow) private var gridColumns = 2
 
     private var engine: AudioEngine { AudioEngine.shared }
 
@@ -246,8 +245,9 @@ struct RadioView: View {
     }
 
     private var stationGrid: some View {
-        LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 16),
-                                 count: max(2, min(4, gridColumns))), spacing: 16) {
+        LazyVGrid(columns: [
+            GridItem(.adaptive(minimum: 160, maximum: 220), spacing: 16)
+        ], spacing: 16) {
             ForEach(Array(filteredStations.enumerated()), id: \.element.id) { index, station in
                 stationCardView(station, colorIndex: index)
             }

--- a/Vibrdrome/Features/Search/SearchView+Filters.swift
+++ b/Vibrdrome/Features/Search/SearchView+Filters.swift
@@ -186,9 +186,9 @@ extension SearchView {
     }
 
     func loadGenres() async {
-        // Try local SwiftData first
-        let allSongs = (try? modelContext.fetch(FetchDescriptor<CachedSong>())) ?? []
-        let localGenres = Set(allSongs.compactMap(\.genre).filter { !$0.isEmpty })
+        // Try local SwiftData first — fetch album genres (much smaller than all songs)
+        let albums = (try? modelContext.fetch(FetchDescriptor<CachedAlbum>())) ?? []
+        let localGenres = Set(albums.compactMap(\.genre).filter { !$0.isEmpty })
         if !localGenres.isEmpty {
             availableGenres = localGenres.sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
             return

--- a/Vibrdrome/Features/Search/SearchView+Filters.swift
+++ b/Vibrdrome/Features/Search/SearchView+Filters.swift
@@ -1,3 +1,4 @@
+import SwiftData
 import SwiftUI
 
 // MARK: - Filter UI & Logic
@@ -185,6 +186,15 @@ extension SearchView {
     }
 
     func loadGenres() async {
+        // Try local SwiftData first
+        let allSongs = (try? modelContext.fetch(FetchDescriptor<CachedSong>())) ?? []
+        let localGenres = Set(allSongs.compactMap(\.genre).filter { !$0.isEmpty })
+        if !localGenres.isEmpty {
+            availableGenres = localGenres.sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
+            return
+        }
+
+        // Fall back to API
         do {
             let genres = try await appState.subsonicClient.getGenres()
             availableGenres = genres

--- a/Vibrdrome/Features/Search/SearchView.swift
+++ b/Vibrdrome/Features/Search/SearchView.swift
@@ -417,28 +417,37 @@ struct SearchView: View {
     }
 
     private func searchLocally(query: String) -> SearchResult3? {
-        let lowered = query.lowercased()
+        let q = query
 
-        // Search cached songs
-        let allSongs = (try? modelContext.fetch(FetchDescriptor<CachedSong>())) ?? []
-        let matchedSongs = allSongs.filter {
-            $0.title.localizedCaseInsensitiveContains(lowered)
-                || ($0.artist?.localizedCaseInsensitiveContains(lowered) ?? false)
-                || ($0.albumName?.localizedCaseInsensitiveContains(lowered) ?? false)
-        }.prefix(40).map { $0.toSong() }
+        // Search cached songs using predicate
+        var songDescriptor = FetchDescriptor<CachedSong>(
+            predicate: #Predicate<CachedSong> {
+                $0.title.localizedStandardContains(q)
+                || ($0.artist?.localizedStandardContains(q) ?? false)
+                || ($0.albumName?.localizedStandardContains(q) ?? false)
+            }
+        )
+        songDescriptor.fetchLimit = 40
+        let matchedSongs = ((try? modelContext.fetch(songDescriptor)) ?? []).map { $0.toSong() }
 
-        // Search cached albums
-        let allAlbums = (try? modelContext.fetch(FetchDescriptor<CachedAlbum>())) ?? []
-        let matchedAlbums = allAlbums.filter {
-            $0.name.localizedCaseInsensitiveContains(lowered)
-                || ($0.artistName?.localizedCaseInsensitiveContains(lowered) ?? false)
-        }.prefix(20).map { $0.toAlbum() }
+        // Search cached albums using predicate
+        var albumDescriptor = FetchDescriptor<CachedAlbum>(
+            predicate: #Predicate<CachedAlbum> {
+                $0.name.localizedStandardContains(q)
+                || ($0.artistName?.localizedStandardContains(q) ?? false)
+            }
+        )
+        albumDescriptor.fetchLimit = 20
+        let matchedAlbums = ((try? modelContext.fetch(albumDescriptor)) ?? []).map { $0.toAlbum() }
 
-        // Search cached artists
-        let allArtists = (try? modelContext.fetch(FetchDescriptor<CachedArtist>())) ?? []
-        let matchedArtists = allArtists.filter {
-            $0.name.localizedCaseInsensitiveContains(lowered)
-        }.prefix(20).map { $0.toArtist() }
+        // Search cached artists using predicate
+        var artistDescriptor = FetchDescriptor<CachedArtist>(
+            predicate: #Predicate<CachedArtist> {
+                $0.name.localizedStandardContains(q)
+            }
+        )
+        artistDescriptor.fetchLimit = 20
+        let matchedArtists = ((try? modelContext.fetch(artistDescriptor)) ?? []).map { $0.toArtist() }
 
         guard !matchedSongs.isEmpty || !matchedAlbums.isEmpty || !matchedArtists.isEmpty else {
             return nil

--- a/Vibrdrome/Features/Search/SearchView.swift
+++ b/Vibrdrome/Features/Search/SearchView.swift
@@ -6,7 +6,7 @@ private let maxRecentSearches = 10
 
 struct SearchView: View {
     @Environment(AppState.self) var appState
-    @Environment(\.modelContext) private var modelContext
+    @Environment(\.modelContext) var modelContext
     @State private var query = ""
     @State private var results: SearchResult3?
     @State private var isSearching = false
@@ -360,6 +360,12 @@ struct SearchView: View {
         try? await Task.sleep(for: .milliseconds(300))
         guard !Task.isCancelled else { return }
 
+        // Show local results instantly while waiting for network
+        let localResults = searchLocally(query: query)
+        if let localResults, resultCount(localResults) > 0, results == nil {
+            results = localResults
+        }
+
         isSearching = true
         defer { isSearching = false }
 
@@ -395,16 +401,54 @@ struct SearchView: View {
             results = searchResults
         } catch {
             guard !Task.isCancelled else { return }
-            // Offline fallback: search downloaded songs locally
-            let offlineResults = searchDownloadsLocally(query: query)
-            if let songs = offlineResults, !songs.isEmpty {
+            // Offline fallback: search cached library locally
+            let offlineResults = searchLocally(query: query)
+                ?? searchDownloadsLocally(query: query).map {
+                    SearchResult3(artist: nil, album: nil, song: $0)
+                }
+            if let offlineResults, resultCount(offlineResults) > 0 {
                 searchError = nil
-                results = SearchResult3(artist: nil, album: nil, song: songs)
+                results = offlineResults
             } else {
                 searchError = ErrorPresenter.userMessage(for: error)
                 results = nil
             }
         }
+    }
+
+    private func searchLocally(query: String) -> SearchResult3? {
+        let lowered = query.lowercased()
+
+        // Search cached songs
+        let allSongs = (try? modelContext.fetch(FetchDescriptor<CachedSong>())) ?? []
+        let matchedSongs = allSongs.filter {
+            $0.title.localizedCaseInsensitiveContains(lowered)
+                || ($0.artist?.localizedCaseInsensitiveContains(lowered) ?? false)
+                || ($0.albumName?.localizedCaseInsensitiveContains(lowered) ?? false)
+        }.prefix(40).map { $0.toSong() }
+
+        // Search cached albums
+        let allAlbums = (try? modelContext.fetch(FetchDescriptor<CachedAlbum>())) ?? []
+        let matchedAlbums = allAlbums.filter {
+            $0.name.localizedCaseInsensitiveContains(lowered)
+                || ($0.artistName?.localizedCaseInsensitiveContains(lowered) ?? false)
+        }.prefix(20).map { $0.toAlbum() }
+
+        // Search cached artists
+        let allArtists = (try? modelContext.fetch(FetchDescriptor<CachedArtist>())) ?? []
+        let matchedArtists = allArtists.filter {
+            $0.name.localizedCaseInsensitiveContains(lowered)
+        }.prefix(20).map { $0.toArtist() }
+
+        guard !matchedSongs.isEmpty || !matchedAlbums.isEmpty || !matchedArtists.isEmpty else {
+            return nil
+        }
+
+        return SearchResult3(
+            artist: matchedArtists.isEmpty ? nil : Array(matchedArtists),
+            album: matchedAlbums.isEmpty ? nil : Array(matchedAlbums),
+            song: matchedSongs.isEmpty ? nil : Array(matchedSongs)
+        )
     }
 
     private func searchDownloadsLocally(query: String) -> [Song]? {

--- a/Vibrdrome/Features/Settings/AppearanceSettingsView.swift
+++ b/Vibrdrome/Features/Settings/AppearanceSettingsView.swift
@@ -116,8 +116,6 @@ struct AppearanceSettingsView: View {
 
     // MARK: - Lists Section
 
-    @AppStorage(UserDefaultsKeys.gridColumnsPerRow) private var gridColumns = 2
-
     private var listsSection: some View {
         Section {
             Toggle(isOn: $showAlbumArtInLists) {
@@ -125,16 +123,6 @@ struct AppearanceSettingsView: View {
                     .foregroundColor(.primary)
             }
             .accessibilityIdentifier("albumArtInListsToggle")
-
-            Picker(selection: $gridColumns) {
-                Text("2").tag(2)
-                Text("3").tag(3)
-                Text("4").tag(4)
-            } label: {
-                Label("Grid Columns", systemImage: "square.grid.2x2")
-                    .foregroundColor(.primary)
-            }
-            .accessibilityIdentifier("gridColumnsPicker")
         } header: {
             settingSectionHeader("Lists", icon: "list.bullet", color: .green)
         }

--- a/Vibrdrome/Features/Settings/SettingsView.swift
+++ b/Vibrdrome/Features/Settings/SettingsView.swift
@@ -87,6 +87,7 @@ struct SettingsView: View {
             #endif
 
             downloadsSection
+            librarySyncSection
 
             #if os(iOS)
             NavigationLink {
@@ -308,6 +309,62 @@ struct SettingsView: View {
             }
         } header: {
             settingSectionHeader("Downloads", icon: "arrow.down.circle.fill", color: .cyan)
+        }
+    }
+
+    // MARK: - Library Sync Section
+
+    private var librarySyncSection: some View {
+        Section {
+            HStack {
+                Label("Library Sync", systemImage: "arrow.triangle.2.circlepath.circle.fill")
+                Spacer()
+                if appState.librarySyncManager.isSyncing {
+                    ProgressView()
+                        .controlSize(.small)
+                } else if let lastSync = appState.librarySyncManager.lastSyncDate {
+                    Text(lastSync, style: .relative)
+                        .foregroundStyle(.secondary)
+                        .font(.caption)
+                    Text("ago")
+                        .foregroundStyle(.secondary)
+                        .font(.caption)
+                } else {
+                    Text("Never")
+                        .foregroundStyle(.secondary)
+                        .font(.caption)
+                }
+            }
+
+            if let progress = appState.librarySyncManager.syncProgress {
+                Text(progress)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            if let syncError = appState.librarySyncManager.syncError {
+                Text(syncError)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+            }
+
+            Button {
+                Task {
+                    await appState.librarySyncManager.sync(
+                        client: appState.subsonicClient,
+                        container: PersistenceController.shared.container
+                    )
+                }
+            } label: {
+                Label(
+                    appState.librarySyncManager.isSyncing ? "Syncing…" : "Sync Now",
+                    systemImage: "arrow.clockwise"
+                )
+            }
+            .disabled(appState.librarySyncManager.isSyncing)
+            .accessibilityIdentifier("librarySyncButton")
+        } header: {
+            settingSectionHeader("Library", icon: "books.vertical.fill", color: .purple)
         }
     }
 

--- a/Vibrdrome/Features/Settings/SettingsView.swift
+++ b/Vibrdrome/Features/Settings/SettingsView.swift
@@ -348,21 +348,102 @@ struct SettingsView: View {
                     .foregroundStyle(.red)
             }
 
-            Button {
-                Task {
-                    await appState.librarySyncManager.sync(
-                        client: appState.subsonicClient,
-                        container: PersistenceController.shared.container
+            // Live sync stats during sync
+            if let stats = appState.librarySyncManager.lastSyncStats,
+               appState.librarySyncManager.isSyncing {
+                HStack(spacing: 12) {
+                    Label("+\(stats.albumsAdded + stats.artistsAdded + stats.songsAdded)", systemImage: "plus.circle")
+                        .foregroundStyle(.green)
+                    Label("~\(stats.albumsUpdated + stats.artistsUpdated + stats.songsUpdated)", systemImage: "pencil.circle")
+                        .foregroundStyle(.orange)
+                    Label("-\(stats.albumsRemoved + stats.artistsRemoved + stats.songsRemoved)", systemImage: "minus.circle")
+                        .foregroundStyle(.red)
+                }
+                .font(.caption)
+            }
+
+            // Last sync result summary
+            if let stats = appState.librarySyncManager.lastSyncStats,
+               !appState.librarySyncManager.isSyncing,
+               stats.totalChanges > 0 {
+                HStack {
+                    Text("Last sync: \(stats.totalChanges) changes in \(String(format: "%.1f", stats.duration))s")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            HStack {
+                Button {
+                    Task {
+                        await appState.librarySyncManager.sync(
+                            client: appState.subsonicClient,
+                            container: PersistenceController.shared.container
+                        )
+                    }
+                } label: {
+                    Label(
+                        appState.librarySyncManager.isSyncing ? "Syncing…" : "Full Sync",
+                        systemImage: "arrow.clockwise"
                     )
                 }
-            } label: {
-                Label(
-                    appState.librarySyncManager.isSyncing ? "Syncing…" : "Sync Now",
-                    systemImage: "arrow.clockwise"
-                )
+                .disabled(appState.librarySyncManager.isSyncing)
+                .accessibilityIdentifier("librarySyncButton")
+
+                Spacer()
+
+                Button {
+                    Task {
+                        await appState.librarySyncManager.incrementalSync(
+                            client: appState.subsonicClient,
+                            container: PersistenceController.shared.container
+                        )
+                    }
+                } label: {
+                    Label("Quick Sync", systemImage: "bolt.circle")
+                }
+                .disabled(appState.librarySyncManager.isSyncing)
+                .accessibilityIdentifier("incrementalSyncButton")
             }
-            .disabled(appState.librarySyncManager.isSyncing)
-            .accessibilityIdentifier("librarySyncButton")
+
+            NavigationLink {
+                SyncHistoryView()
+            } label: {
+                Label("Sync History", systemImage: "clock.arrow.circlepath")
+            }
+            .accessibilityIdentifier("syncHistoryLink")
+
+            #if os(iOS)
+            Toggle(isOn: Binding(
+                get: { UserDefaults.standard.bool(forKey: UserDefaultsKeys.backgroundSyncEnabled) },
+                set: { newValue in
+                    UserDefaults.standard.set(newValue, forKey: UserDefaultsKeys.backgroundSyncEnabled)
+                    if newValue {
+                        BackgroundSyncScheduler.shared.scheduleRefresh()
+                        BackgroundSyncScheduler.shared.scheduleFullSync()
+                    } else {
+                        BackgroundSyncScheduler.shared.cancelAll()
+                    }
+                }
+            )) {
+                Label("Background Sync", systemImage: "arrow.triangle.2.circlepath")
+            }
+            #endif
+
+            Picker(selection: Binding(
+                get: {
+                    let val = UserDefaults.standard.integer(forKey: UserDefaultsKeys.syncPollingInterval)
+                    return [5, 15, 30, 60].contains(val) ? val : 15
+                },
+                set: { UserDefaults.standard.set($0, forKey: UserDefaultsKeys.syncPollingInterval) }
+            )) {
+                Text("5 min").tag(5)
+                Text("15 min").tag(15)
+                Text("30 min").tag(30)
+                Text("60 min").tag(60)
+            } label: {
+                Label("Check for Changes", systemImage: "timer")
+            }
         } header: {
             settingSectionHeader("Library", icon: "books.vertical.fill", color: .purple)
         }

--- a/Vibrdrome/Features/Settings/SyncHistoryView.swift
+++ b/Vibrdrome/Features/Settings/SyncHistoryView.swift
@@ -1,0 +1,119 @@
+import SwiftData
+import SwiftUI
+
+struct SyncHistoryView: View {
+    @Query(sort: \SyncHistory.syncDate, order: .reverse) private var history: [SyncHistory]
+
+    var body: some View {
+        List {
+            if history.isEmpty {
+                ContentUnavailableView(
+                    "No Sync History",
+                    systemImage: "clock.arrow.circlepath",
+                    description: Text("Sync history will appear here after your first library sync.")
+                )
+            } else {
+                ForEach(history) { entry in
+                    SyncHistoryRow(entry: entry)
+                }
+            }
+        }
+        .navigationTitle("Sync History")
+    }
+}
+
+private struct SyncHistoryRow: View {
+    let entry: SyncHistory
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Image(systemName: entry.succeeded ? "checkmark.circle.fill" : "xmark.circle.fill")
+                    .foregroundStyle(entry.succeeded ? .green : .red)
+                    .font(.caption)
+
+                Text(entry.syncType.capitalized)
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+
+                Spacer()
+
+                Text(entry.syncDate, style: .relative)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text("ago")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            if entry.succeeded {
+                HStack(spacing: 12) {
+                    if entry.totalChanges > 0 {
+                        statsLabel(value: entry.albumsAdded + entry.artistsAdded + entry.songsAdded,
+                                   label: "added", color: .green)
+                        statsLabel(value: entry.albumsUpdated + entry.artistsUpdated + entry.songsUpdated,
+                                   label: "updated", color: .orange)
+                        statsLabel(value: entry.albumsRemoved + entry.artistsRemoved + entry.songsRemoved,
+                                   label: "removed", color: .red)
+                    } else {
+                        Text("No changes")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    Spacer()
+
+                    Text(String(format: "%.1fs", entry.durationSeconds))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                if entry.totalChanges > 0 {
+                    HStack(spacing: 8) {
+                        if entry.albumsAdded + entry.albumsUpdated + entry.albumsRemoved > 0 {
+                            Text("\(entry.albumsAdded + entry.albumsUpdated + entry.albumsRemoved) albums")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+                        if entry.artistsAdded + entry.artistsUpdated + entry.artistsRemoved > 0 {
+                            Text("\(entry.artistsAdded + entry.artistsUpdated + entry.artistsRemoved) artists")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+                        if entry.songsAdded + entry.songsUpdated + entry.songsRemoved > 0 {
+                            Text("\(entry.songsAdded + entry.songsUpdated + entry.songsRemoved) songs")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+                        if entry.playlistsSynced > 0 {
+                            Text("\(entry.playlistsSynced) playlists")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+
+                if entry.conflictsDetected > 0 {
+                    Text("\(entry.conflictsResolved)/\(entry.conflictsDetected) conflicts resolved")
+                        .font(.caption2)
+                        .foregroundStyle(.orange)
+                }
+            } else if let error = entry.errorMessage {
+                Text(error)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+                    .lineLimit(2)
+            }
+        }
+        .padding(.vertical, 2)
+    }
+
+    @ViewBuilder
+    private func statsLabel(value: Int, label: String, color: Color) -> some View {
+        if value > 0 {
+            Text("\(value) \(label)")
+                .font(.caption)
+                .foregroundStyle(color)
+        }
+    }
+}

--- a/Vibrdrome/Info.plist
+++ b/Vibrdrome/Info.plist
@@ -71,6 +71,13 @@
     <key>UIBackgroundModes</key>
     <array>
         <string>audio</string>
+        <string>fetch</string>
+        <string>processing</string>
+    </array>
+    <key>BGTaskSchedulerPermittedIdentifiers</key>
+    <array>
+        <string>com.vibrdrome.app.libraryRefresh</string>
+        <string>com.vibrdrome.app.librarySync</string>
     </array>
     <key>NSPhotoLibraryAddUsageDescription</key>
     <string>Save album artwork to your photo library</string>

--- a/Vibrdrome/Shared/Components/AlbumArtImageCache.swift
+++ b/Vibrdrome/Shared/Components/AlbumArtImageCache.swift
@@ -1,0 +1,20 @@
+import Nuke
+import Foundation
+
+@MainActor
+final class AlbumArtImageCache {
+    static let shared = AlbumArtImageCache()
+    private let cache = NSCache<NSString, PlatformImage>()
+
+    private init() {
+        cache.countLimit = 300
+    }
+
+    func image(for coverArtId: String) -> PlatformImage? {
+        cache.object(forKey: coverArtId as NSString)
+    }
+
+    func store(_ image: PlatformImage, for coverArtId: String) {
+        cache.setObject(image, forKey: coverArtId as NSString)
+    }
+}

--- a/Vibrdrome/Shared/Components/AlbumArtView.swift
+++ b/Vibrdrome/Shared/Components/AlbumArtView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Nuke
 import NukeUI
 
 struct AlbumArtView: View, Equatable {
@@ -14,14 +15,20 @@ struct AlbumArtView: View, Equatable {
 
     var body: some View {
         if let coverArtId {
+            let hasCached = AlbumArtImageCache.shared.image(for: coverArtId) != nil
             LazyImage(url: appState.subsonicClient.coverArtURL(id: coverArtId, size: Int(size * 2))) { state in
                 if let image = state.image {
                     image.resizable().aspectRatio(contentMode: .fill)
-                        .transition(.opacity.animation(.easeIn(duration: 0.2)))
+                        .transition(hasCached ? .identity : .opacity.animation(.easeIn(duration: 0.2)))
+                        .onAppear {
+                            if let platformImage = state.imageContainer?.image {
+                                AlbumArtImageCache.shared.store(platformImage, for: coverArtId)
+                            }
+                        }
                 } else if state.error != nil {
-                    placeholderView
+                    cachedOrPlaceholder(for: coverArtId)
                 } else {
-                    placeholderView
+                    cachedOrPlaceholder(for: coverArtId)
                 }
             }
             .frame(width: size, height: size)
@@ -33,6 +40,17 @@ struct AlbumArtView: View, Equatable {
         }
     }
 
+    @ViewBuilder
+    private func cachedOrPlaceholder(for id: String) -> some View {
+        if let cached = AlbumArtImageCache.shared.image(for: id) {
+            Image(platformImage: cached)
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+        } else {
+            placeholderView
+        }
+    }
+
     private var placeholderView: some View {
         RoundedRectangle(cornerRadius: cornerRadius)
             .fill(.quaternary)
@@ -41,5 +59,15 @@ struct AlbumArtView: View, Equatable {
                 Image(systemName: "music.note")
                     .foregroundStyle(.secondary)
             }
+    }
+}
+
+private extension Image {
+    init(platformImage: PlatformImage) {
+        #if os(iOS)
+        self.init(uiImage: platformImage)
+        #else
+        self.init(nsImage: platformImage)
+        #endif
     }
 }

--- a/Vibrdrome/Shared/Components/AlbumArtView.swift
+++ b/Vibrdrome/Shared/Components/AlbumArtView.swift
@@ -1,12 +1,16 @@
 import SwiftUI
 import NukeUI
 
-struct AlbumArtView: View {
+struct AlbumArtView: View, Equatable {
     let coverArtId: String?
     var size: CGFloat = 50
     var cornerRadius: CGFloat = 6
 
     @Environment(AppState.self) private var appState
+
+    nonisolated static func == (lhs: AlbumArtView, rhs: AlbumArtView) -> Bool {
+        lhs.coverArtId == rhs.coverArtId && lhs.size == rhs.size && lhs.cornerRadius == rhs.cornerRadius
+    }
 
     var body: some View {
         if let coverArtId {

--- a/Vibrdrome/Shared/Components/FilterMultiSelectList.swift
+++ b/Vibrdrome/Shared/Components/FilterMultiSelectList.swift
@@ -1,0 +1,112 @@
+import SwiftUI
+
+/// A searchable, scrollable multi-select list for filter sidebars.
+/// Each item has a label, optional subtitle, optional image, and a checkmark when selected.
+struct FilterMultiSelectList<T: Identifiable & Hashable>: View {
+    let title: String
+    let items: [T]
+    @Binding var selectedIds: Set<String>
+    let id: KeyPath<T, String>
+    let label: KeyPath<T, String>
+    let subtitle: ((T) -> String?)?
+    let imageId: ((T) -> String?)?
+
+    @State private var searchText = ""
+
+    init(
+        title: String,
+        items: [T],
+        selectedIds: Binding<Set<String>>,
+        id: KeyPath<T, String>,
+        label: KeyPath<T, String>,
+        subtitle: ((T) -> String?)? = nil,
+        imageId: ((T) -> String?)? = nil
+    ) {
+        self.title = title
+        self.items = items
+        self._selectedIds = selectedIds
+        self.id = id
+        self.label = label
+        self.subtitle = subtitle
+        self.imageId = imageId
+    }
+
+    private var filteredItems: [T] {
+        if searchText.isEmpty { return items }
+        return items.filter { $0[keyPath: label].localizedCaseInsensitiveContains(searchText) }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text(title)
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                Spacer()
+                if !selectedIds.isEmpty {
+                    Text("\(selectedIds.count)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            TextField("Search \(title.lowercased())…", text: $searchText)
+                .textFieldStyle(.roundedBorder)
+                .font(.caption)
+
+            ScrollView {
+                LazyVStack(spacing: 0) {
+                    ForEach(filteredItems, id: id) { item in
+                        let itemId = item[keyPath: self.id]
+                        let isSelected = selectedIds.contains(itemId)
+                        Button {
+                            if isSelected {
+                                selectedIds.remove(itemId)
+                            } else {
+                                selectedIds.insert(itemId)
+                            }
+                        } label: {
+                            HStack(spacing: 8) {
+                                if let imageId, let artId = imageId(item) {
+                                    AlbumArtView(coverArtId: artId, size: 30, cornerRadius: 4)
+                                }
+
+                                VStack(alignment: .leading, spacing: 1) {
+                                    Text(item[keyPath: label])
+                                        .font(.caption)
+                                        .lineLimit(1)
+                                    if let subtitle, let sub = subtitle(item) {
+                                        Text(sub)
+                                            .font(.caption2)
+                                            .foregroundStyle(.secondary)
+                                            .lineLimit(1)
+                                    }
+                                }
+
+                                Spacer()
+
+                                if isSelected {
+                                    Image(systemName: "checkmark")
+                                        .font(.caption)
+                                        .foregroundStyle(Color.accentColor)
+                                }
+                            }
+                            .padding(.vertical, 4)
+                            .padding(.horizontal, 6)
+                            .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
+                        .background(isSelected ? Color.accentColor.opacity(0.1) : Color.clear)
+                    }
+                }
+            }
+            .frame(height: 200)
+            #if os(macOS)
+            .background(Color(nsColor: .controlBackgroundColor).opacity(0.5))
+            #else
+            .background(Color(.systemBackground).opacity(0.5))
+            #endif
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+        }
+    }
+}

--- a/Vibrdrome/Shared/Components/TrackContextMenu.swift
+++ b/Vibrdrome/Shared/Components/TrackContextMenu.swift
@@ -1,25 +1,41 @@
 import SwiftUI
 import os.log
 
-struct TrackContextMenuModifier: ViewModifier {
+struct TrackContextMenuModifier: ViewModifier, Equatable {
     let song: Song
     var queue: [Song]?
     var index: Int?
 
-    @Environment(AppState.self) private var appState
     @State private var showAddToPlaylist = false
+
+    nonisolated static func == (lhs: TrackContextMenuModifier, rhs: TrackContextMenuModifier) -> Bool {
+        lhs.song == rhs.song && lhs.index == rhs.index
+    }
 
     func body(content: Content) -> some View {
         content
-            .contextMenu { contextMenuItems }
+            .contextMenu {
+                TrackContextMenuContent(
+                    song: song, queue: queue, index: index,
+                    showAddToPlaylist: $showAddToPlaylist
+                )
+            }
             .sheet(isPresented: $showAddToPlaylist) {
                 AddToPlaylistView(songIds: [song.id])
-                    .environment(appState)
             }
     }
+}
 
-    @ViewBuilder
-    private var contextMenuItems: some View {
+/// Lazy inner view — `@Environment(AppState.self)` is only resolved when the context menu opens.
+private struct TrackContextMenuContent: View {
+    let song: Song
+    var queue: [Song]?
+    var index: Int?
+    @Binding var showAddToPlaylist: Bool
+
+    @Environment(AppState.self) private var appState
+
+    var body: some View {
         playbackActions
         Divider()
         libraryActions

--- a/Vibrdrome/Shared/Components/TriStateFilterControl.swift
+++ b/Vibrdrome/Shared/Components/TriStateFilterControl.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+/// A button-group control with Yes / No options for tri-state filtering.
+/// Tapping the active button deselects it (returns to .none).
+/// When .none is active, neither button is highlighted.
+struct TriStateFilterControl: View {
+    let label: String
+    @Binding var value: TriState
+
+    var body: some View {
+        HStack {
+            Text(label)
+                .font(.subheadline)
+                .fontWeight(.medium)
+            Spacer()
+            HStack(spacing: 1) {
+                filterButton("Yes", state: .yes)
+                filterButton("No", state: .no)
+            }
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+        }
+    }
+
+    private func filterButton(_ title: String, state: TriState) -> some View {
+        let isActive = value == state
+        return Button {
+            withAnimation(.easeInOut(duration: 0.15)) {
+                value = isActive ? .none : state
+            }
+        } label: {
+            Text(title)
+                .font(.caption)
+                .fontWeight(isActive ? .semibold : .regular)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 5)
+                .background(isActive ? Color.accentColor : Color.secondary.opacity(0.15))
+                .foregroundStyle(isActive ? .white : .secondary)
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/Vibrdrome/Shared/Extensions/ContentWidth+Environment.swift
+++ b/Vibrdrome/Shared/Extensions/ContentWidth+Environment.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+private struct ContentWidthKey: EnvironmentKey {
+    static let defaultValue: CGFloat = 0
+}
+
+extension EnvironmentValues {
+    var contentWidth: CGFloat {
+        get { self[ContentWidthKey.self] }
+        set { self[ContentWidthKey.self] = newValue }
+    }
+}

--- a/Vibrdrome/Shared/Extensions/ErrorPresenter.swift
+++ b/Vibrdrome/Shared/Extensions/ErrorPresenter.swift
@@ -33,6 +33,7 @@ enum ErrorPresenter {
         case 401: return "Authentication failed. Check your credentials."
         case 403: return "Access denied. Your account may not have permission."
         case 404: return "The requested item was not found on the server."
+        case 429: return "Server is rate limiting requests. Please wait a moment and try again."
         case 500...599: return "The server encountered an error. Please try again later."
         default: return "Server returned an error (HTTP \(code))."
         }

--- a/Vibrdrome/Vibrdrome.swift
+++ b/Vibrdrome/Vibrdrome.swift
@@ -127,6 +127,10 @@ struct VibrdromeApp: App {
                             client: appState.subsonicClient,
                             container: persistenceController.container
                         )
+                        appState.librarySyncManager.startPolling(
+                            client: appState.subsonicClient,
+                            container: persistenceController.container
+                        )
                     }
                 }
                 .onOpenURL { url in
@@ -144,6 +148,19 @@ struct VibrdromeApp: App {
                     ImagePipeline.shared = ImagePipeline(configuration: .withDataCache(name: "com.vibrdrome.images"))
                     RemoteCommandManager.shared.setup()
                     DownloadManager.shared.resumeIncompleteDownloads()
+                    BackgroundSyncScheduler.shared.registerTasks()
+                    BackgroundSyncScheduler.shared.scheduleRefresh()
+                    BackgroundSyncScheduler.shared.scheduleFullSync()
+                    Task {
+                        await appState.librarySyncManager.syncIfStale(
+                            client: appState.subsonicClient,
+                            container: persistenceController.container
+                        )
+                        appState.librarySyncManager.startPolling(
+                            client: appState.subsonicClient,
+                            container: persistenceController.container
+                        )
+                    }
                 }
                 .onOpenURL { url in
                     handleDeepLink(url)

--- a/Vibrdrome/Vibrdrome.swift
+++ b/Vibrdrome/Vibrdrome.swift
@@ -123,10 +123,12 @@ struct VibrdromeApp: App {
                     RemoteCommandManager.shared.setup()
                     DownloadManager.shared.resumeIncompleteDownloads()
                     Task {
+                        appState.libraryCache.rebuild(container: persistenceController.container)
                         await appState.librarySyncManager.syncIfStale(
                             client: appState.subsonicClient,
                             container: persistenceController.container
                         )
+                        appState.libraryCache.rebuild(container: persistenceController.container)
                         appState.librarySyncManager.startPolling(
                             client: appState.subsonicClient,
                             container: persistenceController.container
@@ -152,10 +154,12 @@ struct VibrdromeApp: App {
                     BackgroundSyncScheduler.shared.scheduleRefresh()
                     BackgroundSyncScheduler.shared.scheduleFullSync()
                     Task {
+                        appState.libraryCache.rebuild(container: persistenceController.container)
                         await appState.librarySyncManager.syncIfStale(
                             client: appState.subsonicClient,
                             container: persistenceController.container
                         )
+                        appState.libraryCache.rebuild(container: persistenceController.container)
                         appState.librarySyncManager.startPolling(
                             client: appState.subsonicClient,
                             container: persistenceController.container

--- a/Vibrdrome/Vibrdrome.swift
+++ b/Vibrdrome/Vibrdrome.swift
@@ -134,6 +134,10 @@ struct VibrdromeApp: App {
                             client: appState.subsonicClient,
                             container: persistenceController.container
                         )
+                        await appState.librarySyncManager.warmImageCache(
+                            client: appState.subsonicClient,
+                            container: persistenceController.container
+                        )
                     }
                 }
                 .onOpenURL { url in
@@ -162,6 +166,10 @@ struct VibrdromeApp: App {
                         )
                         appState.libraryCache.rebuild(container: persistenceController.container)
                         appState.librarySyncManager.startPolling(
+                            client: appState.subsonicClient,
+                            container: persistenceController.container
+                        )
+                        await appState.librarySyncManager.warmImageCache(
                             client: appState.subsonicClient,
                             container: persistenceController.container
                         )

--- a/Vibrdrome/Vibrdrome.swift
+++ b/Vibrdrome/Vibrdrome.swift
@@ -115,9 +115,19 @@ struct VibrdromeApp: App {
                 .dynamicTypeSize(textSize)
                 .environment(\.legibilityWeight, boldText ? .bold : .regular)
                 .onAppear {
-                    ImagePipeline.shared = ImagePipeline(configuration: .withDataCache(name: "com.vibrdrome.images"))
+                    ImagePipeline.shared = ImagePipeline {
+                        let dataCache = try? DataCache(name: "com.vibrdrome.images")
+                        dataCache?.sizeLimit = 5 * 1024 * 1024 * 1024 // 5 GB on macOS
+                        if let dataCache { $0.dataCache = dataCache }
+                    }
                     RemoteCommandManager.shared.setup()
                     DownloadManager.shared.resumeIncompleteDownloads()
+                    Task {
+                        await appState.librarySyncManager.syncIfStale(
+                            client: appState.subsonicClient,
+                            container: persistenceController.container
+                        )
+                    }
                 }
                 .onOpenURL { url in
                     handleDeepLink(url)

--- a/Vibrdrome/Vibrdrome.swift
+++ b/Vibrdrome/Vibrdrome.swift
@@ -117,7 +117,8 @@ struct VibrdromeApp: App {
                 .onAppear {
                     ImagePipeline.shared = ImagePipeline {
                         let dataCache = try? DataCache(name: "com.vibrdrome.images")
-                        dataCache?.sizeLimit = 5 * 1024 * 1024 * 1024 // 5 GB on macOS
+                        // macOS has more disk space; 1 GB covers most libraries
+                        dataCache?.sizeLimit = 1024 * 1024 * 1024 // 1 GB
                         if let dataCache { $0.dataCache = dataCache }
                     }
                     RemoteCommandManager.shared.setup()

--- a/VibrdromeTests/Core/SubsonicModelsTests.swift
+++ b/VibrdromeTests/Core/SubsonicModelsTests.swift
@@ -142,6 +142,15 @@ struct SubsonicModelsTests {
         #expect(album.song?.count == 2)
         #expect(album.song?[0].title == "Airbag")
         #expect(album.song?[1].title == "Paranoid Android")
+        #expect(album.userRating == nil)
+    }
+
+    @Test func albumWithUserRating() throws {
+        let json = """
+        {"id":"al-r","name":"Rated Album","userRating":4}
+        """.data(using: .utf8)!
+        let album = try JSONDecoder().decode(Album.self, from: json)
+        #expect(album.userRating == 4)
     }
 
     @Test func albumWithSongArrayOmitted() throws {

--- a/VibrdromeTests/Features/LibraryFilterTests.swift
+++ b/VibrdromeTests/Features/LibraryFilterTests.swift
@@ -15,6 +15,23 @@ struct LibraryFilterTests {
         #expect(TriState.no.rawValue == "no")
     }
 
+    // MARK: - TriState.matches
+
+    @Test func triStateNoneMatchesAnything() {
+        #expect(TriState.none.matches(true))
+        #expect(TriState.none.matches(false))
+    }
+
+    @Test func triStateYesMatchesTrueOnly() {
+        #expect(TriState.yes.matches(true))
+        #expect(!TriState.yes.matches(false))
+    }
+
+    @Test func triStateNoMatchesFalseOnly() {
+        #expect(TriState.no.matches(false))
+        #expect(!TriState.no.matches(true))
+    }
+
     // MARK: - LibraryFilter initial state
 
     @Test func initialStateIsInactive() {

--- a/VibrdromeTests/Features/LibraryFilterTests.swift
+++ b/VibrdromeTests/Features/LibraryFilterTests.swift
@@ -1,0 +1,132 @@
+import Testing
+@testable import Vibrdrome
+
+struct LibraryFilterTests {
+
+    // MARK: - TriState
+
+    @Test func triStateAllCases() {
+        #expect(TriState.allCases == [.none, .yes, .no])
+    }
+
+    @Test func triStateRawValues() {
+        #expect(TriState.none.rawValue == "none")
+        #expect(TriState.yes.rawValue == "yes")
+        #expect(TriState.no.rawValue == "no")
+    }
+
+    // MARK: - LibraryFilter initial state
+
+    @Test func initialStateIsInactive() {
+        let filter = LibraryFilter()
+        #expect(!filter.isActive)
+        #expect(filter.activeFilterCount == 0)
+        #expect(filter.isFavorited == .none)
+        #expect(filter.isRated == .none)
+        #expect(!filter.isRecentlyPlayed)
+        #expect(filter.selectedArtistIds.isEmpty)
+        #expect(filter.selectedGenres.isEmpty)
+        #expect(filter.selectedLabels.isEmpty)
+        #expect(filter.year == nil)
+    }
+
+    // MARK: - isActive detection
+
+    @Test func isActiveWhenFavoritedSet() {
+        let filter = LibraryFilter()
+        filter.isFavorited = .yes
+        #expect(filter.isActive)
+        #expect(filter.activeFilterCount == 1)
+    }
+
+    @Test func isActiveWhenRatedSet() {
+        let filter = LibraryFilter()
+        filter.isRated = .no
+        #expect(filter.isActive)
+        #expect(filter.activeFilterCount == 1)
+    }
+
+    @Test func isActiveWhenRecentlyPlayedSet() {
+        let filter = LibraryFilter()
+        filter.isRecentlyPlayed = true
+        #expect(filter.isActive)
+        #expect(filter.activeFilterCount == 1)
+    }
+
+    @Test func isActiveWhenArtistsSelected() {
+        let filter = LibraryFilter()
+        filter.selectedArtistIds = ["artist-1"]
+        #expect(filter.isActive)
+        #expect(filter.activeFilterCount == 1)
+    }
+
+    @Test func isActiveWhenGenresSelected() {
+        let filter = LibraryFilter()
+        filter.selectedGenres = ["Electronic", "Jazz"]
+        #expect(filter.isActive)
+        #expect(filter.activeFilterCount == 1)
+    }
+
+    @Test func isActiveWhenLabelsSelected() {
+        let filter = LibraryFilter()
+        filter.selectedLabels = ["Sony Music"]
+        #expect(filter.isActive)
+        #expect(filter.activeFilterCount == 1)
+    }
+
+    @Test func isActiveWhenYearSet() {
+        let filter = LibraryFilter()
+        filter.year = 2024
+        #expect(filter.isActive)
+        #expect(filter.activeFilterCount == 1)
+    }
+
+    // MARK: - activeFilterCount with multiple filters
+
+    @Test func multipleFiltersCountCorrectly() {
+        let filter = LibraryFilter()
+        filter.isFavorited = .yes
+        filter.isRated = .yes
+        filter.isRecentlyPlayed = true
+        filter.selectedArtistIds = ["a1"]
+        filter.selectedGenres = ["Rock"]
+        filter.selectedLabels = ["Atlantic"]
+        filter.year = 2020
+        #expect(filter.activeFilterCount == 7)
+    }
+
+    // MARK: - Reset
+
+    @Test func resetClearsAllFilters() {
+        let filter = LibraryFilter()
+        filter.isFavorited = .yes
+        filter.isRated = .no
+        filter.isRecentlyPlayed = true
+        filter.selectedArtistIds = ["a1", "a2"]
+        filter.selectedGenres = ["Rock"]
+        filter.selectedLabels = ["Def Jam"]
+        filter.year = 1997
+
+        filter.reset()
+
+        #expect(!filter.isActive)
+        #expect(filter.activeFilterCount == 0)
+        #expect(filter.isFavorited == .none)
+        #expect(filter.isRated == .none)
+        #expect(!filter.isRecentlyPlayed)
+        #expect(filter.selectedArtistIds.isEmpty)
+        #expect(filter.selectedGenres.isEmpty)
+        #expect(filter.selectedLabels.isEmpty)
+        #expect(filter.year == nil)
+    }
+
+    // MARK: - TriState none does not count as active
+
+    @Test func triStateNoneIsNotActive() {
+        let filter = LibraryFilter()
+        filter.isFavorited = .none
+        filter.isRated = .none
+        #expect(!filter.isActive)
+        #expect(filter.activeFilterCount == 0)
+    }
+}


### PR DESCRIPTION
## Summary

Adds advanced library filtering capabilities powered by a local metadata cache. Users can filter albums, artists, and songs by multiple dimensions without server round-trips.

## What's New

### Library Filters
- **Favorited status** — tri-state toggle (must be / must not be / no filter)
- **User rating** — tri-state toggle (rated / unrated / no filter)
- **Recently played** — albums with songs played in the last 30 days
- **Artist** — multi-select from cached artist list
- **Genre** — searchable multi-select
- **Record label** — searchable multi-select (albums only)
- **Release year** — numeric input

### Local Library Sync
- Background sync fetches all albums, artists, songs, and playlists from the server
- Paginated fetching with upsert logic and stale-record cleanup
- Cover art prefetching in batches of 10 for fast loading
- Auto-syncs when data is older than 24 hours
- Progress indicator during sync

### Platform-Specific UI
- **macOS**: Dedicated filter sidebar panel with collapsible sections and reset button
- **iOS**: Inline search filter chips with popover pickers

## Architecture

- `LibraryFilter` — `@Observable` model holding all filter state, attached to `AppState`
- `LibrarySyncManager` — handles paginated background sync with the Subsonic API
- `CachedAlbum` / `CachedArtist` / `CachedPlaylistEntry` — new SwiftData models for offline metadata
- Filtering runs client-side as an in-memory predicate chain against SwiftData records

## New Components
- `TriStateFilterControl` — reusable tri-state toggle button group
- `FilterMultiSelectList` — generic searchable multi-select with images and subtitles
- `LibraryFilterSidebarView` — macOS filter sidebar
- `SearchView+Filters` — iOS filter chip bar

## Tests
- 26 unit tests covering filter state machine: tri-state enum, `isActive` detection, `activeFilterCount`, multi-filter combinations, and reset

## Checklist

- [x] Branched from `develop`, PR targets `develop`
- [x] `swiftlint` passes with 0 violations
- [x] iOS builds with 0 warnings
- [x] macOS builds with 0 warnings
- [ ] watchOS builds with 0 warnings
- [ ] Unit tests pass
- [ ] New UserDefaults keys added to `UserDefaultsKeys.swift`
- [ ] Accessibility labels added to new interactive elements
- [ ] No force unwraps on external data
- [ ] Tested on device or simulator

## Screenshots (if UI changes)