### PR TITLE
Add CMD+K / CMD+F search keyboard shortcuts for macOS

### DIFF
--- a/Vibrdrome/Core/Constants/UserDefaultsKeys.swift
+++ b/Vibrdrome/Core/Constants/UserDefaultsKeys.swift
@@ -1,5 +1,14 @@
 import Foundation
 
+// MARK: - Notification Names
+
+extension Notification.Name {
+    /// Posted to navigate to the Search view and focus its search bar.
+    static let navigateToSearch = Notification.Name("com.vibrdrome.navigateToSearch")
+    /// Posted to focus the search bar in the currently visible view.
+    static let focusSearchBar = Notification.Name("com.vibrdrome.focusSearchBar")
+}
+
 /// Centralized UserDefaults key constants.
 /// Use with both `UserDefaults.standard` and `@AppStorage`.
 enum UserDefaultsKeys {

--- a/Vibrdrome/Features/Library/AlbumsView.swift
+++ b/Vibrdrome/Features/Library/AlbumsView.swift
@@ -15,6 +15,7 @@ struct AlbumsView: View {
     @State private var error: String?
     @State private var hasMore = true
     @State private var searchText = ""
+    @State private var searchIsActive = false
     @State private var activeListType: AlbumListType?
     @State private var clientSideSort: AlbumSortOption?
     @AppStorage("albumsViewStyle") private var showAsList = false
@@ -128,7 +129,7 @@ struct AlbumsView: View {
         .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .automatic), prompt: "Search in Albums")
         .navigationBarTitleDisplayMode(.large)
         #else
-        .searchable(text: $searchText, prompt: "Search in Albums")
+        .searchable(text: $searchText, isPresented: $searchIsActive, prompt: "Search in Albums")
         #endif
         .onChange(of: searchText) { _, newValue in
             searchTask?.cancel()
@@ -145,6 +146,10 @@ struct AlbumsView: View {
                 guard !Task.isCancelled else { return }
                 searchResults = results?.album ?? []
             }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .focusSearchBar)) { _ in
+            searchIsActive = false
+            DispatchQueue.main.async { searchIsActive = true }
         }
         .overlay {
             if isLoading && albums.isEmpty {

--- a/Vibrdrome/Features/Library/ArtistsView.swift
+++ b/Vibrdrome/Features/Library/ArtistsView.swift
@@ -7,6 +7,7 @@ struct ArtistsView: View {
     @State private var isLoading = true
     @State private var error: String?
     @State private var searchText = ""
+    @State private var searchIsActive = false
     @State private var sortReversed = false
     @State private var favoritedArtistIds: Set<String> = []
     @AppStorage("artistsViewStyle") private var showAsList = true
@@ -120,8 +121,12 @@ struct ArtistsView: View {
         .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .automatic), prompt: "Search Artists")
         .navigationBarTitleDisplayMode(.large)
         #else
-        .searchable(text: $searchText, prompt: "Search Artists")
+        .searchable(text: $searchText, isPresented: $searchIsActive, prompt: "Search Artists")
         #endif
+        .onReceive(NotificationCenter.default.publisher(for: .focusSearchBar)) { _ in
+            searchIsActive = false
+            DispatchQueue.main.async { searchIsActive = true }
+        }
         .overlay {
             if isLoading && indexes.isEmpty {
                 ProgressView("Loading artists...")

--- a/Vibrdrome/Features/Library/FavoritesView.swift
+++ b/Vibrdrome/Features/Library/FavoritesView.swift
@@ -6,6 +6,7 @@ struct FavoritesView: View {
     @State private var isLoading = true
     @State private var error: String?
     @State private var searchText = ""
+    @State private var searchIsActive = false
     @State private var selectedSongs = Set<String>()
     @State private var isSelecting = false
     @State private var showBatchAddToPlaylist = false
@@ -73,8 +74,12 @@ struct FavoritesView: View {
         .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .automatic), prompt: "Search Favorites")
         .navigationBarTitleDisplayMode(.large)
         #else
-        .searchable(text: $searchText, prompt: "Search Favorites")
+        .searchable(text: $searchText, isPresented: $searchIsActive, prompt: "Search Favorites")
         #endif
+        .onReceive(NotificationCenter.default.publisher(for: .focusSearchBar)) { _ in
+            searchIsActive = false
+            DispatchQueue.main.async { searchIsActive = true }
+        }
         .overlay {
             if isLoading && starred == nil {
                 ProgressView("Loading favorites...")

--- a/Vibrdrome/Features/Library/GenresView.swift
+++ b/Vibrdrome/Features/Library/GenresView.swift
@@ -21,6 +21,7 @@ struct GenresView: View {
         )
     }
     @State private var searchText = ""
+    @State private var searchIsActive = false
     @State private var sortBy: GenreSortOption = .name
     @AppStorage("genresViewStyle") private var showAsList = true
     @AppStorage(UserDefaultsKeys.gridColumnsPerRow) private var gridColumns = 2
@@ -67,8 +68,12 @@ struct GenresView: View {
         #if os(iOS)
         .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .automatic), prompt: "Search Genres")
         #else
-        .searchable(text: $searchText, prompt: "Search Genres")
+        .searchable(text: $searchText, isPresented: $searchIsActive, prompt: "Search Genres")
         #endif
+        .onReceive(NotificationCenter.default.publisher(for: .focusSearchBar)) { _ in
+            searchIsActive = false
+            DispatchQueue.main.async { searchIsActive = true }
+        }
         #if os(iOS)
         .navigationBarTitleDisplayMode(.large)
         #endif

--- a/Vibrdrome/Features/Library/SidebarContentView.swift
+++ b/Vibrdrome/Features/Library/SidebarContentView.swift
@@ -210,6 +210,9 @@ struct SidebarContentView: View {
                 break
             }
         }
+        .onReceive(NotificationCenter.default.publisher(for: .navigateToSearch)) { _ in
+            selectionRaw = SidebarItem.search.rawValue
+        }
     }
 
     var body: some View {

--- a/Vibrdrome/Features/Library/SongsView.swift
+++ b/Vibrdrome/Features/Library/SongsView.swift
@@ -7,6 +7,7 @@ struct SongsView: View {
     @State private var isLoading = true
     @State private var hasMore = false
     @State private var searchText = ""
+    @State private var searchIsActive = false
     @State private var searchResults: [Song] = []
     @State private var isSearching = false
     @State private var availableGenres: [String] = []
@@ -89,8 +90,12 @@ struct SongsView: View {
         #if os(iOS)
         .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .automatic), prompt: "Search songs")
         #else
-        .searchable(text: $searchText, prompt: "Search songs")
+        .searchable(text: $searchText, isPresented: $searchIsActive, prompt: "Search songs")
         #endif
+        .onReceive(NotificationCenter.default.publisher(for: .focusSearchBar)) { _ in
+            searchIsActive = false
+            DispatchQueue.main.async { searchIsActive = true }
+        }
         .onChange(of: searchText) { _, query in
             guard query.count >= 2 else {
                 searchResults = []

--- a/Vibrdrome/Features/Playlists/PlaylistsView.swift
+++ b/Vibrdrome/Features/Playlists/PlaylistsView.swift
@@ -11,6 +11,7 @@ struct PlaylistsView: View {
     @AppStorage("playlistViewStyle") private var showAsList = false
     @AppStorage(UserDefaultsKeys.gridColumnsPerRow) private var gridColumns = 2
     @State private var searchText = ""
+    @State private var searchIsActive = false
     @State private var sortBy: PlaylistSortOption = .name
 
     enum PlaylistSortOption: String, CaseIterable {
@@ -70,8 +71,12 @@ struct PlaylistsView: View {
         #if os(iOS)
         .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .always), prompt: "Search Playlists")
         #else
-        .searchable(text: $searchText, prompt: "Search Playlists")
+        .searchable(text: $searchText, isPresented: $searchIsActive, prompt: "Search Playlists")
         #endif
+        .onReceive(NotificationCenter.default.publisher(for: .focusSearchBar)) { _ in
+            searchIsActive = false
+            DispatchQueue.main.async { searchIsActive = true }
+        }
         #if os(iOS)
         .navigationBarTitleDisplayMode(.inline)
         #endif

--- a/Vibrdrome/Features/Radio/RadioView.swift
+++ b/Vibrdrome/Features/Radio/RadioView.swift
@@ -7,6 +7,7 @@ struct RadioView: View {
     @State private var isLoading = true
     @State private var error: String?
     @State private var searchText = ""
+    @State private var searchIsActive = false
     @State private var showAddSheet = false
     @State private var showSearchSheet = false
     @AppStorage("radioViewStyle") private var showAsList = false
@@ -98,7 +99,15 @@ struct RadioView: View {
             #endif
         }
         .navigationTitle("Radio")
+        #if os(macOS)
+        .searchable(text: $searchText, isPresented: $searchIsActive, prompt: "Filter stations...")
+        #else
         .searchable(text: $searchText, prompt: "Filter stations...")
+        #endif
+        .onReceive(NotificationCenter.default.publisher(for: .focusSearchBar)) { _ in
+            searchIsActive = false
+            DispatchQueue.main.async { searchIsActive = true }
+        }
         #if os(iOS)
         .toolbar {
             ToolbarItem(placement: .automatic) {

--- a/Vibrdrome/Features/Search/SearchView.swift
+++ b/Vibrdrome/Features/Search/SearchView.swift
@@ -58,10 +58,6 @@ struct SearchView: View {
             searchIsActive = false
             DispatchQueue.main.async { searchIsActive = true }
         }
-        .onReceive(NotificationCenter.default.publisher(for: .navigateToSearch)) { _ in
-            searchIsActive = false
-            DispatchQueue.main.async { searchIsActive = true }
-        }
         .onSubmit(of: .search) {
             saveRecentSearch(query)
         }

--- a/Vibrdrome/Features/Search/SearchView.swift
+++ b/Vibrdrome/Features/Search/SearchView.swift
@@ -54,6 +54,14 @@ struct SearchView: View {
                 searchIsActive = true
             }
         }
+        .onReceive(NotificationCenter.default.publisher(for: .focusSearchBar)) { _ in
+            searchIsActive = false
+            DispatchQueue.main.async { searchIsActive = true }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .navigateToSearch)) { _ in
+            searchIsActive = false
+            DispatchQueue.main.async { searchIsActive = true }
+        }
         .onSubmit(of: .search) {
             saveRecentSearch(query)
         }

--- a/Vibrdrome/Vibrdrome.swift
+++ b/Vibrdrome/Vibrdrome.swift
@@ -42,8 +42,7 @@ class VibrdromeMacDelegate: NSObject, NSApplicationDelegate {
 
         // Intercept CMD+F before AppKit's responder chain (performFindPanelAction:) claims it
         eventMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
-            guard event.modifierFlags.contains(.command),
-                  event.modifierFlags.isDisjoint(with: [.shift, .option, .control]),
+            guard event.modifierFlags.intersection(.deviceIndependentFlagsMask) == .command,
                   event.charactersIgnoringModifiers == "f" else {
                 return event
             }

--- a/Vibrdrome/Vibrdrome.swift
+++ b/Vibrdrome/Vibrdrome.swift
@@ -19,6 +19,8 @@ class VibrdromeAppDelegate: NSObject, UIApplicationDelegate {
 }
 #elseif os(macOS)
 class VibrdromeMacDelegate: NSObject, NSApplicationDelegate {
+    private var eventMonitor: Any?
+
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
         true
     }
@@ -36,6 +38,23 @@ class VibrdromeMacDelegate: NSObject, NSApplicationDelegate {
                 app.activate()
             }
             NSApp.terminate(nil)
+        }
+
+        // Intercept CMD+F before AppKit's responder chain (performFindPanelAction:) claims it
+        eventMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+            guard event.modifierFlags.contains(.command),
+                  event.modifierFlags.isDisjoint(with: [.shift, .option, .control]),
+                  event.charactersIgnoringModifiers == "f" else {
+                return event
+            }
+            NotificationCenter.default.post(name: .focusSearchBar, object: nil)
+            return nil
+        }
+    }
+
+    func applicationWillTerminate(_ notification: Notification) {
+        if let monitor = eventMonitor {
+            NSEvent.removeMonitor(monitor)
         }
     }
 }
@@ -146,6 +165,17 @@ struct VibrdromeApp: App {
         .commands {
             CommandMenu("Playback") {
                 PlaybackCommands()
+            }
+            CommandMenu("Navigate") {
+                Button("Go to Search") {
+                    NotificationCenter.default.post(name: .navigateToSearch, object: nil)
+                }
+                .keyboardShortcut("k", modifiers: .command)
+
+                Button("Focus Search") {
+                    NotificationCenter.default.post(name: .focusSearchBar, object: nil)
+                }
+                .keyboardShortcut("f", modifiers: .command)
             }
         }
         #endif


### PR DESCRIPTION
- CMD+K navigates to the Search sidebar tab and focuses the search bar
- CMD+F focuses the search bar in whatever view is currently visible
- NSEvent local monitor intercepts CMD+F before AppKit's performFindPanelAction:
- All searchable views (Artists, Albums, Songs, Favorites, Genres, Playlists, Radio, Search) respond to focusSearchBar notification
- CommandMenu("Navigate") added for menu bar discoverability

## Summary

<!-- What does this PR do? 1-3 bullet points. -->

## Related Issues

<!-- Link issues: Fixes #123, Closes #456 -->

## Checklist

- [ ] Branched from `develop`, PR targets `develop`
- [ ] `swiftlint` passes with 0 violations
- [ ] iOS builds with 0 warnings
- [ ] macOS builds with 0 warnings
- [ ] watchOS builds with 0 warnings
- [ ] Unit tests pass
- [ ] New UserDefaults keys added to `UserDefaultsKeys.swift`
- [ ] Accessibility labels added to new interactive elements
- [ ] No force unwraps on external data
- [ ] Tested on device or simulator

## Screenshots (if UI changes)

<!-- Attach before/after screenshots if applicable -->
