### PR TITLE
Build 44: Queue overhaul, landscape player, watch art, auto-suggest toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,24 @@ All notable changes to Vibrdrome (iOS/macOS) are documented here.
 
 ## v1.0.0
 
-### Build 43 — April 15, 2026
+### Build 44 -- April 16, 2026
+- Queue overhaul: all tracks visible (passed-over tracks dimmed), tap plays without hiding others
+- Recently Played: records gapless auto-advance, filters brief skips (<30s or <30%)
+- Now Playing landscape layout (art left, controls right, auto-rotates)
+- Grid art scales to column count (3/4 columns no longer overlap)
+- Queue context menu: full track menu with Remove from Queue
+- Album detail: opaque row background for context menu preview
+- Watch album art: arrives with metadata (no stale art on track change)
+- Auto-Suggest toggle in Settings > Player (on by default)
+- Cold-start audio session fix (first play after fresh launch)
+- 536 unit tests in 40 suites
+
+**TestFlight Notes:**
+> Queue fixed: tap plays without hiding tracks, all tracks stay visible.
+> Landscape Now Playing layout. Grid columns scale properly. Watch art
+> refreshes on track change. Auto-Suggest toggle added.
+
+### Build 43 -- April 15, 2026
 - Lossless badge in Now Playing for FLAC/ALAC/WAV/AIFF (toggleable in Settings > Player)
 - Your Top Artists carousel on Home with album art from play history
 - Search tab auto-focuses keyboard on open

--- a/TESTING.md
+++ b/TESTING.md
@@ -72,6 +72,7 @@ Run through this checklist before every TestFlight build. Each item should be ve
 - [ ] Settings gear opens Quick Settings sheet
 - [ ] Quick Settings: sleep timer, speed, crossfade, download, share all work
 - [ ] Sleep timer: no volume pop on expire (smooth volume fade to silence)
+- [ ] Landscape layout: art left, controls right (iPhone and iPad)
 - [ ] EQ sheet opens from toolbar
 - [ ] Lyrics sheet opens (synced lyrics auto-scroll and tap-to-seek)
 - [ ] Lyrics with negative offset don't break sync
@@ -93,14 +94,18 @@ Run through this checklist before every TestFlight build. Each item should be ve
 
 ## Queue
 
-- [ ] Tap to jump to track
+- [ ] Tap to jump to track (plays audio, all other tracks remain visible)
+- [ ] Passed-over tracks shown dimmed (50% opacity)
+- [ ] After tapped track finishes, next track plays
 - [ ] Swipe left to remove
 - [ ] Drag to reorder
-- [ ] Long-press context menu works
+- [ ] Long-press context menu: full track menu with Remove from Queue
 - [ ] Save as Playlist from menu
-- [ ] Total duration shows in "Up Next" header
-- [ ] Recently Played section shows previous songs (dimmed)
+- [ ] Total duration shows in "Queue" header
+- [ ] Recently Played section shows songs that actually played
+- [ ] Brief skips (<30s) do not appear in Recently Played
 - [ ] Smart shuffle avoids consecutive same-artist tracks
+- [ ] Auto-Suggest toggle: when off, playback stops at end of queue
 
 ## Swipe Actions
 

--- a/Vibrdrome/Core/Audio/AudioEngine+Playback.swift
+++ b/Vibrdrome/Core/Audio/AudioEngine+Playback.swift
@@ -422,10 +422,13 @@ extension AudioEngine {
                 currentIndex = queue.count - 1
                 refillRadioIfNeeded()
                 return false
+            } else if UserDefaults.standard.bool(forKey: UserDefaultsKeys.autoSuggestEnabled) {
+                currentIndex = queue.count - 1
+                autoSuggestMore()
+                return false
             } else {
                 currentIndex = queue.count - 1
-                // Auto-continue with similar songs instead of stopping
-                autoSuggestMore()
+                pause()
                 return false
             }
         }

--- a/Vibrdrome/Core/Audio/NowPlayingManager.swift
+++ b/Vibrdrome/Core/Audio/NowPlayingManager.swift
@@ -1,9 +1,12 @@
 import Foundation
 import MediaPlayer
 import WidgetKit
+import os.log
 #if os(macOS)
 import AppKit
 #endif
+
+private let npLog = Logger(subsystem: "com.vibrdrome.app", category: "NowPlaying")
 
 // Free function outside @MainActor class so the closure doesn't inherit MainActor isolation.
 // MPMediaItemArtwork calls its requestHandler on an internal background queue (*/accessQueue),
