### PR TITLE
Fix queue system, landscape player, grid scaling, context menus

### DIFF
--- a/Vibrdrome/Core/Audio/AudioEngine+Playback.swift
+++ b/Vibrdrome/Core/Audio/AudioEngine+Playback.swift
@@ -31,13 +31,12 @@ extension AudioEngine {
             return
         }
 
-        submitScrobbleIfNeeded()
+        // Ensure audio session is active (may have been deactivated since app launch)
+        #if os(iOS)
+        try? AVAudioSession.sharedInstance().setActive(true)
+        #endif
 
-        // Record outgoing song in play history (only if it actually played)
-        if let outgoing = currentSong, outgoing.id != song.id {
-            playHistory.append(outgoing)
-            if playHistory.count > 50 { playHistory.removeFirst() }
-        }
+        submitScrobbleIfNeeded()
 
         // Clear history when loading a brand new queue
         if newQueue != nil {
@@ -458,6 +457,8 @@ extension AudioEngine {
 
     func handleTrackEnd() {
         SleepTimer.shared.trackDidEnd()
+        // Record the outgoing song (it reached its end)
+        if let current = currentSong { recordSongAsPlayed(current) }
         if !isPlaying { return }
 
         switch repeatMode {
@@ -502,12 +503,8 @@ extension AudioEngine {
 
     func handleAutoAdvance() {
         submitScrobbleIfNeeded()
-
-        // Record outgoing song in play history
-        if let outgoing = currentSong {
-            playHistory.append(outgoing)
-            if playHistory.count > 50 { playHistory.removeFirst() }
-        }
+        // Explicitly record the outgoing song (it fully played to completion)
+        if let current = currentSong { recordSongAsPlayed(current) }
 
         guard let nextIndex = lookaheadIndex, nextIndex < queue.count else {
             playbackLog.warning("Auto-advance but no valid lookahead index")
@@ -549,11 +546,20 @@ extension AudioEngine {
     /// Unlike play(song:from:at:), this preserves the full queue intact.
     func skipToIndex(_ index: Int) {
         guard index >= 0, index < queue.count else { return }
-        // Record outgoing song in play history
-        if let outgoing = currentSong {
-            playHistory.append(outgoing)
-            if playHistory.count > 50 { playHistory.removeFirst() }
+        if isUITesting {
+            currentIndex = index
+            currentSong = queue[index]
+            return
         }
+
+        submitScrobbleIfNeeded()
+
+        if isCrossfading {
+            incrementGeneration()
+            crossfadeController.forceComplete()
+            isCrossfading = false
+        }
+
         let song = queue[index]
         currentIndex = index
         currentSong = song
@@ -565,10 +571,20 @@ extension AudioEngine {
         duration = 0
 
         let url = resolveURL(for: song)
-        replacePlayerItem(with: url)
-        activePlayer?.play()
-        isPlaying = true
+        currentReplayGainFactor = computeReplayGainFactor(for: song)
 
+        switch activeMode {
+        case .gapless:
+            replacePlayerItem(with: url)
+            applyEffectiveVolume()
+            gaplessPlayer?.rate = playbackRate
+            prepareLookahead()
+        case .crossfade:
+            startCrossfadePlayback(url: url)
+            applyEffectiveVolume()
+        }
+
+        isPlaying = true
         NowPlayingManager.shared.update(song: song, isPlaying: true)
         scrobbleNowPlaying(songId: song.id)
     }

--- a/Vibrdrome/Core/Audio/AudioEngine+Queue.swift
+++ b/Vibrdrome/Core/Audio/AudioEngine+Queue.swift
@@ -9,14 +9,18 @@ extension AudioEngine {
         return Array(queue[(currentIndex + 1)...])
     }
 
-    /// Songs played before the current track (most recent first, max 20).
-    /// Uses actual play history if available, falls back to queue position.
+    /// Songs actually played before the current track (most recent first, max 20).
     var recentlyPlayed: [Song] {
-        if !playHistory.isEmpty {
-            return Array(playHistory.reversed().prefix(20))
-        }
-        guard currentIndex > 0 else { return [] }
-        return Array(queue[0..<currentIndex].reversed().prefix(20))
+        Array(playHistory.reversed().prefix(20))
+    }
+
+    /// All queue tracks except the currently playing one, with absolute queue indices.
+    /// Used by QueueView and SidePanels for full-queue display.
+    var queueEntries: [(index: Int, song: Song)] {
+        guard !queue.isEmpty else { return [] }
+        return queue.enumerated()
+            .filter { $0.offset != currentIndex }
+            .map { (index: $0.offset, song: $0.element) }
     }
 
     func addToQueue(_ song: Song) {
@@ -42,18 +46,38 @@ extension AudioEngine {
         if activeMode == .gapless { prepareLookahead() }
     }
 
-    func removeFromQueue(at index: Int) {
-        let absoluteIndex = currentIndex + 1 + index
-        guard absoluteIndex > currentIndex, absoluteIndex < queue.count else { return }
-        queue.remove(at: absoluteIndex)
-        if index == 0 && activeMode == .gapless { prepareLookahead() }
+    /// Remove a track from the queue by its absolute queue index.
+    func removeFromQueue(atAbsolute index: Int) {
+        guard index >= 0, index < queue.count, index != currentIndex else { return }
+        queue.remove(at: index)
+        if index < currentIndex { currentIndex -= 1 }
+        if activeMode == .gapless { prepareLookahead() }
     }
 
+    /// Reorder tracks within the queue display (all tracks except currently playing).
+    /// Source/destination are relative to `queueEntries` (the all-except-current array).
     func moveInQueue(from source: IndexSet, to destination: Int) {
-        guard currentIndex + 1 < queue.count else { return }
-        var upNextSlice = Array(queue[(currentIndex + 1)...])
-        upNextSlice.move(fromOffsets: source, toOffset: destination)
-        queue.replaceSubrange((currentIndex + 1)..., with: upNextSlice)
+        guard queue.count > 1 else { return }
+        let savedSong = queue[currentIndex]
+        let afterCurrentId: String? = currentIndex + 1 < queue.count
+            ? queue[currentIndex + 1].id : nil
+
+        var items = Array(queue)
+        items.remove(at: currentIndex)
+        items.move(fromOffsets: source, toOffset: destination)
+
+        // Reinsert current song right before the track that was originally after it
+        let insertAt: Int
+        if let afterId = afterCurrentId,
+           let pos = items.firstIndex(where: { $0.id == afterId }) {
+            insertAt = pos
+        } else {
+            insertAt = items.count
+        }
+        items.insert(savedSong, at: insertAt)
+
+        queue = items
+        currentIndex = insertAt
         if activeMode == .gapless { prepareLookahead() }
     }
 

--- a/Vibrdrome/Core/Audio/AudioEngine.swift
+++ b/Vibrdrome/Core/Audio/AudioEngine.swift
@@ -29,7 +29,13 @@ final class AudioEngine {
     // MARK: - State
 
     var isPlaying = false
-    var currentSong: Song?
+    var currentSong: Song? {
+        didSet {
+            if let old = oldValue, old.id != currentSong?.id {
+                recordSongIfPlayed(old)
+            }
+        }
+    }
     var currentRadioStation: InternetRadioStation?
     var currentTime: TimeInterval = 0
     var duration: TimeInterval = 0
@@ -152,6 +158,30 @@ final class AudioEngine {
     func resetScrobbleState() { scrobbleSubmitted = false; trackStartTime = Date() }
     func markScrobbleSubmitted() { scrobbleSubmitted = true; lastScrobbleTime = Date() }
     var hasLookahead: Bool { lookaheadItem != nil }
+
+    // MARK: - Play History Helpers
+
+    /// Record a song only if it was listened to meaningfully (>30s or >30% of duration).
+    /// Used by the currentSong didSet for manual skips/taps.
+    func recordSongIfPlayed(_ song: Song) {
+        let dominated = duration > 0 ? currentTime > duration * 0.3 : currentTime > 30
+        guard dominated || currentTime > 30 else { return }
+        guard playHistory.last?.id != song.id else { return }
+        var updated = playHistory
+        updated.append(song)
+        if updated.count > 50 { updated.removeFirst() }
+        playHistory = updated
+    }
+
+    /// Force-record a song in play history (track played to completion).
+    /// Used by handleAutoAdvance/handleTrackEnd where we know it fully played.
+    func recordSongAsPlayed(_ song: Song) {
+        guard playHistory.last?.id != song.id else { return }
+        var updated = playHistory
+        updated.append(song)
+        if updated.count > 50 { updated.removeFirst() }
+        playHistory = updated
+    }
 
     // Observer accessor methods for extensions
     func removeCurrentTimeObserver() {

--- a/Vibrdrome/Features/Library/AlbumDetailView.swift
+++ b/Vibrdrome/Features/Library/AlbumDetailView.swift
@@ -50,36 +50,7 @@ struct AlbumDetailView: View {
                                 .background(.ultraThinMaterial)
                             }
 
-                            HStack(spacing: 0) {
-                                if isSelecting {
-                                    Button {
-                                        toggleSelection(song.id)
-                                    } label: {
-                                        Image(systemName: selectedSongs.contains(song.id)
-                                              ? "checkmark.circle.fill" : "circle")
-                                            .foregroundStyle(selectedSongs.contains(song.id)
-                                                             ? Color.accentColor : .secondary)
-                                            .font(.title3)
-                                    }
-                                    .buttonStyle(.plain)
-                                    .padding(.leading, 16)
-                                    .padding(.trailing, 4)
-                                }
-
-                                TrackRow(song: song, showTrackNumber: true)
-                                    .padding(.horizontal, isSelecting ? 8 : 16)
-                                    .padding(.vertical, 8)
-                                    .contentShape(Rectangle())
-                                    .onTapGesture {
-                                        if isSelecting {
-                                            toggleSelection(song.id)
-                                        } else {
-                                            AudioEngine.shared.play(song: song, from: songs, at: index)
-                                        }
-                                    }
-                                    .accessibilityIdentifier("trackRow_\(index)")
-                                    .trackContextMenu(song: song, queue: songs, index: index)
-                            }
+                            trackRowContainer(song: song, songs: songs, index: index)
                             Divider()
                                 .padding(.leading, isSelecting ? 72 : 56)
                         }
@@ -469,6 +440,46 @@ struct AlbumDetailView: View {
         .disabled(album.song?.isEmpty ?? true)
         .accessibilityLabel("More Options")
         .accessibilityIdentifier("albumMoreButton")
+    }
+
+    @ViewBuilder
+    private func trackRowContainer(song: Song, songs: [Song], index: Int) -> some View {
+        #if os(iOS)
+        let bg = Color(.systemBackground)
+        #else
+        let bg = Color(.windowBackgroundColor)
+        #endif
+        HStack(spacing: 0) {
+            if isSelecting {
+                Button {
+                    toggleSelection(song.id)
+                } label: {
+                    Image(systemName: selectedSongs.contains(song.id)
+                          ? "checkmark.circle.fill" : "circle")
+                        .foregroundStyle(selectedSongs.contains(song.id)
+                                         ? Color.accentColor : .secondary)
+                        .font(.title3)
+                }
+                .buttonStyle(.plain)
+                .padding(.leading, 16)
+                .padding(.trailing, 4)
+            }
+
+            TrackRow(song: song, showTrackNumber: true)
+                .padding(.horizontal, isSelecting ? 8 : 16)
+                .padding(.vertical, 8)
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    if isSelecting {
+                        toggleSelection(song.id)
+                    } else {
+                        AudioEngine.shared.play(song: song, from: songs, at: index)
+                    }
+                }
+                .accessibilityIdentifier("trackRow_\(index)")
+                .trackContextMenu(song: song, queue: songs, index: index)
+        }
+        .background(bg)
     }
 
     @ViewBuilder

--- a/Vibrdrome/Features/Library/AlbumsView.swift
+++ b/Vibrdrome/Features/Library/AlbumsView.swift
@@ -215,9 +215,11 @@ struct AlbumsView: View {
 
     private func albumGridCard(_ album: Album) -> some View {
         VStack(alignment: .leading, spacing: 6) {
-            AlbumArtView(coverArtId: album.coverArt, size: Theme.albumCardSize, cornerRadius: 10)
-                .frame(maxWidth: .infinity)
-                .shadow(color: .black.opacity(0.15), radius: 6, y: 3)
+            GeometryReader { geo in
+                AlbumArtView(coverArtId: album.coverArt, size: geo.size.width, cornerRadius: 10)
+            }
+            .aspectRatio(1, contentMode: .fit)
+            .shadow(color: .black.opacity(0.15), radius: 6, y: 3)
 
             Text(album.name)
                 .font(.subheadline)

--- a/Vibrdrome/Features/Library/ArtistsView.swift
+++ b/Vibrdrome/Features/Library/ArtistsView.swift
@@ -228,11 +228,16 @@ struct ArtistsView: View {
 
     private func artistGridCard(_ artist: Artist) -> some View {
         VStack(spacing: 8) {
-            AlbumArtView(
-                coverArtId: artist.coverArt,
-                size: Theme.artistBubbleSize,
-                cornerRadius: Theme.artistBubbleSize / 2
-            )
+            GeometryReader { geo in
+                let artSize = min(geo.size.width, geo.size.height)
+                AlbumArtView(
+                    coverArtId: artist.coverArt,
+                    size: artSize,
+                    cornerRadius: artSize / 2
+                )
+                .frame(maxWidth: .infinity)
+            }
+            .aspectRatio(1, contentMode: .fit)
             .shadow(color: .black.opacity(0.15), radius: 6, y: 3)
 
             Text(artist.name)

--- a/Vibrdrome/Features/Library/GenresView.swift
+++ b/Vibrdrome/Features/Library/GenresView.swift
@@ -170,12 +170,14 @@ struct GenresView: View {
 
     private func genreCard(_ genre: Genre) -> some View {
         VStack(alignment: .leading, spacing: 8) {
-            AlbumArtView(
-                coverArtId: genreArt[genre.value],
-                size: Theme.albumCardSize,
-                cornerRadius: 10
-            )
-            .frame(maxWidth: .infinity)
+            GeometryReader { geo in
+                AlbumArtView(
+                    coverArtId: genreArt[genre.value],
+                    size: geo.size.width,
+                    cornerRadius: 10
+                )
+            }
+            .aspectRatio(1, contentMode: .fit)
             .shadow(color: .black.opacity(0.15), radius: 6, y: 3)
 
             Text(genre.value)

--- a/Vibrdrome/Features/Library/SongsView.swift
+++ b/Vibrdrome/Features/Library/SongsView.swift
@@ -461,9 +461,11 @@ struct SongsView: View {
 
     private func songCard(_ song: Song) -> some View {
         VStack(alignment: .leading, spacing: 6) {
-            AlbumArtView(coverArtId: song.coverArt, size: 160, cornerRadius: 10)
-                .frame(maxWidth: .infinity)
-                .shadow(color: .black.opacity(0.15), radius: 6, y: 3)
+            GeometryReader { geo in
+                AlbumArtView(coverArtId: song.coverArt, size: geo.size.width, cornerRadius: 10)
+            }
+            .aspectRatio(1, contentMode: .fit)
+            .shadow(color: .black.opacity(0.15), radius: 6, y: 3)
 
             Button {
                 appState.pendingNavigation = .song(id: song.id)

--- a/Vibrdrome/Features/Player/NowPlayingView.swift
+++ b/Vibrdrome/Features/Player/NowPlayingView.swift
@@ -236,47 +236,19 @@ struct NowPlayingView: View {
         }
         #else
         GeometryReader { geo in
+            let isLandscape = geo.size.width > geo.size.height
             let controlsNeeded: CGFloat = 460
             let maxArtFromWidth = geo.size.width - 60
             let maxArtFromHeight = geo.size.height - controlsNeeded
             let artSize = max(100, min(maxArtFromWidth, maxArtFromHeight))
 
-            VStack(spacing: 0) {
-                dismissHandle
-
-                Spacer(minLength: 4)
-
-                albumArt(size: artSize)
-
-                Spacer(minLength: 8)
-
-                iOSSongInfo
-                    .padding(.bottom, 10)
-
-                heartRow
-                    .padding(.bottom, 12)
-
-                progressSlider
-                    .padding(.bottom, 4)
-
-                if showAudioQualityInfo {
-                    streamingInfo
-                        .padding(.bottom, 16)
+            Group {
+                if isLandscape {
+                    iOSLandscapeLayout(geo: geo)
+                } else {
+                    iOSPortraitLayout(artSize: artSize, geo: geo)
                 }
-
-                iOSPlaybackRow
-                    .padding(.bottom, 16)
-
-                if showVolumeSlider {
-                    volumeSlider
-                        .padding(.bottom, 14)
-                }
-
-                bottomToolbar
-
-                Spacer(minLength: 6)
             }
-            .padding(.horizontal, 28)
             .frame(width: geo.size.width, height: geo.size.height)
             .background {
                 ZStack {
@@ -298,6 +270,83 @@ struct NowPlayingView: View {
         }
         #endif
     }
+
+    // MARK: - iOS Portrait Layout
+
+    #if os(iOS)
+    private func iOSPortraitLayout(artSize: CGFloat, geo: GeometryProxy) -> some View {
+        VStack(spacing: 0) {
+            dismissHandle
+
+            Spacer(minLength: 4)
+
+            albumArt(size: artSize)
+
+            Spacer(minLength: 8)
+
+            iOSSongInfo
+                .padding(.bottom, 10)
+
+            heartRow
+                .padding(.bottom, 12)
+
+            progressSlider
+                .padding(.bottom, 4)
+
+            if showAudioQualityInfo {
+                streamingInfo
+                    .padding(.bottom, 16)
+            }
+
+            iOSPlaybackRow
+                .padding(.bottom, 16)
+
+            if showVolumeSlider {
+                volumeSlider
+                    .padding(.bottom, 14)
+            }
+
+            bottomToolbar
+
+            Spacer(minLength: 6)
+        }
+        .padding(.horizontal, 28)
+    }
+
+    // MARK: - iOS Landscape Layout
+
+    private func iOSLandscapeLayout(geo: GeometryProxy) -> some View {
+        let artSize = min(geo.size.height - 40, geo.size.width * 0.4)
+
+        return HStack(spacing: 20) {
+            // Left: album art
+            VStack {
+                Spacer(minLength: 4)
+                albumArt(size: artSize)
+                Spacer(minLength: 4)
+            }
+
+            // Right: controls
+            VStack(spacing: 0) {
+                Spacer(minLength: 4)
+
+                iOSSongInfo
+                    .padding(.bottom, 8)
+
+                progressSlider
+                    .padding(.bottom, 4)
+
+                iOSPlaybackRow
+                    .padding(.bottom, 8)
+
+                bottomToolbar
+
+                Spacer(minLength: 4)
+            }
+        }
+        .padding(.horizontal, 20)
+    }
+    #endif
 
     // MARK: - Image Loading
 

--- a/Vibrdrome/Features/Player/QueueView.swift
+++ b/Vibrdrome/Features/Player/QueueView.swift
@@ -88,82 +88,51 @@ struct QueueView: View {
                     }
                 }
 
-                // Up next
-                let upNext = engine.upNext
-                if !upNext.isEmpty {
-                    let totalSeconds = upNext.compactMap(\.duration).reduce(0, +)
-                    Section("Up Next — \(upNext.count) songs · \(formatDuration(totalSeconds))") {
-                        ForEach(Array(upNext.enumerated()), id: \.element.id) { index, song in
+                // Queue (all tracks except currently playing)
+                let entries = engine.queueEntries
+                if !entries.isEmpty {
+                    let totalSeconds = entries.compactMap(\.song.duration).reduce(0, +)
+                    Section("Queue -- \(entries.count) songs -- \(formatDuration(totalSeconds))") {
+                        ForEach(Array(entries.enumerated()), id: \.element.song.id) { _, entry in
                             HStack(spacing: 12) {
-                                AlbumArtView(coverArtId: song.coverArt, size: 40)
+                                AlbumArtView(coverArtId: entry.song.coverArt, size: 40)
 
                                 VStack(alignment: .leading, spacing: 2) {
-                                    Button {
-                                        appState.pendingNavigation = .song(id: song.id)
-                                        dismiss()
-                                    } label: {
-                                        Text(song.title)
-                                            .font(.body)
-                                            .lineLimit(1)
-                                    }
-                                    .buttonStyle(.plain)
+                                    Text(entry.song.title)
+                                        .font(.body)
+                                        .lineLimit(1)
 
-                                    if let artist = song.artist {
-                                        Button {
-                                            if let artistId = song.artistId {
-                                                appState.pendingNavigation = .artist(id: artistId)
-                                                dismiss()
-                                            }
-                                        } label: {
-                                            Text(artist)
-                                                .font(.caption)
-                                                .foregroundStyle(.secondary)
-                                                .lineLimit(1)
-                                        }
-                                        .buttonStyle(.plain)
-                                        .disabled(song.artistId == nil)
+                                    if let artist = entry.song.artist {
+                                        Text(artist)
+                                            .font(.caption)
+                                            .foregroundStyle(.secondary)
+                                            .lineLimit(1)
                                     }
                                 }
 
                                 Spacer()
 
-                                if let duration = song.duration {
+                                if let duration = entry.song.duration {
                                     Text(formatDuration(duration))
                                         .font(.caption)
                                         .foregroundStyle(.tertiary)
                                         .monospacedDigit()
                                 }
                             }
+                            .opacity(entry.index < engine.currentIndex ? 0.5 : 1.0)
                             .contentShape(Rectangle())
                             .onTapGesture {
                                 #if os(iOS)
                                 Haptics.light()
                                 #endif
-                                let absoluteIndex = engine.currentIndex + 1 + index
-                                engine.play(song: song, from: engine.queue, at: absoluteIndex)
+                                engine.skipToIndex(entry.index)
                             }
-                            .contextMenu {
-                                Button {
-                                    let absoluteIndex = engine.currentIndex + 1 + index
-                                    engine.play(song: song, from: engine.queue, at: absoluteIndex)
-                                } label: {
-                                    Label("Play Now", systemImage: "play.fill")
-                                }
-                                Button {
-                                    engine.addToQueueNext(song)
-                                } label: {
-                                    Label("Play Next", systemImage: "text.line.first.and.arrowtriangle.forward")
-                                }
-                                Divider()
-                                Button(role: .destructive) {
-                                    engine.removeFromQueue(at: index)
-                                } label: {
-                                    Label("Remove from Queue", systemImage: "minus.circle")
-                                }
+                            .trackContextMenu(song: entry.song) {
+                                engine.removeFromQueue(atAbsolute: entry.index)
                             }
                             .swipeActions(edge: .trailing, allowsFullSwipe: true) {
                                 Button(role: .destructive) {
-                                    engine.removeFromQueue(at: index)
+                                    engine.removeFromQueue(atAbsolute: entry.index)
                                 } label: {
                                     Label("Remove", systemImage: "trash")
                                 }

--- a/Vibrdrome/Features/Player/SidePanels.swift
+++ b/Vibrdrome/Features/Player/SidePanels.swift
@@ -55,11 +55,11 @@ struct QueuePanelView: View {
                     }
                 }
 
-                let upNext = engine.upNext
-                if !upNext.isEmpty {
-                    Section("Up Next — \(upNext.count) songs") {
-                        ForEach(Array(upNext.enumerated()), id: \.element.id) { index, song in
-                            upNextRow(song, index: index)
+                let entries = engine.queueEntries
+                if !entries.isEmpty {
+                    Section("Queue -- \(entries.count) songs") {
+                        ForEach(Array(entries.enumerated()), id: \.element.song.id) { _, entry in
+                            queueRow(entry)
                         }
                     }
                 }
@@ -112,21 +112,21 @@ struct QueuePanelView: View {
         }
     }
 
-    private func upNextRow(_ song: Song, index: Int) -> some View {
+    private func queueRow(_ entry: (index: Int, song: Song)) -> some View {
         HStack(spacing: 12) {
-            AlbumArtView(coverArtId: song.coverArt, size: 40)
+            AlbumArtView(coverArtId: entry.song.coverArt, size: 40)
             VStack(alignment: .leading, spacing: 2) {
                 Button {
-                    appState.pendingNavigation = .song(id: song.id)
+                    appState.pendingNavigation = .song(id: entry.song.id)
                 } label: {
-                    Text(song.title)
+                    Text(entry.song.title)
                         .font(.body)
                         .lineLimit(1)
                 }
                 .buttonStyle(.plain)
-                if let artist = song.artist {
+                if let artist = entry.song.artist {
                     Button {
-                        if let artistId = song.artistId {
+                        if let artistId = entry.song.artistId {
                             appState.pendingNavigation = .artist(id: artistId)
                         }
                     } label: {
@@ -136,31 +136,30 @@ struct QueuePanelView: View {
                             .lineLimit(1)
                     }
                     .buttonStyle(.plain)
-                    .disabled(song.artistId == nil)
+                    .disabled(entry.song.artistId == nil)
                 }
             }
             Spacer()
-            if let duration = song.duration {
+            if let duration = entry.song.duration {
                 Text(formatDuration(duration))
                     .font(.caption)
                     .foregroundStyle(.tertiary)
                     .monospacedDigit()
             }
         }
+        .opacity(entry.index < engine.currentIndex ? 0.5 : 1.0)
         .contentShape(Rectangle())
         .onTapGesture {
-            let absoluteIndex = engine.currentIndex + 1 + index
-            engine.play(song: song, from: engine.queue, at: absoluteIndex)
+            engine.skipToIndex(entry.index)
         }
         .contextMenu {
             Button {
-                let absoluteIndex = engine.currentIndex + 1 + index
-                engine.play(song: song, from: engine.queue, at: absoluteIndex)
+                engine.skipToIndex(entry.index)
             } label: {
                 Label("Play Now", systemImage: "play.fill")
             }
             Button(role: .destructive) {
-                engine.removeFromQueue(at: index)
+                engine.removeFromQueue(atAbsolute: entry.index)
             } label: {
                 Label("Remove from Queue", systemImage: "minus.circle")
             }

--- a/Vibrdrome/Shared/Components/TrackContextMenu.swift
+++ b/Vibrdrome/Shared/Components/TrackContextMenu.swift
@@ -5,6 +5,7 @@ struct TrackContextMenuModifier: ViewModifier {
     let song: Song
     var queue: [Song]?
     var index: Int?
+    var onRemove: (() -> Void)?
 
     @Environment(AppState.self) private var appState
     @State private var showAddToPlaylist = false
@@ -27,6 +28,14 @@ struct TrackContextMenuModifier: ViewModifier {
         jukeboxActions
         Divider()
         navigationActions
+        if let onRemove {
+            Divider()
+            Button(role: .destructive) {
+                onRemove()
+            } label: {
+                Label("Remove from Queue", systemImage: "minus.circle")
+            }
+        }
     }
 
     @ViewBuilder
@@ -158,5 +167,12 @@ struct TrackContextMenuModifier: ViewModifier {
 extension View {
     func trackContextMenu(song: Song, queue: [Song]? = nil, index: Int? = nil) -> some View {
         modifier(TrackContextMenuModifier(song: song, queue: queue, index: index))
+    }
+
+    func trackContextMenu(
+        song: Song, queue: [Song]? = nil, index: Int? = nil,
+        onRemove: @escaping () -> Void
+    ) -> some View {
+        modifier(TrackContextMenuModifier(song: song, queue: queue, index: index, onRemove: onRemove))
     }
 }

--- a/VibrdromeTests/Core/QueueEdgeCaseTests.swift
+++ b/VibrdromeTests/Core/QueueEdgeCaseTests.swift
@@ -67,13 +67,13 @@ struct QueueEdgeCaseTests {
         #expect(engine.upNext.isEmpty)
     }
 
-    // MARK: - removeFromQueue
+    // MARK: - removeFromQueue (absolute index)
 
     @Test func removeFromQueueRemovesCorrectSong() {
         let engine = AudioEngine.shared
         engine.queue = [makeSong(id: "a"), makeSong(id: "b"), makeSong(id: "c")]
         engine.currentIndex = 0
-        engine.removeFromQueue(at: 0) // removes "b" (first in upNext)
+        engine.removeFromQueue(atAbsolute: 1) // removes "b"
         #expect(engine.queue.count == 2)
         #expect(engine.queue[1].id == "c")
     }
@@ -82,9 +82,47 @@ struct QueueEdgeCaseTests {
         let engine = AudioEngine.shared
         engine.queue = [makeSong(id: "a"), makeSong(id: "b")]
         engine.currentIndex = 0
-        // Try to remove at index -1 (before current) — should be guarded
-        engine.removeFromQueue(at: -1)
+        engine.removeFromQueue(atAbsolute: 0) // tries to remove current — guarded
         #expect(engine.queue.count == 2) // unchanged
+    }
+
+    @Test func removeFromQueueAdjustsCurrentIndex() {
+        let engine = AudioEngine.shared
+        engine.queue = [makeSong(id: "a"), makeSong(id: "b"), makeSong(id: "c"), makeSong(id: "d")]
+        engine.currentIndex = 2 // "c" is current
+        engine.removeFromQueue(atAbsolute: 0) // remove "a" (before current)
+        #expect(engine.queue.count == 3)
+        #expect(engine.currentIndex == 1) // adjusted down
+        #expect(engine.queue[engine.currentIndex].id == "c") // still playing "c"
+    }
+
+    // MARK: - queueEntries
+
+    @Test func queueEntriesExcludesCurrent() {
+        let engine = AudioEngine.shared
+        engine.queue = [makeSong(id: "a"), makeSong(id: "b"), makeSong(id: "c")]
+        engine.currentIndex = 1
+        let entries = engine.queueEntries
+        #expect(entries.count == 2)
+        #expect(entries[0].song.id == "a")
+        #expect(entries[0].index == 0)
+        #expect(entries[1].song.id == "c")
+        #expect(entries[1].index == 2)
+    }
+
+    @Test func queueEntriesAfterSkipShowsAllTracks() {
+        let engine = AudioEngine.shared
+        engine.queue = [
+            makeSong(id: "a"), makeSong(id: "b"), makeSong(id: "c"),
+            makeSong(id: "d"), makeSong(id: "e"),
+        ]
+        engine.currentIndex = 3 // skip to "d"
+        let entries = engine.queueEntries
+        #expect(entries.count == 4) // all except "d"
+        #expect(entries[0].song.id == "a")
+        #expect(entries[1].song.id == "b")
+        #expect(entries[2].song.id == "c")
+        #expect(entries[3].song.id == "e")
     }
 
     // MARK: - moveInQueue
@@ -93,11 +131,29 @@ struct QueueEdgeCaseTests {
         let engine = AudioEngine.shared
         engine.queue = [makeSong(id: "a"), makeSong(id: "b"), makeSong(id: "c"), makeSong(id: "d")]
         engine.currentIndex = 0
-        // Move "b" (index 0 in upNext) to end (index 2 in upNext)
+        // queueEntries = [(1,b), (2,c), (3,d)]
+        // Move "b" (index 0 in entries) to end (index 3 in entries)
         engine.moveInQueue(from: IndexSet(integer: 0), to: 3)
-        #expect(engine.queue[1].id == "c")
-        #expect(engine.queue[2].id == "d")
-        #expect(engine.queue[3].id == "b")
+        // After move of entries: [c, d, b]
+        // Reinsert "a" before "b" (was after "a" originally)
+        #expect(engine.queue[engine.currentIndex].id == "a") // still playing "a"
+        // After "a", "b" should still be next (reinsert logic)
+        #expect(engine.queue[engine.currentIndex + 1].id == "b")
+    }
+
+    @Test func moveInQueuePreservesCurrentSong() {
+        let engine = AudioEngine.shared
+        engine.queue = [
+            makeSong(id: "a"), makeSong(id: "b"), makeSong(id: "c"),
+            makeSong(id: "d"), makeSong(id: "e"),
+        ]
+        engine.currentIndex = 2 // "c" is playing, next is "d"
+        // queueEntries = [(0,a), (1,b), (3,d), (4,e)]
+        // Move "a" (index 0 in entries) to after "e" (destination 4)
+        engine.moveInQueue(from: IndexSet(integer: 0), to: 4)
+        #expect(engine.queue[engine.currentIndex].id == "c") // still playing "c"
+        // "d" should still be next after "c"
+        #expect(engine.queue[engine.currentIndex + 1].id == "d")
     }
 
     // MARK: - skipToIndex


### PR DESCRIPTION
## Summary
- **Queue system overhaul**: full queue display (all tracks visible, passed-over tracks dimmed), play history correctly records gapless auto-advance and filters brief skips, skipToIndex fully sets up playback (ReplayGain, volume, rate, lookahead)
- **Now Playing landscape layout**: album art left, controls right, auto-switches on rotation
- **Grid art scaling**: responsive to column count (2/3/4) instead of fixed 160pt
- **Context menus**: full track menu on queue rows with Remove from Queue, opaque row background for album detail context menu preview
- **Cold-start fix**: audio session activated on play() for first-launch reliability
- **SidePanels fix**: uses skipToIndex instead of play(from:) which was clearing history

## Test plan
- [ ] Play album, let 3+ tracks auto-advance -- all appear in Recently Played
- [ ] Skip after 5s -- does NOT appear in Recently Played
- [ ] Skip after 60s -- appears in Recently Played
- [ ] Tap track 8 in queue -- plays, tracks above dimmed, tracks below full opacity
- [ ] After track 8 finishes -- track 9 plays
- [ ] Tap dimmed/passed track -- plays, queue intact
- [ ] Queue: swipe-remove, drag-reorder, clear all work
- [ ] Landscape Now Playing layout correct on iPhone and iPad
- [ ] Grid columns 3/4 -- art scales, no overlap
- [ ] Long-press album track -- no text bleed-through
- [ ] Queue long-press -- full context menu with Remove from Queue
- [ ] Kill app, relaunch, play album -- audio plays on first tap
- [ ] macOS build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)