### PR TITLE
Build 42: Tab reorder fix, queue layout, play history

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
           xcodebuild build \
             -project Vibrdrome.xcodeproj \
             -scheme Vibrdrome \
-            -destination 'platform=iOS Simulator,name=iPhone 16' \
+            -destination 'generic/platform=iOS Simulator' \
             -configuration Debug \
             CODE_SIGNING_ALLOWED=NO \
             SWIFT_VERSION=5
@@ -115,7 +115,7 @@ jobs:
           xcodebuild test \
             -project Vibrdrome.xcodeproj \
             -scheme Vibrdrome \
-            -destination 'platform=iOS Simulator,name=iPhone 16' \
+            -destination 'generic/platform=iOS Simulator' \
             CODE_SIGNING_ALLOWED=NO \
             SWIFT_VERSION=5 \
             -resultBundlePath TestResults.xcresult || true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to Vibrdrome (iOS/macOS) are documented here.
 
 ## v1.0.0
 
+### Build 42 — April 15, 2026
+- Tab bar reorder works instantly without kicking to Home
+- Queue layout: Recently Played on top, Now Playing in middle, Up Next below
+- Queue auto-scrolls to Now Playing on open
+- Play history records from all playback paths (gapless, skip, queue tap)
+- Recently Played falls back to queue position on fresh launch
+- 532 unit tests in 40 suites
+
+**TestFlight Notes:**
+> Tab reorder fixed (instant, no Home kick). Queue reordered: Recently Played,
+> Now Playing, Up Next. Play history tracks all playback paths.
+
 ### Build 40 — April 15, 2026
 - Tab bar drag-to-reorder restored in Settings
 - A-Z section index on Artists list with tap-to-jump (split X-Z into individual letters, [Unknown] as #)

--- a/Vibrdrome/Core/Audio/AudioEngine+Playback.swift
+++ b/Vibrdrome/Core/Audio/AudioEngine+Playback.swift
@@ -503,6 +503,12 @@ extension AudioEngine {
     func handleAutoAdvance() {
         submitScrobbleIfNeeded()
 
+        // Record outgoing song in play history
+        if let outgoing = currentSong {
+            playHistory.append(outgoing)
+            if playHistory.count > 50 { playHistory.removeFirst() }
+        }
+
         guard let nextIndex = lookaheadIndex, nextIndex < queue.count else {
             playbackLog.warning("Auto-advance but no valid lookahead index")
             return
@@ -543,6 +549,11 @@ extension AudioEngine {
     /// Unlike play(song:from:at:), this preserves the full queue intact.
     func skipToIndex(_ index: Int) {
         guard index >= 0, index < queue.count else { return }
+        // Record outgoing song in play history
+        if let outgoing = currentSong {
+            playHistory.append(outgoing)
+            if playHistory.count > 50 { playHistory.removeFirst() }
+        }
         let song = queue[index]
         currentIndex = index
         currentSong = song

--- a/Vibrdrome/Core/Audio/AudioEngine+Queue.swift
+++ b/Vibrdrome/Core/Audio/AudioEngine+Queue.swift
@@ -9,9 +9,14 @@ extension AudioEngine {
         return Array(queue[(currentIndex + 1)...])
     }
 
-    /// Songs actually played before the current track (most recent first, max 20)
+    /// Songs played before the current track (most recent first, max 20).
+    /// Uses actual play history if available, falls back to queue position.
     var recentlyPlayed: [Song] {
-        Array(playHistory.reversed().prefix(20))
+        if !playHistory.isEmpty {
+            return Array(playHistory.reversed().prefix(20))
+        }
+        guard currentIndex > 0 else { return [] }
+        return Array(queue[0..<currentIndex].reversed().prefix(20))
     }
 
     func addToQueue(_ song: Song) {

--- a/Vibrdrome/Features/Library/ContentView.swift
+++ b/Vibrdrome/Features/Library/ContentView.swift
@@ -172,7 +172,6 @@ struct ContentView: View {
             }
         }
         .tabViewStyle(.sidebarAdaptable)
-        .id(tabBarOrderJSON)
         .animation(.smooth, value: selectedTab)
         .onChange(of: selectedTab) { _, _ in
             #if os(iOS)

--- a/Vibrdrome/Features/Player/QueueView.swift
+++ b/Vibrdrome/Features/Player/QueueView.swift
@@ -10,55 +10,9 @@ struct QueueView: View {
 
     var body: some View {
         NavigationStack {
+            ScrollViewReader { proxy in
             List {
-                // Now playing
-                if let current = engine.currentSong {
-                    Section("Now Playing") {
-                        HStack(spacing: 12) {
-                            AlbumArtView(coverArtId: current.coverArt, size: 44)
-
-                            VStack(alignment: .leading, spacing: 2) {
-                                Button {
-                                    appState.pendingNavigation = .song(id: current.id)
-                                    dismiss()
-                                } label: {
-                                    Text(current.title)
-                                        .font(.body)
-                                        .bold()
-                                        .lineLimit(1)
-                                }
-                                .buttonStyle(.plain)
-
-                                if let artist = current.artist {
-                                    Button {
-                                        if let artistId = current.artistId {
-                                            appState.pendingNavigation = .artist(id: artistId)
-                                            dismiss()
-                                        }
-                                    } label: {
-                                        Text(artist)
-                                            .font(.caption)
-                                            .foregroundStyle(.secondary)
-                                            .lineLimit(1)
-                                    }
-                                    .buttonStyle(.plain)
-                                    .disabled(current.artistId == nil)
-                                }
-                            }
-
-                            Spacer()
-
-                            if engine.isPlaying {
-                                Image(systemName: "waveform")
-                                    .foregroundStyle(Color.accentColor)
-                                    .symbolEffect(.variableColor)
-                                    .accessibilityLabel("Playing")
-                            }
-                        }
-                    }
-                }
-
-                // Recently played
+                // Recently played (top)
                 let history = engine.recentlyPlayed
                 if !history.isEmpty {
                     Section("Recently Played") {
@@ -77,6 +31,39 @@ struct QueueView: View {
                                 }
                             }
                             .opacity(0.6)
+                        }
+                    }
+                }
+
+                // Now playing (middle, fixed position)
+                if let current = engine.currentSong {
+                    Section("Now Playing") {
+                        EmptyView().id("nowPlayingAnchor")
+                        HStack(spacing: 12) {
+                            AlbumArtView(coverArtId: current.coverArt, size: 44)
+
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(current.title)
+                                    .font(.body)
+                                    .bold()
+                                    .lineLimit(1)
+
+                                if let artist = current.artist {
+                                    Text(artist)
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                        .lineLimit(1)
+                                }
+                            }
+
+                            Spacer()
+
+                            if engine.isPlaying {
+                                Image(systemName: "waveform")
+                                    .foregroundStyle(Color.accentColor)
+                                    .symbolEffect(.variableColor)
+                                    .accessibilityLabel("Playing")
+                            }
                         }
                     }
                 }
@@ -201,6 +188,12 @@ struct QueueView: View {
             #if os(iOS)
             .listStyle(.insetGrouped)
             #endif
+            .onAppear {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                    withAnimation { proxy.scrollTo("nowPlayingAnchor", anchor: .top) }
+                }
+            }
+            } // ScrollViewReader
             .navigationTitle("Queue")
             #if os(iOS)
             .navigationBarTitleDisplayMode(.inline)

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -347,6 +347,23 @@
 
         <div class="timeline">
 
+            <!-- Build 42 -->
+            <div class="timeline-item" data-animate>
+                <div class="build-card">
+                    <div class="build-header">
+                        <span class="build-badge">Build 42</span>
+                        <span class="build-date">April 15, 2026</span>
+                    </div>
+                    <ul>
+                        <li>Tab bar reorder works instantly without kicking to Home</li>
+                        <li>Queue layout: Recently Played, Now Playing, Up Next</li>
+                        <li>Queue auto-scrolls to Now Playing on open</li>
+                        <li>Play history tracks all playback paths</li>
+                        <li>532 unit tests in 40 suites</li>
+                    </ul>
+                </div>
+            </div>
+
             <!-- Build 40 -->
             <div class="timeline-item" data-animate>
                 <div class="build-card">

--- a/project.yml
+++ b/project.yml
@@ -89,7 +89,7 @@ targets:
         DEVELOPMENT_TEAM: 85JD2B827Q
         PRODUCT_BUNDLE_IDENTIFIER: com.vibrdrome.app
         MARKETING_VERSION: "1.0.0"
-        CURRENT_PROJECT_VERSION: "40"
+        CURRENT_PROJECT_VERSION: "42"
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS: "YES"
       configs:
@@ -122,7 +122,7 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.vibrdrome.app.widget
         CODE_SIGN_ENTITLEMENTS: VibrdromeWidget/VibrdromeWidget.entitlements
         MARKETING_VERSION: "1.0.0"
-        CURRENT_PROJECT_VERSION: "40"
+        CURRENT_PROJECT_VERSION: "42"
     entitlements:
       path: VibrdromeWidget/VibrdromeWidget.entitlements
 
@@ -139,7 +139,7 @@ targets:
         DEVELOPMENT_TEAM: 85JD2B827Q
         PRODUCT_BUNDLE_IDENTIFIER: com.vibrdrome.app.watchkitapp
         MARKETING_VERSION: "1.0.0"
-        CURRENT_PROJECT_VERSION: "40"
+        CURRENT_PROJECT_VERSION: "42"
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         SWIFT_VERSION: "6.0"
 


### PR DESCRIPTION
## Summary
- Tab bar reorder works instantly without kicking to Home
- Queue layout: Recently Played, Now Playing, Up Next with auto-scroll
- Play history records from gapless, skip, and queue tap paths
- Recently Played falls back to queue position on fresh launch

## Test plan
- [x] SwiftLint: 0 violations
- [x] Unit tests: 532 passing, 40 suites
- [x] iOS, macOS, watchOS builds clean
- [x] Device tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)