@@ -72,30 +75,39 @@ final class NowPlayingManager {
         }
         #endif
 
-        // Load cover art asynchronously
-        if let coverArtId = song.coverArt {
-            let songId = song.id
-            let url = AppState.shared.subsonicClient.coverArtURL(id: coverArtId, size: 600)
-            Task {
-                do {
-                    let (data, _) = try await URLSession.shared.data(from: url)
-                    // Verify we're still on the same song before applying artwork
-                    guard AudioEngine.shared.currentSong?.id == songId else { return }
-                    #if os(iOS)
-                    guard let image = UIImage(data: data) else { return }
-                    #else
-                    guard let image = NSImage(data: data) else { return }
-                    #endif
-                    let artwork = makeArtwork(from: image)
-                    self.currentInfo[MPMediaItemPropertyArtwork] = artwork
-                    self.infoCenter.nowPlayingInfo = self.currentInfo
-                    #if os(iOS)
-                    self.sendArtworkToWatch(image: image, song: song)
-                    #endif
-                } catch {
-                    // Cover art loading failed, not critical
-                }
+        Task { await loadAndApplyArtwork(for: song) }
+    }
+
+    private func loadAndApplyArtwork(for song: Song) async {
+        guard let coverArtId = song.coverArt else {
+            npLog.warning("No coverArt ID for \(song.title)")
+            return
+        }
+        let songId = song.id
+        let url = AppState.shared.subsonicClient.coverArtURL(id: coverArtId, size: 600)
+        npLog.info("Loading cover art for \(song.title) (id: \(songId))")
+        do {
+            let (data, _) = try await URLSession.shared.data(from: url)
+            guard AudioEngine.shared.currentSong?.id == songId else {
+                npLog.warning("Song changed during art load, skipping (was: \(songId))")
+                return
             }
+            #if os(iOS)
+            guard let image = UIImage(data: data) else {
+                npLog.error("Failed to create UIImage from \(data.count) bytes")
+                return
+            }
+            #else
+            guard let image = NSImage(data: data) else { return }
+            #endif
+            currentInfo[MPMediaItemPropertyArtwork] = makeArtwork(from: image)
+            infoCenter.nowPlayingInfo = currentInfo
+            #if os(iOS)
+            npLog.info("Sending artwork to watch (\(Int(image.size.width))x\(Int(image.size.height)))")
+            sendArtworkToWatch(image: image, song: song)
+            #endif
+        } catch {
+            npLog.error("Cover art load failed: \(error)")
         }
     }
 
@@ -155,8 +167,15 @@ final class NowPlayingManager {
 
     #if os(iOS)
     private func sendArtworkToWatch(image: UIImage, song: Song) {
-        guard let small = image.preparingThumbnail(of: CGSize(width: 120, height: 120)),
-              let jpegData = small.jpegData(compressionQuality: 0.6) else { return }
+        guard let small = image.preparingThumbnail(of: CGSize(width: 120, height: 120)) else {
+            npLog.error("Failed to create 120x120 thumbnail")
+            return
+        }
+        guard let jpegData = small.jpegData(compressionQuality: 0.6) else {
+            npLog.error("Failed to create JPEG from thumbnail")
+            return
+        }
+        npLog.info("Watch art ready: \(jpegData.count) bytes")
         WatchSessionManager.shared.sendNowPlayingUpdate(
             title: song.title,
             artist: song.artist ?? "Unknown Artist",

--- a/Vibrdrome/Core/Constants/UserDefaultsKeys.swift
+++ b/Vibrdrome/Core/Constants/UserDefaultsKeys.swift
@@ -18,6 +18,7 @@ enum UserDefaultsKeys {
     static let crossfadeCurve = "crossfadeCurve"
     static let replayGainMode = "replayGainMode"
     static let scrobblingEnabled = "scrobblingEnabled"
+    static let autoSuggestEnabled = "autoSuggestEnabled"
 
     // MARK: - Equalizer
 

--- a/Vibrdrome/Core/Networking/WatchSessionManager.swift
+++ b/Vibrdrome/Core/Networking/WatchSessionManager.swift
@@ -58,11 +58,37 @@ final class WatchSessionManager: NSObject, ObservableObject {
     func sendNowPlayingUpdate(title: String, artist: String, album: String,
                               isPlaying: Bool, coverArtData: Data?) {
         guard isReady else { return }
-        sendNowPlayingUpdate(title: title, artist: artist, album: album, isPlaying: isPlaying)
+        let engine = AudioEngine.shared
 
-        // Send cover art via message (too large for application context)
-        if let artData = coverArtData, wcSession?.isReachable == true {
-            wcSession?.sendMessage(["coverArtData": artData], replyHandler: nil)
+        var context: [String: Any] = [
+            "title": title,
+            "artist": artist,
+            "album": album,
+            "isPlaying": isPlaying,
+            "elapsed": engine.currentTime,
+            "duration": engine.duration,
+            "isStarred": engine.currentSong?.starred != nil,
+            "isShuffleOn": engine.shuffleEnabled,
+            "repeatMode": repeatModeString(engine.repeatMode),
+            "sleepTimerActive": SleepTimer.shared.isActive,
+        ]
+
+        let upNext = engine.upNext.prefix(20)
+        context["queue"] = upNext.map { ["title": $0.title, "artist": $0.artist ?? ""] }
+
+        // Include art in the same message so watch processes everything in one snapshot
+        if let artData = coverArtData {
+            context["coverArtData"] = artData
+        }
+
+        // Context update (without art -- too large for applicationContext)
+        var contextWithoutArt = context
+        contextWithoutArt.removeValue(forKey: "coverArtData")
+        try? wcSession?.updateApplicationContext(contextWithoutArt)
+
+        // Send full message including art
+        if wcSession?.isReachable == true {
+            wcSession?.sendMessage(context, replyHandler: nil)
         }
     }
 

--- a/Vibrdrome/Features/Settings/PlayerSettingsView.swift
+++ b/Vibrdrome/Features/Settings/PlayerSettingsView.swift
@@ -27,6 +27,7 @@ struct PlayerSettingsView: View {
     @AppStorage(UserDefaultsKeys.wifiMaxBitRate) private var wifiMaxBitRate: Int = 0
     @AppStorage(UserDefaultsKeys.cellularMaxBitRate) private var cellularMaxBitRate: Int = 0
     @AppStorage(UserDefaultsKeys.gaplessPlayback) private var gaplessPlayback: Bool = true
+    @AppStorage(UserDefaultsKeys.autoSuggestEnabled) private var autoSuggestEnabled: Bool = true
     @AppStorage(UserDefaultsKeys.crossfadeDuration) private var crossfadeDuration: Int = 0
     @AppStorage(UserDefaultsKeys.crossfadeCurve) private var crossfadeCurve: String = "linear"
     @AppStorage(UserDefaultsKeys.replayGainMode) private var replayGainMode: String = "off"
@@ -147,6 +148,12 @@ struct PlayerSettingsView: View {
                     .foregroundColor(.primary)
             }
             .accessibilityIdentifier("gaplessPlaybackToggle")
+
+            Toggle(isOn: $autoSuggestEnabled) {
+                Label("Auto-Suggest", systemImage: "sparkles")
+                    .foregroundColor(.primary)
+            }
+            .accessibilityIdentifier("autoSuggestToggle")
 
             Picker(selection: $crossfadeDuration) {
                 Text("Off").tag(0)

--- a/VibrdromeWatch/WatchSessionManager.swift
+++ b/VibrdromeWatch/WatchSessionManager.swift
@@ -124,6 +124,12 @@ final class WatchSessionManager: NSObject, ObservableObject {
     // MARK: - Apply Updates
 
     private func applySnapshot(_ snapshot: NowPlayingSnapshot) {
+        // Clear stale artwork when song changes (new art arrives async)
+        if let newTitle = snapshot.title, newTitle != self.title {
+            if snapshot.coverArtData == nil {
+                self.coverArtData = nil
+            }
+        }
         if let title = snapshot.title { self.title = title }
         if let artist = snapshot.artist { self.artist = artist }
         if let album = snapshot.album { self.album = album }

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -347,6 +347,27 @@
 
         <div class="timeline">
 
+            <!-- Build 44 -->
+            <div class="timeline-item" data-animate>
+                <div class="build-card">
+                    <div class="build-header">
+                        <span class="build-badge">Build 44</span>
+                        <span class="build-date">April 16, 2026</span>
+                    </div>
+                    <ul>
+                        <li>Queue overhaul: all tracks visible, tap plays without hiding others</li>
+                        <li>Recently Played records gapless auto-advance, filters brief skips</li>
+                        <li>Now Playing landscape layout (art left, controls right)</li>
+                        <li>Grid art scales to 3/4 column settings</li>
+                        <li>Full context menu on queue tracks</li>
+                        <li>Watch album art refreshes on track change</li>
+                        <li>Auto-Suggest on/off toggle in Settings</li>
+                        <li>Cold-start audio session fix</li>
+                        <li>536 unit tests in 40 suites</li>
+                    </ul>
+                </div>
+            </div>
+
             <!-- Build 43 -->
             <div class="timeline-item" data-animate>
                 <div class="build-card">

--- a/docs/features.html
+++ b/docs/features.html
@@ -436,6 +436,7 @@
                     <li>Heart, 5-star rating, and queue in one row</li>
                     <li>Shuffle and repeat alongside transport controls</li>
                     <li>Drag-to-reorder toolbar: Visualizer, EQ, AirPlay, Lyrics, Settings</li>
+                    <li>Landscape layout: album art left, controls right</li>
                     <li>Quick Settings sheet with crossfade preview</li>
                     <li>Now playing indicator: animated waveform on current track</li>
                     <li>"Playing from" context: Playlist name, Shuffle mode</li>
@@ -598,10 +599,10 @@
             <div class="feature-text">
                 <h2>Smart Queue</h2>
                 <ul>
-                    <li>Auto-continues with similar songs when queue runs out</li>
-                    <li>Falls back to random songs if no similar found</li>
+                    <li>Full queue view: all tracks visible, passed-over tracks dimmed</li>
+                    <li>Tap any track to play without hiding others</li>
+                    <li>Auto-Suggest: continues with similar songs (toggleable in Settings)</li>
                     <li>Save current queue as a playlist</li>
-                    <li>Queue sharing from the queue menu</li>
                 </ul>
                 <div class="platforms">
                     <span class="platform-badge">iOS</span>

--- a/project.yml
+++ b/project.yml
@@ -89,7 +89,7 @@ targets:
         DEVELOPMENT_TEAM: 85JD2B827Q
         PRODUCT_BUNDLE_IDENTIFIER: com.vibrdrome.app
         MARKETING_VERSION: "1.0.0"
-        CURRENT_PROJECT_VERSION: "43"
+        CURRENT_PROJECT_VERSION: "44"
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS: "YES"
       configs:
@@ -122,7 +122,7 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.vibrdrome.app.widget
         CODE_SIGN_ENTITLEMENTS: VibrdromeWidget/VibrdromeWidget.entitlements
         MARKETING_VERSION: "1.0.0"
-        CURRENT_PROJECT_VERSION: "43"
+        CURRENT_PROJECT_VERSION: "44"
     entitlements:
       path: VibrdromeWidget/VibrdromeWidget.entitlements
 
@@ -139,7 +139,7 @@ targets:
         DEVELOPMENT_TEAM: 85JD2B827Q
         PRODUCT_BUNDLE_IDENTIFIER: com.vibrdrome.app.watchkitapp
         MARKETING_VERSION: "1.0.0"
-        CURRENT_PROJECT_VERSION: "43"
+        CURRENT_PROJECT_VERSION: "44"
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         SWIFT_VERSION: "6.0"
 


### PR DESCRIPTION
## Summary
- **Queue overhaul**: all tracks visible, tap plays without hiding, passed-over tracks dimmed, full context menu
- **Recently Played**: records gapless auto-advance, filters brief skips (<30s/<30%)
- **Now Playing landscape**: art left, controls right (iPhone + iPad)
- **Grid art scaling**: responsive to 3/4 column settings
- **Watch album art**: sent with metadata in single message, clears stale art on track change
- **Auto-Suggest toggle**: Settings > Player (on by default, stops playback at end of queue when off)
- **Cold-start audio fix**: session activated on first play
- **Album detail**: opaque row background for context menu
- **SidePanels**: fixed to use skipToIndex (was clearing play history)

## Test plan
- [ ] Queue: tap track plays, all tracks remain visible, passed-over dimmed
- [ ] Recently Played: gapless tracks appear, brief skips (<30s) do not
- [ ] Landscape Now Playing layout on iPhone
- [ ] Grid columns 3/4: art scales, no overlap
- [ ] Watch: album art refreshes on track change (no stale art)
- [ ] Auto-Suggest off: playback stops at end of queue
- [ ] Auto-Suggest on: similar songs added when queue ends
- [ ] Long-press queue track: full context menu with Remove
- [ ] Cold start: first play after fresh launch works
- [ ] macOS build succeeds
- [ ] watchOS build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)