### PR TITLE
PR 7a: Library Sync Infrastructure & Metadata Caching

### DIFF
--- a/Vibrdrome/App/AppState.swift
+++ b/Vibrdrome/App/AppState.swift
@@ -58,6 +58,12 @@ final class AppState {
         case queue, lyrics, artistInfo
     }
     var activeSidePanel: SidePanel?
+
+    /// Library sync manager.
+    let librarySyncManager = LibrarySyncManager.shared
+
+    /// Pre-computed model arrays so library tabs are instant on first tap.
+    let libraryCache = LibraryDataCache()
     var serverURL: String = ""
     var username: String = ""
     var errorMessage: String?
@@ -115,6 +121,8 @@ final class AppState {
         #if os(iOS)
         SubsonicClientProvider.shared.client = subsonicClient
         #endif
+        LibrarySyncManager.shared.client = subsonicClient
+        LibrarySyncManager.shared.container = PersistenceController.shared.container
     }
 
     func loadSavedCredentials() {

--- a/Vibrdrome/Core/Audio/NowPlayingManager.swift
+++ b/Vibrdrome/Core/Audio/NowPlayingManager.swift
@@ -27,34 +27,6 @@ final class NowPlayingManager {
     private let infoCenter = MPNowPlayingInfoCenter.default()
     private var currentInfo = [String: Any]()
 
-    /// Update the stored artwork and flush to `infoCenter`. Used by radio
-    /// artwork loading so the station's cover art isn't overwritten by the
-    /// next elapsed-time tick (which writes `currentInfo` back).
-    func setCurrentArtwork(_ artwork: MPMediaItemArtwork) {
-        currentInfo[MPMediaItemPropertyArtwork] = artwork
-        infoCenter.nowPlayingInfo = currentInfo
-    }
-
-    /// Reset `currentInfo` to station metadata so subsequent `updateElapsedTime`
-    /// / `updatePlaybackState` ticks don't overwrite with stale song info.
-    func update(station: InternetRadioStation, isPlaying: Bool) {
-        currentInfo = [String: Any]()
-        currentInfo[MPMediaItemPropertyTitle] = station.name
-        currentInfo[MPMediaItemPropertyArtist] = "Internet Radio"
-        currentInfo[MPNowPlayingInfoPropertyIsLiveStream] = true
-        currentInfo[MPNowPlayingInfoPropertyPlaybackRate] = isPlaying ? 1.0 : 0.0
-        infoCenter.nowPlayingInfo = currentInfo
-
-        #if os(iOS)
-        WatchSessionManager.shared.sendNowPlayingUpdate(
-            title: station.name,
-            artist: "Internet Radio",
-            album: "",
-            isPlaying: isPlaying
-        )
-        #endif
-    }
-
     func update(song: Song, isPlaying: Bool) {
         currentInfo = [String: Any]()
         currentInfo[MPMediaItemPropertyTitle] = song.title
@@ -104,6 +76,41 @@ final class NowPlayingManager {
         #endif
 
         Task { await loadAndApplyArtwork(for: song) }
+    }
+
+    func update(station: InternetRadioStation, isPlaying: Bool) {
+        currentInfo = [String: Any]()
+        currentInfo[MPMediaItemPropertyTitle] = station.name
+        currentInfo[MPMediaItemPropertyArtist] = "Internet Radio"
+        currentInfo[MPMediaItemPropertyAlbumTitle] = ""
+        currentInfo[MPNowPlayingInfoPropertyElapsedPlaybackTime] = 0.0
+        currentInfo[MPNowPlayingInfoPropertyPlaybackRate] = isPlaying ? 1.0 : 0.0
+        currentInfo[MPNowPlayingInfoPropertyDefaultPlaybackRate] = 1.0
+        currentInfo[MPNowPlayingInfoPropertyIsLiveStream] = true
+        currentInfo.removeValue(forKey: MPMediaItemPropertyArtwork)
+        infoCenter.nowPlayingInfo = currentInfo
+
+        updateWidget(title: station.name, artist: "Internet Radio",
+                     album: "", isPlaying: isPlaying,
+                     coverArtId: station.radioCoverArtId)
+
+        #if os(iOS)
+        WatchSessionManager.shared.sendNowPlayingUpdate(
+            title: station.name,
+            artist: "Internet Radio",
+            album: "",
+            isPlaying: isPlaying
+        )
+        #endif
+    }
+
+    func setCurrentArtwork(_ artwork: MPMediaItemArtwork?) {
+        if let artwork {
+            currentInfo[MPMediaItemPropertyArtwork] = artwork
+        } else {
+            currentInfo.removeValue(forKey: MPMediaItemPropertyArtwork)
+        }
+        infoCenter.nowPlayingInfo = currentInfo
     }
 
     private func loadAndApplyArtwork(for song: Song) async {

--- a/Vibrdrome/Core/Constants/UserDefaultsKeys.swift
+++ b/Vibrdrome/Core/Constants/UserDefaultsKeys.swift
@@ -149,4 +149,12 @@ enum UserDefaultsKeys {
     static let macSidePanelMechanic = "macSidePanelMechanic"
     static let macSidePanelWidth = "macSidePanelWidth"
     static let macMiniPlayerPanelTrigger = "macMiniPlayerPanelTrigger"
+
+    // MARK: - Library Sync
+
+    static let lastLibrarySyncDate = "lastLibrarySyncDate"
+    static let lastFullSyncDate = "lastFullSyncDate"
+    static let lastServerModified = "lastServerModified"
+    static let backgroundSyncEnabled = "backgroundSyncEnabled"
+    static let syncPollingInterval = "syncPollingInterval"
 }

--- a/Vibrdrome/Core/Constants/UserDefaultsKeys.swift
+++ b/Vibrdrome/Core/Constants/UserDefaultsKeys.swift
@@ -157,4 +157,5 @@ enum UserDefaultsKeys {
     static let lastServerModified = "lastServerModified"
     static let backgroundSyncEnabled = "backgroundSyncEnabled"
     static let syncPollingInterval = "syncPollingInterval"
+    static let lastCoverArtPrefetchDate = "lastCoverArtPrefetchDate"
 }

--- a/Vibrdrome/Core/Networking/OfflineActionQueue.swift
+++ b/Vibrdrome/Core/Networking/OfflineActionQueue.swift
@@ -150,7 +150,7 @@ final class OfflineActionQueue {
 
     // MARK: - Flush
 
-    /// Sync all pending actions to server
+    /// Sync all pending actions to server, with conflict detection and resolution.
     func flushPending() async {
         guard !isSyncing else { return }
         isSyncing = true
@@ -164,9 +164,14 @@ final class OfflineActionQueue {
 
         guard let actions = try? context.fetch(descriptor), !actions.isEmpty else { return }
         let client = AppState.shared.subsonicClient
+
+        // Conflict resolution: collapse contradictory actions on the same target.
+        // e.g., star + unstar on the same song → last one wins.
+        let resolved = resolveConflicts(actions: actions, context: context)
+
         var synced = 0
 
-        for action in actions {
+        for action in resolved {
             do {
                 try await executeAction(action, client: client)
                 context.delete(action)
@@ -190,6 +195,56 @@ final class OfflineActionQueue {
         if synced > 0 {
             offlineLog.info("Synced \(synced) pending actions")
         }
+    }
+
+    // MARK: - Conflict Resolution
+
+    /// Collapse contradictory actions on the same target.
+    /// Uses last-write-wins: the most recent action for each target survives.
+    private func resolveConflicts(actions: [PendingAction],
+                                  context: ModelContext) -> [PendingAction] {
+        // Group by target ID
+        var grouped: [String: [PendingAction]] = [:]
+        for action in actions {
+            grouped[action.targetId, default: []].append(action)
+        }
+
+        var resolved: [PendingAction] = []
+
+        for (_, group) in grouped {
+            // Separate star/unstar pairs from other action types
+            let starActions = group.filter {
+                $0.actionType == "star" || $0.actionType == "unstar" ||
+                $0.actionType == "starAlbum" || $0.actionType == "unstarAlbum" ||
+                $0.actionType == "starArtist" || $0.actionType == "unstarArtist"
+            }
+            let otherActions = group.filter {
+                !($0.actionType == "star" || $0.actionType == "unstar" ||
+                  $0.actionType == "starAlbum" || $0.actionType == "unstarAlbum" ||
+                  $0.actionType == "starArtist" || $0.actionType == "unstarArtist")
+            }
+
+            // Other actions (scrobbles etc.) always go through
+            resolved.append(contentsOf: otherActions)
+
+            // For star/unstar, check for contradictions
+            if starActions.count > 1 {
+                // Multiple star/unstar on same target — keep only the latest
+                let sorted = starActions.sorted { $0.createdAt < $1.createdAt }
+                let winner = sorted.last!
+                offlineLog.info("Conflict resolved (last-write-wins): \(winner.actionType) wins for \(winner.targetId)")
+
+                // Delete the losers
+                for action in sorted.dropLast() {
+                    context.delete(action)
+                }
+                resolved.append(winner)
+            } else {
+                resolved.append(contentsOf: starActions)
+            }
+        }
+
+        return resolved
     }
 
     private func executeAction(_ action: PendingAction, client: SubsonicClient) async throws {

--- a/Vibrdrome/Core/Networking/SubsonicClient.swift
+++ b/Vibrdrome/Core/Networking/SubsonicClient.swift
@@ -122,7 +122,10 @@ final class SubsonicClient {
             }
         }
 
-        throw SubsonicError.httpError(500)
+        // Unreachable: the for-loop above always exits via `return` on success or `throw`
+        // on the final attempt. Using fatalError makes that invariant explicit and will
+        // surface immediately if the control-flow assumption is ever broken by a refactor.
+        fatalError("SubsonicClient.request retry loop exited without returning or throwing")
     }
 
     private func performRequest(_ endpoint: SubsonicEndpoint) async throws -> SubsonicResponseBody {

--- a/Vibrdrome/Core/Networking/SubsonicClient.swift
+++ b/Vibrdrome/Core/Networking/SubsonicClient.swift
@@ -14,6 +14,11 @@ final class SubsonicClient {
     private static let maxRetries = 3
     private static let retryDelays: [UInt64] = [1_000_000_000, 2_000_000_000, 4_000_000_000] // 1s, 2s, 4s
 
+    /// Internal marker for HTTP 429 so retry delay can honor Retry-After when present.
+    private struct RateLimitError: Error {
+        let retryAfterNanoseconds: UInt64?
+    }
+
     var isConnected: Bool = false
 
     init(baseURL: URL, username: String, password: String) {
@@ -33,6 +38,9 @@ final class SubsonicClient {
     // MARK: - Retry Logic
 
     private func isRetryable(_ error: Error) -> Bool {
+        if error is RateLimitError {
+            return true
+        }
         if let urlError = error as? URLError {
             switch urlError.code {
             case .timedOut, .networkConnectionLost, .notConnectedToInternet,
@@ -45,7 +53,7 @@ final class SubsonicClient {
         if let subsonicError = error as? SubsonicError {
             switch subsonicError {
             case .httpError(let code):
-                return code >= 500 // Only retry server errors, not 4xx
+                return code == 429 || code >= 500
             default:
                 return false
             }
@@ -53,30 +61,68 @@ final class SubsonicClient {
         return false
     }
 
+    private func retryDelayNanoseconds(for error: Error, attempt: Int) -> UInt64? {
+        guard isRetryable(error) else { return nil }
+
+        if let rateLimitError = error as? RateLimitError,
+           let retryAfter = rateLimitError.retryAfterNanoseconds {
+            return retryAfter
+        }
+
+        return Self.retryDelays[min(attempt, Self.retryDelays.count - 1)]
+    }
+
+    private func parseRetryAfterNanoseconds(from response: HTTPURLResponse) -> UInt64? {
+        guard let header = response.value(forHTTPHeaderField: "Retry-After")?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !header.isEmpty else {
+            return nil
+        }
+
+        if let seconds = TimeInterval(header), seconds > 0 {
+            return UInt64(seconds * 1_000_000_000)
+        }
+
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss z"
+
+        guard let retryDate = formatter.date(from: header) else { return nil }
+        let seconds = max(0, retryDate.timeIntervalSinceNow)
+        guard seconds > 0 else { return nil }
+        return UInt64(seconds * 1_000_000_000)
+    }
+
     // MARK: - Core Request
 
     private func request(_ endpoint: SubsonicEndpoint) async throws -> SubsonicResponseBody {
-        var lastError: Error?
-
         for attempt in 0...Self.maxRetries {
-            if attempt > 0 {
-                let delay = Self.retryDelays[min(attempt - 1, Self.retryDelays.count - 1)]
-                networkLog.info("Retry \(attempt)/\(Self.maxRetries) for \(endpoint.path) after \(delay / 1_000_000_000)s")
-                try await Task.sleep(nanoseconds: delay)
-            }
-
             do {
                 return try await performRequest(endpoint)
             } catch {
-                lastError = error
-                if !isRetryable(error) {
+                if attempt == Self.maxRetries {
+                    if error is RateLimitError {
+                        throw SubsonicError.httpError(429)
+                    }
                     throw error
                 }
-                networkLog.warning("Transient error on \(endpoint.path): \(error.localizedDescription)")
+
+                guard let delay = retryDelayNanoseconds(for: error, attempt: attempt) else {
+                    throw error
+                }
+
+                if error is RateLimitError {
+                    networkLog.warning("Rate limited on \(endpoint.path); retry \(attempt + 1)/\(Self.maxRetries) after \(delay / 1_000_000_000)s")
+                } else {
+                    networkLog.warning("Transient error on \(endpoint.path): \(error.localizedDescription)")
+                    networkLog.info("Retry \(attempt + 1)/\(Self.maxRetries) for \(endpoint.path) after \(delay / 1_000_000_000)s")
+                }
+
+                try await Task.sleep(nanoseconds: delay)
             }
         }
 
-        throw lastError!
+        throw SubsonicError.httpError(500)
     }
 
     private func performRequest(_ endpoint: SubsonicEndpoint) async throws -> SubsonicResponseBody {
@@ -102,6 +148,9 @@ final class SubsonicClient {
         guard let httpResponse = response as? HTTPURLResponse,
               (200...299).contains(httpResponse.statusCode) else {
             let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
+            if statusCode == 429, let httpResponse = response as? HTTPURLResponse {
+                throw RateLimitError(retryAfterNanoseconds: parseRetryAfterNanoseconds(from: httpResponse))
+            }
             if statusCode == 401, !AppState.shared.requiresReAuth {
                 networkLog.warning("401 Unauthorized — triggering re-authentication prompt")
                 AppState.shared.requiresReAuth = true
@@ -480,8 +529,8 @@ final class SubsonicClient {
         return body.musicFolders?.musicFolder ?? []
     }
 
-    func getIndexes(musicFolderId: String? = nil) async throws -> IndexesResponse {
-        let body = try await request(.getIndexes(musicFolderId: musicFolderId))
+    func getIndexes(musicFolderId: String? = nil, ifModifiedSince: Int? = nil) async throws -> IndexesResponse {
+        let body = try await request(.getIndexes(musicFolderId: musicFolderId, ifModifiedSince: ifModifiedSince))
         guard let indexes = body.indexes else {
             throw SubsonicError.apiError(code: 70, message: "Indexes not found")
         }

--- a/Vibrdrome/Core/Networking/SubsonicEndpoints.swift
+++ b/Vibrdrome/Core/Networking/SubsonicEndpoints.swift
@@ -51,7 +51,7 @@ enum SubsonicEndpoint: Sendable {
     case getSimilarSongs2(id: String, count: Int = 50)
     case getTopSongs(artist: String, count: Int = 50)
     case getMusicFolders
-    case getIndexes(musicFolderId: String? = nil)
+    case getIndexes(musicFolderId: String? = nil, ifModifiedSince: Int? = nil)
     case getMusicDirectory(id: String)
     case jukeboxControl(action: String, index: Int? = nil, offset: Int? = nil,
                         ids: [String]? = nil, gain: Float? = nil)
@@ -285,9 +285,10 @@ enum SubsonicEndpoint: Sendable {
                 URLQueryItem(name: "count", value: "\(count)")
             ]
 
-        case .getIndexes(let musicFolderId):
+        case .getIndexes(let musicFolderId, let ifModifiedSince):
             var items: [URLQueryItem] = []
             if let musicFolderId { items.append(URLQueryItem(name: "musicFolderId", value: musicFolderId)) }
+            if let ifModifiedSince { items.append(URLQueryItem(name: "ifModifiedSince", value: "\(ifModifiedSince)")) }
             return items
 
         case .getMusicDirectory(let id):

--- a/Vibrdrome/Core/Networking/SubsonicModels.swift
+++ b/Vibrdrome/Core/Networking/SubsonicModels.swift
@@ -137,6 +137,10 @@ struct AlbumInfo2: Decodable, Sendable {
 
 // MARK: - Album Models
 
+struct RecordLabel: Decodable, Sendable {
+    let name: String
+}
+
 struct Album: Decodable, Identifiable, Sendable {
     let id: String
     let name: String
@@ -149,8 +153,14 @@ struct Album: Decodable, Identifiable, Sendable {
     let genre: String?
     let starred: String?
     let created: String?
+    let userRating: Int?
     let song: [Song]?
     let replayGain: ReplayGain?
+    let musicBrainzId: String?
+    let recordLabels: [RecordLabel]?
+
+    /// First record label name, for convenience.
+    var label: String? { recordLabels?.first?.name }
 }
 
 struct AlbumList2Response: Decodable, Sendable {
@@ -171,7 +181,7 @@ struct TopSongsResponse: Decodable, Sendable {
 
 // MARK: - Song Model
 
-struct Song: Decodable, Identifiable, Sendable {
+struct Song: Decodable, Identifiable, Sendable, Equatable {
     let id: String
     let parent: String?
     let title: String
@@ -223,7 +233,7 @@ struct Song: Decodable, Identifiable, Sendable {
     }
 }
 
-struct ReplayGain: Decodable, Sendable {
+struct ReplayGain: Decodable, Sendable, Equatable {
     let trackGain: Double?
     let albumGain: Double?
     let trackPeak: Double?

--- a/Vibrdrome/Core/Persistence/BackgroundSyncScheduler.swift
+++ b/Vibrdrome/Core/Persistence/BackgroundSyncScheduler.swift
@@ -1,0 +1,154 @@
+#if os(iOS)
+import BackgroundTasks
+import Foundation
+import os.log
+
+private let bgSyncLog = Logger(subsystem: "com.vibrdrome.app", category: "BackgroundSync")
+
+/// Manages background library sync via BGTaskScheduler on iOS.
+/// Registers and schedules both app refresh and processing tasks.
+@MainActor
+final class BackgroundSyncScheduler {
+    static let shared = BackgroundSyncScheduler()
+
+    /// Task identifier for lightweight app refresh (incremental sync).
+    static let refreshTaskId = "com.vibrdrome.app.libraryRefresh"
+    /// Task identifier for longer processing task (full sync).
+    static let processingTaskId = "com.vibrdrome.app.librarySync"
+
+    private init() {}
+
+    /// Register background task handlers. Call once at app launch.
+    func registerTasks() {
+        BGTaskScheduler.shared.register(
+            forTaskWithIdentifier: Self.refreshTaskId,
+            using: nil
+        ) { task in
+            guard let refreshTask = task as? BGAppRefreshTask else { return }
+            Task { @MainActor in
+                await self.handleRefreshTask(refreshTask)
+            }
+        }
+
+        BGTaskScheduler.shared.register(
+            forTaskWithIdentifier: Self.processingTaskId,
+            using: nil
+        ) { task in
+            guard let processingTask = task as? BGProcessingTask else { return }
+            Task { @MainActor in
+                await self.handleProcessingTask(processingTask)
+            }
+        }
+
+        bgSyncLog.info("Registered background sync tasks")
+    }
+
+    /// Schedule the next background refresh. Call after each sync completes.
+    func scheduleRefresh() {
+        guard AppState.shared.isConfigured else { return }
+        guard UserDefaults.standard.bool(forKey: UserDefaultsKeys.backgroundSyncEnabled) else {
+            bgSyncLog.info("Background sync disabled, not scheduling refresh")
+            return
+        }
+
+        let request = BGAppRefreshTaskRequest(identifier: Self.refreshTaskId)
+        // Earliest: 1 hour from now
+        request.earliestBeginDate = Date(timeIntervalSinceNow: 3600)
+
+        do {
+            try BGTaskScheduler.shared.submit(request)
+            bgSyncLog.info("Scheduled background refresh for ~1 hour from now")
+        } catch {
+            bgSyncLog.error("Failed to schedule background refresh: \(error)")
+        }
+    }
+
+    /// Schedule a longer background processing task for full sync.
+    func scheduleFullSync() {
+        guard AppState.shared.isConfigured else { return }
+        guard UserDefaults.standard.bool(forKey: UserDefaultsKeys.backgroundSyncEnabled) else { return }
+
+        let request = BGProcessingTaskRequest(identifier: Self.processingTaskId)
+        request.requiresNetworkConnectivity = true
+        request.requiresExternalPower = false
+        // Earliest: 24 hours from now
+        request.earliestBeginDate = Date(timeIntervalSinceNow: 86400)
+
+        do {
+            try BGTaskScheduler.shared.submit(request)
+            bgSyncLog.info("Scheduled background full sync for ~24 hours from now")
+        } catch {
+            bgSyncLog.error("Failed to schedule background full sync: \(error)")
+        }
+    }
+
+    /// Cancel all pending background sync tasks.
+    func cancelAll() {
+        BGTaskScheduler.shared.cancel(taskRequestWithIdentifier: Self.refreshTaskId)
+        BGTaskScheduler.shared.cancel(taskRequestWithIdentifier: Self.processingTaskId)
+        bgSyncLog.info("Cancelled all background sync tasks")
+    }
+
+    // MARK: - Task Handlers
+
+    private func handleRefreshTask(_ task: BGAppRefreshTask) async {
+        bgSyncLog.info("Background refresh task started")
+
+        // Schedule the next refresh before doing work
+        scheduleRefresh()
+
+        let appState = AppState.shared
+        guard appState.isConfigured else {
+            bgSyncLog.info("App not configured, completing background refresh")
+            task.setTaskCompleted(success: true)
+            return
+        }
+
+        // Create a cancellation handler
+        let syncTask = Task {
+            await appState.librarySyncManager.incrementalSync(
+                client: appState.subsonicClient,
+                container: PersistenceController.shared.container
+            )
+        }
+
+        task.expirationHandler = {
+            syncTask.cancel()
+            bgSyncLog.warning("Background refresh task expired")
+        }
+
+        await syncTask.value
+        task.setTaskCompleted(success: appState.librarySyncManager.syncError == nil)
+        bgSyncLog.info("Background refresh task completed")
+    }
+
+    private func handleProcessingTask(_ task: BGProcessingTask) async {
+        bgSyncLog.info("Background processing task started")
+
+        // Schedule the next full sync
+        scheduleFullSync()
+
+        let appState = AppState.shared
+        guard appState.isConfigured else {
+            task.setTaskCompleted(success: true)
+            return
+        }
+
+        let syncTask = Task {
+            await appState.librarySyncManager.sync(
+                client: appState.subsonicClient,
+                container: PersistenceController.shared.container
+            )
+        }
+
+        task.expirationHandler = {
+            syncTask.cancel()
+            bgSyncLog.warning("Background processing task expired")
+        }
+
+        await syncTask.value
+        task.setTaskCompleted(success: appState.librarySyncManager.syncError == nil)
+        bgSyncLog.info("Background processing task completed")
+    }
+}
+#endif

--- a/Vibrdrome/Core/Persistence/BackgroundSyncScheduler.swift
+++ b/Vibrdrome/Core/Persistence/BackgroundSyncScheduler.swift
@@ -12,21 +12,33 @@ final class BackgroundSyncScheduler {
     static let shared = BackgroundSyncScheduler()
 
     /// Task identifier for lightweight app refresh (incremental sync).
-    static let refreshTaskId = "com.vibrdrome.app.libraryRefresh"
+    /// `nonisolated` so `registerTasks()` (itself nonisolated, called from App.init())
+    /// can read these without hopping to the main actor.
+    nonisolated static let refreshTaskId = "com.vibrdrome.app.libraryRefresh"
     /// Task identifier for longer processing task (full sync).
-    static let processingTaskId = "com.vibrdrome.app.librarySync"
+    nonisolated static let processingTaskId = "com.vibrdrome.app.librarySync"
 
     private init() {}
 
-    /// Register background task handlers. Call once at app launch.
-    func registerTasks() {
+    /// Register background task handlers. MUST be called synchronously from `App.init()`
+    /// before the app finishes launching. If iOS launches the app specifically to handle
+    /// a background task, registration must already be in place or the handler is missing
+    /// and the task fails silently.
+    ///
+    /// `nonisolated` so it can run on whatever thread initializes the SwiftUI `App` struct
+    /// without an `await` hop; `BGTaskScheduler.register` is thread-safe.
+    nonisolated func registerTasks() {
         BGTaskScheduler.shared.register(
             forTaskWithIdentifier: Self.refreshTaskId,
             using: nil
         ) { task in
             guard let refreshTask = task as? BGAppRefreshTask else { return }
+            // BGTask subclasses are not Sendable; transferring them into a MainActor Task
+            // is safe here because the system invokes the handler exactly once and we do
+            // not touch the task from any other isolation domain.
+            nonisolated(unsafe) let unsafeTask = refreshTask
             Task { @MainActor in
-                await self.handleRefreshTask(refreshTask)
+                await self.handleRefreshTask(unsafeTask)
             }
         }
 
@@ -35,8 +47,9 @@ final class BackgroundSyncScheduler {
             using: nil
         ) { task in
             guard let processingTask = task as? BGProcessingTask else { return }
+            nonisolated(unsafe) let unsafeTask = processingTask
             Task { @MainActor in
-                await self.handleProcessingTask(processingTask)
+                await self.handleProcessingTask(unsafeTask)
             }
         }
 

--- a/Vibrdrome/Core/Persistence/LibraryDataCache.swift
+++ b/Vibrdrome/Core/Persistence/LibraryDataCache.swift
@@ -17,6 +17,8 @@ final class LibraryDataCache {
     private(set) var songFilterGenres: [String]?
 
     /// Incremented after each successful rebuild so views can detect changes via `.onChange`.
+    /// Intentionally in-session only (not persisted) — resets to 0 on launch. Views only need
+    /// to detect changes *within* a session; cross-launch staleness is handled by `LibrarySyncManager`.
     private(set) var generation: Int = 0
 
     private var buildTask: Task<Void, Never>?

--- a/Vibrdrome/Core/Persistence/LibraryDataCache.swift
+++ b/Vibrdrome/Core/Persistence/LibraryDataCache.swift
@@ -1,0 +1,118 @@
+import Foundation
+import SwiftData
+import os.log
+
+private let cacheLog = Logger(subsystem: "com.vibrdrome.app", category: "LibraryCache")
+
+/// Pre-computes converted model arrays on a background thread so library tabs
+/// are ready instantly when first selected.
+@Observable
+@MainActor
+final class LibraryDataCache {
+    private(set) var songs: [Song]?
+    private(set) var artists: [Artist]?
+    private(set) var albums: [Album]?
+    private(set) var songFilterYears: [Int]?
+    private(set) var songFilterArtists: [String]?
+    private(set) var songFilterGenres: [String]?
+
+    /// Incremented after each successful rebuild so views can detect changes via `.onChange`.
+    private(set) var generation: Int = 0
+
+    private var buildTask: Task<Void, Never>?
+
+    /// Kick off a background rebuild of all cached model arrays.
+    func rebuild(container: ModelContainer) {
+        buildTask?.cancel()
+        buildTask = Task {
+            let result = await Task.detached(priority: .userInitiated) {
+                Self.buildCache(container: container)
+            }.value
+            guard !Task.isCancelled else { return }
+            songs = result.songs
+            artists = result.artists
+            albums = result.albums
+            songFilterYears = result.years
+            songFilterArtists = result.artistNames
+            songFilterGenres = result.genres
+            generation += 1
+            cacheLog.info("Library cache ready — \(result.songs.count) songs, \(result.artists.count) artists, \(result.albums.count) albums")
+        }
+    }
+
+    /// Clear all cached data (e.g. on logout or server switch).
+    func invalidate() {
+        buildTask?.cancel()
+        songs = nil
+        artists = nil
+        albums = nil
+        songFilterYears = nil
+        songFilterArtists = nil
+        songFilterGenres = nil
+    }
+
+    // MARK: - Background Work
+
+    private struct CacheResult: Sendable {
+        let songs: [Song]
+        let artists: [Artist]
+        let albums: [Album]
+        let years: [Int]
+        let artistNames: [String]
+        let genres: [String]
+    }
+
+    nonisolated private static func buildCache(container: ModelContainer) -> CacheResult {
+        let context = ModelContext(container)
+        context.autosaveEnabled = false
+
+        // Artists
+        let artistDescriptor = FetchDescriptor<CachedArtist>(sortBy: [SortDescriptor<CachedArtist>(\.name)])
+        let convertedArtists: [Artist]
+        if let cached = try? context.fetch(artistDescriptor) {
+            convertedArtists = cached.map { $0.toArtist() }
+        } else {
+            convertedArtists = []
+        }
+
+        // Albums
+        let albumDescriptor = FetchDescriptor<CachedAlbum>(sortBy: [SortDescriptor<CachedAlbum>(\.name)])
+        let convertedAlbums: [Album]
+        if let cached = try? context.fetch(albumDescriptor) {
+            convertedAlbums = cached.map { $0.toAlbum() }
+        } else {
+            convertedAlbums = []
+        }
+
+        // Songs — single pass for conversion + filter option extraction
+        let songDescriptor = FetchDescriptor<CachedSong>(sortBy: [SortDescriptor<CachedSong>(\.title)])
+        var convertedSongs = [Song]()
+        var yearSet = Set<Int>()
+        var artistSet = Set<String>()
+        var genreSet = Set<String>()
+        if let cached = try? context.fetch(songDescriptor) {
+            convertedSongs.reserveCapacity(cached.count)
+            for item in cached {
+                convertedSongs.append(item.toSong())
+                if let year = item.year { yearSet.insert(year) }
+                if let artist = item.artist { artistSet.insert(artist) }
+                if let genre = item.genre { genreSet.insert(genre) }
+            }
+        }
+
+        let sortedYears = yearSet.sorted(by: >)
+        let sortedArtists = Array(artistSet)
+            .sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
+        let sortedGenres = Array(genreSet)
+            .sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
+
+        return CacheResult(
+            songs: convertedSongs,
+            artists: convertedArtists,
+            albums: convertedAlbums,
+            years: sortedYears,
+            artistNames: sortedArtists,
+            genres: sortedGenres
+        )
+    }
+}

--- a/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
+++ b/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
@@ -42,8 +42,10 @@ final class LibrarySyncManager {
 
     // Page sizes for paginated API calls. 500 is a safe default for most Subsonic servers;
     // could be made configurable per-server if needed for very large or constrained instances.
-    private let albumPageSize = 500
-    private let songPageSize = 500
+    // `nonisolated` so the `nonisolated static` sync helpers running off the main actor can
+    // read them without hopping back to MainActor just to read a constant.
+    nonisolated static let albumPageSize = 500
+    nonisolated static let songPageSize = 500
 
     /// Stale threshold for auto-sync (24 hours).
     private let staleInterval: TimeInterval = 86400
@@ -164,31 +166,64 @@ final class LibrarySyncManager {
             syncProgress = nil
         }
 
+        // Progress callback — hops to MainActor to update @Observable state.
+        // Marked @Sendable so it's safe to pass into nonisolated static helpers.
+        @Sendable func updateProgress(_ message: String) {
+            Task { @MainActor in
+                self.syncProgress = message
+            }
+        }
+        @Sendable func publishPartialStats(_ partial: SyncStats) {
+            Task { @MainActor in
+                self.lastSyncStats = partial
+            }
+        }
+
         do {
-            let context = ModelContext(container)
-            context.autosaveEnabled = false
+            // All heavy lifting (SwiftData fetch/insert/save + per-row diff loops) happens on a
+            // detached task using a background ModelContext. This keeps the main actor free so
+            // the polling task (which fires every 15+ min) doesn't stutter UI on large libraries.
+            // Background mode is incremental-only: BGAppRefreshTask gets ~30s of CPU, a full sync
+            // on a large library would hit the expirationHandler and be killed.
+            let incremental = (mode == .incremental || mode == .background)
 
-            switch mode {
-            case .full, .background:
-                try await syncAlbums(client: client, context: context, stats: &stats, incremental: false)
-                try await syncArtists(client: client, context: context, stats: &stats, incremental: false)
-                try await syncSongs(client: client, context: context, stats: &stats, incremental: false)
-                try await syncPlaylists(client: client, context: context, stats: &stats)
+            stats = try await Task.detached(priority: .utility) { () -> SyncStats in
+                var working = SyncStats()
+
+                try await Self.syncAlbumsOffMain(
+                    client: client, container: container,
+                    stats: &working, incremental: incremental,
+                    progress: updateProgress, publishStats: publishPartialStats
+                )
+                try await Self.syncArtistsOffMain(
+                    client: client, container: container,
+                    stats: &working, incremental: incremental,
+                    progress: updateProgress, publishStats: publishPartialStats
+                )
+                try await Self.syncSongsOffMain(
+                    client: client, container: container,
+                    stats: &working, incremental: incremental,
+                    progress: updateProgress, publishStats: publishPartialStats
+                )
+                try await Self.syncPlaylistsOffMain(
+                    client: client, container: container,
+                    stats: &working,
+                    progress: updateProgress, publishStats: publishPartialStats
+                )
+                return working
+            }.value
+
+            if mode == .full {
                 UserDefaults.standard.set(Date(), forKey: UserDefaultsKeys.lastFullSyncDate)
-
-            case .incremental:
-                try await syncAlbums(client: client, context: context, stats: &stats, incremental: true)
-                try await syncArtists(client: client, context: context, stats: &stats, incremental: true)
-                try await syncSongs(client: client, context: context, stats: &stats, incremental: true)
-                try await syncPlaylists(client: client, context: context, stats: &stats)
             }
 
-            try context.save()
             lastSyncDate = Date()
             lastSyncStats = stats
 
-            // Save sync history
-            saveSyncHistory(stats: stats, mode: mode, context: context)
+            // Save sync history on a fresh context (the work context above is already gone).
+            let historyContext = ModelContext(container)
+            historyContext.autosaveEnabled = false
+            saveSyncHistory(stats: stats, mode: mode, context: historyContext)
 
             syncLog.info("""
                 Library sync (\(mode.rawValue)) completed in \
@@ -199,9 +234,14 @@ final class LibrarySyncManager {
                 -\(stats.albumsRemoved + stats.artistsRemoved + stats.songsRemoved))
                 """)
 
-            // Prefetch cover art in background after metadata sync
-            if stats.albumsAdded > 0 || stats.artistsAdded > 0 {
-                await prefetchCoverArt(client: client, context: context)
+            // Prefetch cover art in background after metadata sync. Also fires when existing
+            // albums/artists gain a new coverArtId (e.g. server-side art-scan completes after
+            // the metadata was already cached), not just when new rows are inserted.
+            let artChanged = stats.albumsAdded > 0 || stats.artistsAdded > 0 ||
+                stats.albumsUpdated > 0 || stats.artistsUpdated > 0
+            if artChanged {
+                let prefetchContext = ModelContext(container)
+                await prefetchCoverArt(client: client, context: prefetchContext)
             }
         } catch {
             syncError = "Sync failed: \(error.localizedDescription)"
@@ -232,23 +272,22 @@ final class LibrarySyncManager {
         }
     }
 
-    /// Update the stored server lastModified timestamp.
-    private func updateServerModifiedTimestamp(client: SubsonicClient) async {
-        do {
-            let indexes = try await client.getIndexes()
-            if let lastModified = indexes.lastModified {
-                UserDefaults.standard.set(lastModified, forKey: UserDefaultsKeys.lastServerModified)
-            }
-        } catch {
-            syncLog.warning("Failed to fetch server modified timestamp: \(error.localizedDescription)")
-        }
-    }
-
     // MARK: - Albums
 
-    private func syncAlbums(client: SubsonicClient, context: ModelContext,
-                            stats: inout SyncStats, incremental: Bool) async throws {
-        syncProgress = "Syncing albums…"
+    /// Nonisolated so the fetch / insert / diff loops run off MainActor. On 10k+ libraries
+    /// these previously stuttered the UI every polling interval.
+    nonisolated static func syncAlbumsOffMain(
+        client: SubsonicClient,
+        container: ModelContainer,
+        stats: inout SyncStats,
+        incremental: Bool,
+        progress: @Sendable (String) -> Void,
+        publishStats: @Sendable (SyncStats) -> Void
+    ) async throws {
+        progress("Syncing albums…")
+
+        let context = ModelContext(container)
+        context.autosaveEnabled = false
 
         // Build lookup dictionary of existing albums for O(1) access
         let allLocal = try context.fetch(FetchDescriptor<CachedAlbum>())
@@ -300,7 +339,7 @@ final class LibrarySyncManager {
                 }
 
                 totalFetched += page.count
-                syncProgress = "Syncing albums… \(totalFetched)"
+                progress("Syncing albums… \(totalFetched)")
                 offset += page.count
 
                 if page.count < albumPageSize { break }
@@ -314,14 +353,14 @@ final class LibrarySyncManager {
         }
 
         try context.save()
-        lastSyncStats = stats
+        publishStats(stats)
         let added = stats.albumsAdded
         let updated = stats.albumsUpdated
         let removed = stats.albumsRemoved
         syncLog.info("Synced \(totalFetched) albums (+\(added) ~\(updated) -\(removed))")
     }
 
-    private func hasAlbumChanged(_ cached: CachedAlbum, _ server: Album) -> Bool {
+    nonisolated static func hasAlbumChanged(_ cached: CachedAlbum, _ server: Album) -> Bool {
         cached.name != server.name ||
         cached.artistName != server.artist ||
         cached.artistId != server.artistId ||
@@ -338,11 +377,20 @@ final class LibrarySyncManager {
 
     // MARK: - Artists
 
-    private func syncArtists(client: SubsonicClient, context: ModelContext,
-                             stats: inout SyncStats, incremental: Bool) async throws {
-        syncProgress = "Syncing artists…"
+    nonisolated static func syncArtistsOffMain(
+        client: SubsonicClient,
+        container: ModelContainer,
+        stats: inout SyncStats,
+        incremental: Bool,
+        progress: @Sendable (String) -> Void,
+        publishStats: @Sendable (SyncStats) -> Void
+    ) async throws {
+        progress("Syncing artists…")
         let indexes = try await client.getArtists()
         var serverArtistIds = Set<String>()
+
+        let context = ModelContext(container)
+        context.autosaveEnabled = false
 
         // Build lookup dictionary
         let allLocal = try context.fetch(FetchDescriptor<CachedArtist>())
@@ -376,14 +424,14 @@ final class LibrarySyncManager {
         }
 
         try context.save()
-        lastSyncStats = stats
+        publishStats(stats)
         let artAdded = stats.artistsAdded
         let artUpdated = stats.artistsUpdated
         let artRemoved = stats.artistsRemoved
         syncLog.info("Synced \(serverArtistIds.count) artists (+\(artAdded) ~\(artUpdated) -\(artRemoved))")
     }
 
-    private func hasArtistChanged(_ cached: CachedArtist, _ server: Artist) -> Bool {
+    nonisolated static func hasArtistChanged(_ cached: CachedArtist, _ server: Artist) -> Bool {
         cached.name != server.name ||
         cached.coverArtId != server.coverArt ||
         cached.albumCount != server.albumCount ||
@@ -392,9 +440,18 @@ final class LibrarySyncManager {
 
     // MARK: - Songs
 
-    private func syncSongs(client: SubsonicClient, context: ModelContext,
-                           stats: inout SyncStats, incremental: Bool) async throws {
-        syncProgress = "Syncing songs…"
+    nonisolated static func syncSongsOffMain(
+        client: SubsonicClient,
+        container: ModelContainer,
+        stats: inout SyncStats,
+        incremental: Bool,
+        progress: @Sendable (String) -> Void,
+        publishStats: @Sendable (SyncStats) -> Void
+    ) async throws {
+        progress("Syncing songs…")
+
+        let context = ModelContext(container)
+        context.autosaveEnabled = false
 
         // Build lookup dictionary for O(1) access
         let allLocal = try context.fetch(FetchDescriptor<CachedSong>())
@@ -435,12 +492,12 @@ final class LibrarySyncManager {
             }
 
             totalFetched += songs.count
-            syncProgress = "Syncing songs… \(totalFetched)"
+            progress("Syncing songs… \(totalFetched)")
             offset += songs.count
 
             if totalFetched % 2000 == 0 {
                 try context.save()
-                lastSyncStats = stats
+                publishStats(stats)
             }
 
             if songs.count < songPageSize { break }
@@ -455,7 +512,7 @@ final class LibrarySyncManager {
         }
 
         try context.save()
-        lastSyncStats = stats
+        publishStats(stats)
         await updateServerModifiedTimestamp(client: client)
         let songAdded = stats.songsAdded
         let songUpdated = stats.songsUpdated
@@ -463,7 +520,19 @@ final class LibrarySyncManager {
         syncLog.info("Synced \(totalFetched) songs (+\(songAdded) ~\(songUpdated) -\(songRemoved))")
     }
 
-    private func hasSongChanged(_ cached: CachedSong, _ server: Song) -> Bool {
+    /// Nonisolated so songs sync (off MainActor) can call it directly.
+    nonisolated static func updateServerModifiedTimestamp(client: SubsonicClient) async {
+        do {
+            let indexes = try await client.getIndexes()
+            if let lastModified = indexes.lastModified {
+                UserDefaults.standard.set(lastModified, forKey: UserDefaultsKeys.lastServerModified)
+            }
+        } catch {
+            syncLog.warning("Failed to fetch server modified timestamp: \(error.localizedDescription)")
+        }
+    }
+
+    nonisolated static func hasSongChanged(_ cached: CachedSong, _ server: Song) -> Bool {
         cached.title != server.title ||
         cached.artist != server.artist ||
         cached.albumName != server.album ||
@@ -476,7 +545,7 @@ final class LibrarySyncManager {
         cached.bitRate != server.bitRate
     }
 
-    private func updateSongFields(_ cached: CachedSong, from song: Song) {
+    nonisolated static func updateSongFields(_ cached: CachedSong, from song: Song) {
         cached.title = song.title
         cached.artist = song.artist
         cached.albumArtist = song.albumArtist
@@ -500,11 +569,24 @@ final class LibrarySyncManager {
 
     // MARK: - Playlists
 
-    private func syncPlaylists(client: SubsonicClient, context: ModelContext,
-                               stats: inout SyncStats) async throws {
-        syncProgress = "Syncing playlists…"
+    nonisolated static func syncPlaylistsOffMain(
+        client: SubsonicClient,
+        container: ModelContainer,
+        stats: inout SyncStats,
+        progress: @Sendable (String) -> Void,
+        publishStats: @Sendable (SyncStats) -> Void
+    ) async throws {
+        progress("Syncing playlists…")
+
+        let context = ModelContext(container)
+        context.autosaveEnabled = false
+
         let playlists = try await client.getPlaylists()
-        var serverPlaylistIds = Set<String>()
+
+        // Source of truth for "what exists on the server" is the getPlaylists() list — NOT the
+        // set of playlists whose details we managed to fetch below. A transient failure on a
+        // single getPlaylist(id:) call must not cause its cached row to be deleted locally.
+        let serverPlaylistIds = Set(playlists.map { $0.id })
 
         let allLocal = try context.fetch(FetchDescriptor<CachedPlaylist>())
         let localMap = Dictionary(uniqueKeysWithValues: allLocal.map { ($0.id, $0) })
@@ -538,22 +620,23 @@ final class LibrarySyncManager {
         }
 
         for detail in details {
-            serverPlaylistIds.insert(detail.id)
             upsertPlaylist(detail, context: context, localMap: localMap)
             stats.playlistsSynced += 1
         }
 
+        // Only delete local playlists that are confirmed missing from the server list.
+        // Playlists whose detail fetch failed will simply retain their existing cached entries.
         for local in allLocal where !serverPlaylistIds.contains(local.id) {
             context.delete(local)
         }
 
         try context.save()
-        lastSyncStats = stats
+        publishStats(stats)
         syncLog.info("Synced \(playlists.count) playlists with entries")
     }
 
-    private func upsertPlaylist(_ playlist: Playlist, context: ModelContext,
-                                localMap: [String: CachedPlaylist]) {
+    nonisolated static func upsertPlaylist(_ playlist: Playlist, context: ModelContext,
+                                           localMap: [String: CachedPlaylist]) {
         let cached: CachedPlaylist
         if let existing = localMap[playlist.id] {
             existing.name = playlist.name

--- a/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
+++ b/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
@@ -590,6 +590,12 @@ final class LibrarySyncManager {
     /// Skipped if a prefetch already ran during sync this session.
     func warmImageCache(client: SubsonicClient, container: ModelContainer) async {
         guard !didPrefetchThisSession else { return }
+        // Skip if a full prefetch completed recently (within 24 hours)
+        if let lastPrefetch = UserDefaults.standard.object(forKey: UserDefaultsKeys.lastCoverArtPrefetchDate) as? Date,
+           Date().timeIntervalSince(lastPrefetch) < 86_400 {
+            didPrefetchThisSession = true
+            return
+        }
         let context = ModelContext(container)
         await prefetchCoverArt(client: client, context: context)
     }
@@ -624,22 +630,39 @@ final class LibrarySyncManager {
         syncLog.info("Prefetching \(total) cover art images")
 
         let pipeline = ImagePipeline.shared
-        let urlMap: [(String, URL)] = coverArtIds.map { id in
-            (id, client.coverArtURL(id: id, size: 600))
+
+        // Filter out images already in memory or disk cache so we only fetch what's missing
+        let dataCache = pipeline.configuration.dataCache as? DataCache
+        let uncachedUrls: [(String, URL)] = coverArtIds.compactMap { id in
+            let url = client.coverArtURL(id: id, size: 600)
+            let request = ImageRequest(url: url)
+            if pipeline.cache.containsCachedImage(for: request) { return nil }
+            let key = pipeline.cache.makeDataCacheKey(for: request)
+            if dataCache?.containsData(for: key) == true { return nil }
+            return (id, url)
         }
 
-        var fetched = 0
+        let alreadyCached = total - uncachedUrls.count
+        guard !uncachedUrls.isEmpty else {
+            didPrefetchThisSession = true
+            UserDefaults.standard.set(Date(), forKey: UserDefaultsKeys.lastCoverArtPrefetchDate)
+            syncLog.info("Cover art prefetch skipped — all \(total) images already cached")
+            return
+        }
+
+        syncLog.info("Prefetching \(uncachedUrls.count) cover art images (\(alreadyCached) already cached)")
+
+        var fetched = alreadyCached
         let batchSize = 10
         let perImageTimeout: UInt64 = 15_000_000_000 // 15 seconds
 
-        for batchStart in stride(from: 0, to: urlMap.count, by: batchSize) {
+        for batchStart in stride(from: 0, to: uncachedUrls.count, by: batchSize) {
             guard !Task.isCancelled else { break }
-            let batch = urlMap[batchStart..<min(batchStart + batchSize, urlMap.count)]
+            let batch = uncachedUrls[batchStart..<min(batchStart + batchSize, uncachedUrls.count)]
             await withTaskGroup(of: Void.self) { group in
                 for (_, url) in batch {
                     group.addTask {
                         let request = ImageRequest(url: url)
-                        if pipeline.cache.containsCachedImage(for: request) { return }
                         // Timeout prevents a single stalled request from blocking the entire prefetch
                         await withTaskGroup(of: Void.self) { inner in
                             inner.addTask {
@@ -660,7 +683,8 @@ final class LibrarySyncManager {
         }
 
         didPrefetchThisSession = true
-        syncLog.info("Cover art prefetch complete: \(fetched) processed")
+        UserDefaults.standard.set(Date(), forKey: UserDefaultsKeys.lastCoverArtPrefetchDate)
+        syncLog.info("Cover art prefetch complete: \(fetched)/\(total) processed")
     }
 
     // MARK: - Sync History

--- a/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
+++ b/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
@@ -40,6 +40,8 @@ final class LibrarySyncManager {
     /// Polling timer for change detection while app is active.
     private var pollingTask: Task<Void, Never>?
 
+    // Page sizes for paginated API calls. 500 is a safe default for most Subsonic servers;
+    // could be made configurable per-server if needed for very large or constrained instances.
     private let albumPageSize = 500
     private let songPageSize = 500
 

--- a/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
+++ b/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
@@ -509,27 +509,29 @@ final class LibrarySyncManager {
         let allLocal = try context.fetch(FetchDescriptor<CachedPlaylist>())
         let localMap = Dictionary(uniqueKeysWithValues: allLocal.map { ($0.id, $0) })
 
-        // Fetch playlist details with bounded concurrency
-        let details = try await withThrowingTaskGroup(of: Playlist.self, returning: [Playlist].self) { group in
+        // Fetch playlist details with bounded concurrency (tolerates individual failures e.g. deleted playlists)
+        let details = await withTaskGroup(of: Playlist?.self, returning: [Playlist].self) { group in
             var results: [Playlist] = []
             var inflight = 0
             let maxConcurrency = 2
 
             for playlist in playlists {
                 if inflight >= maxConcurrency {
-                    if let detail = try await group.next() {
+                    if let detail = await group.next() ?? nil {
                         results.append(detail)
                     }
                     inflight -= 1
                 }
                 group.addTask {
-                    try await client.getPlaylist(id: playlist.id)
+                    try? await client.getPlaylist(id: playlist.id)
                 }
                 inflight += 1
             }
 
-            for try await detail in group {
-                results.append(detail)
+            for await detail in group {
+                if let detail {
+                    results.append(detail)
+                }
             }
             return results
         }

--- a/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
+++ b/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
@@ -117,7 +117,7 @@ final class LibrarySyncManager {
         } else {
             // Server unchanged — just update the stale check timestamp
             lastSyncDate = Date()
-            syncLog.info("Server data unchanged, skipping sync")
+            syncLog.info("Server data unchanged, skipping sync (trigger: auto-stale-check)")
         }
     }
 
@@ -136,7 +136,7 @@ final class LibrarySyncManager {
 
                 let changed = await self.hasServerChanged(client: client)
                 if changed {
-                    syncLog.info("Polling detected server changes, triggering incremental sync")
+                    syncLog.info("Polling detected server changes, triggering incremental sync (trigger: auto-poll)")
                     await self.performSync(mode: .incremental, client: client, container: container)
                 }
             }
@@ -517,6 +517,7 @@ final class LibrarySyncManager {
 
             for playlist in playlists {
                 if inflight >= maxConcurrency {
+                    // swiftlint:disable:next redundant_nil_coalescing
                     if let detail = await group.next() ?? nil {
                         results.append(detail)
                     }
@@ -654,6 +655,16 @@ final class LibrarySyncManager {
 
         syncLog.info("Prefetching \(uncachedUrls.count) cover art images (\(alreadyCached) already cached)")
 
+        let fetched = await prefetchBatches(uncachedUrls: uncachedUrls, total: total, alreadyCached: alreadyCached)
+
+        didPrefetchThisSession = true
+        UserDefaults.standard.set(Date(), forKey: UserDefaultsKeys.lastCoverArtPrefetchDate)
+        syncLog.info("Cover art prefetch complete: \(fetched)/\(total) processed")
+    }
+
+    /// Fetch cover art in batches of 10 with per-image timeouts. Returns total processed count.
+    private func prefetchBatches(uncachedUrls: [(String, URL)], total: Int, alreadyCached: Int) async -> Int {
+        let pipeline = ImagePipeline.shared
         var fetched = alreadyCached
         let batchSize = 10
         let perImageTimeout: UInt64 = 15_000_000_000 // 15 seconds
@@ -683,10 +694,7 @@ final class LibrarySyncManager {
             fetched += batch.count
             syncProgress = "Prefetching cover art… \(fetched)/\(total)"
         }
-
-        didPrefetchThisSession = true
-        UserDefaults.standard.set(Date(), forKey: UserDefaultsKeys.lastCoverArtPrefetchDate)
-        syncLog.info("Cover art prefetch complete: \(fetched)/\(total) processed")
+        return fetched
     }
 
     // MARK: - Sync History

--- a/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
+++ b/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
@@ -1,0 +1,706 @@
+import Foundation
+import Nuke
+import SwiftData
+import os.log
+
+private let syncLog = Logger(subsystem: "com.vibrdrome.app", category: "LibrarySync")
+
+/// Sync mode determines the depth of library synchronization.
+enum SyncMode: String, Sendable {
+    /// Full re-sync of all metadata — catches additions, updates, and deletions.
+    case full
+    /// Lightweight sync — only fetches recently changed content.
+    case incremental
+    /// Triggered by BGTaskScheduler in the background.
+    case background
+}
+
+/// Syncs library metadata (albums, artists, songs, playlists) from the Subsonic API
+/// into SwiftData for local filtering, search, and offline support.
+@Observable
+@MainActor
+final class LibrarySyncManager {
+    static let shared = LibrarySyncManager()
+
+    /// Configured by AppState at login for convenience sync calls.
+    weak var client: SubsonicClient?
+    var container: ModelContainer?
+
+    var isSyncing = false
+    var syncProgress: String?
+    var lastSyncDate: Date? {
+        get { UserDefaults.standard.object(forKey: UserDefaultsKeys.lastLibrarySyncDate) as? Date }
+        set { UserDefaults.standard.set(newValue, forKey: UserDefaultsKeys.lastLibrarySyncDate) }
+    }
+    var syncError: String?
+
+    /// Stats from the most recent sync, updated live during sync.
+    var lastSyncStats: SyncStats?
+
+    /// Polling timer for change detection while app is active.
+    private var pollingTask: Task<Void, Never>?
+
+    private let albumPageSize = 500
+    private let songPageSize = 500
+
+    /// Stale threshold for auto-sync (24 hours).
+    private let staleInterval: TimeInterval = 86400
+    /// Interval between full syncs to catch deletions (7 days).
+    private let fullSyncInterval: TimeInterval = 604_800
+
+    // MARK: - Sync Stats
+
+    struct SyncStats: Sendable {
+        var albumsAdded = 0
+        var albumsUpdated = 0
+        var albumsRemoved = 0
+        var artistsAdded = 0
+        var artistsUpdated = 0
+        var artistsRemoved = 0
+        var songsAdded = 0
+        var songsUpdated = 0
+        var songsRemoved = 0
+        var playlistsSynced = 0
+        var conflictsDetected = 0
+        var conflictsResolved = 0
+        var startTime = Date()
+
+        var totalChanges: Int {
+            albumsAdded + albumsUpdated + albumsRemoved +
+            artistsAdded + artistsUpdated + artistsRemoved +
+            songsAdded + songsUpdated + songsRemoved
+        }
+
+        var duration: TimeInterval {
+            Date().timeIntervalSince(startTime)
+        }
+    }
+
+    // MARK: - Public API
+
+    /// Run a full library sync: albums, artists, songs, then playlists.
+    func sync(client: SubsonicClient, container: ModelContainer) async {
+        await performSync(mode: .full, client: client, container: container)
+    }
+
+    /// Run an incremental sync — only fetches changes since last sync.
+    func incrementalSync(client: SubsonicClient, container: ModelContainer) async {
+        await performSync(mode: .incremental, client: client, container: container)
+    }
+
+    /// Convenience: sync using the configured client and container.
+    func syncIfStale() async {
+        guard let client, let container else { return }
+        await syncIfStale(client: client, container: container)
+    }
+
+    /// Check if sync is stale and trigger the appropriate sync mode.
+    func syncIfStale(client: SubsonicClient, container: ModelContainer) async {
+        guard let last = lastSyncDate else {
+            await performSync(mode: .full, client: client, container: container)
+            return
+        }
+        let elapsed = Date().timeIntervalSince(last)
+        guard elapsed > staleInterval else { return }
+
+        // Check if server data actually changed before doing work
+        let serverChanged = await hasServerChanged(client: client)
+
+        if serverChanged {
+            // Use full sync if it's been over a week, otherwise incremental
+            let lastFull = UserDefaults.standard.object(forKey: UserDefaultsKeys.lastFullSyncDate) as? Date
+            let needsFullSync = lastFull == nil || Date().timeIntervalSince(lastFull!) > fullSyncInterval
+            let mode: SyncMode = needsFullSync ? .full : .incremental
+            await performSync(mode: mode, client: client, container: container)
+        } else {
+            // Server unchanged — just update the stale check timestamp
+            lastSyncDate = Date()
+            syncLog.info("Server data unchanged, skipping sync")
+        }
+    }
+
+    // MARK: - Change Detection Polling
+
+    /// Start periodic polling for server changes while the app is active.
+    func startPolling(client: SubsonicClient, container: ModelContainer) {
+        stopPolling()
+        let intervalMinutes = UserDefaults.standard.integer(forKey: UserDefaultsKeys.syncPollingInterval)
+        let interval = max(TimeInterval(intervalMinutes > 0 ? intervalMinutes : 15) * 60, 300)
+
+        pollingTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(interval))
+                guard !Task.isCancelled, let self, !self.isSyncing else { continue }
+
+                let changed = await self.hasServerChanged(client: client)
+                if changed {
+                    syncLog.info("Polling detected server changes, triggering incremental sync")
+                    await self.performSync(mode: .incremental, client: client, container: container)
+                }
+            }
+        }
+        syncLog.info("Started change detection polling every \(Int(interval))s")
+    }
+
+    /// Stop the periodic polling timer.
+    func stopPolling() {
+        pollingTask?.cancel()
+        pollingTask = nil
+    }
+
+    // MARK: - Core Sync Engine
+
+    private func performSync(mode: SyncMode, client: SubsonicClient, container: ModelContainer) async {
+        guard !isSyncing else { return }
+        isSyncing = true
+        syncError = nil
+        syncProgress = mode == .full ? "Starting full sync…" : "Starting incremental sync…"
+        var stats = SyncStats()
+        lastSyncStats = stats
+        defer {
+            isSyncing = false
+            syncProgress = nil
+        }
+
+        do {
+            let context = ModelContext(container)
+            context.autosaveEnabled = false
+
+            switch mode {
+            case .full, .background:
+                try await syncAlbums(client: client, context: context, stats: &stats, incremental: false)
+                try await syncArtists(client: client, context: context, stats: &stats, incremental: false)
+                try await syncSongs(client: client, context: context, stats: &stats, incremental: false)
+                try await syncPlaylists(client: client, context: context, stats: &stats)
+                UserDefaults.standard.set(Date(), forKey: UserDefaultsKeys.lastFullSyncDate)
+
+            case .incremental:
+                try await syncAlbums(client: client, context: context, stats: &stats, incremental: true)
+                try await syncArtists(client: client, context: context, stats: &stats, incremental: true)
+                try await syncSongs(client: client, context: context, stats: &stats, incremental: true)
+                try await syncPlaylists(client: client, context: context, stats: &stats)
+            }
+
+            try context.save()
+            lastSyncDate = Date()
+            lastSyncStats = stats
+
+            // Save sync history
+            saveSyncHistory(stats: stats, mode: mode, context: context)
+
+            syncLog.info("""
+                Library sync (\(mode.rawValue)) completed in \
+                \(String(format: "%.1f", stats.duration))s — \
+                \(stats.totalChanges) changes \
+                (+\(stats.albumsAdded + stats.artistsAdded + stats.songsAdded) \
+                ~\(stats.albumsUpdated + stats.artistsUpdated + stats.songsUpdated) \
+                -\(stats.albumsRemoved + stats.artistsRemoved + stats.songsRemoved))
+                """)
+
+            // Prefetch cover art in background after metadata sync
+            if stats.albumsAdded > 0 || stats.artistsAdded > 0 {
+                await prefetchCoverArt(client: client, context: context)
+            }
+        } catch {
+            syncError = "Sync failed: \(error.localizedDescription)"
+            lastSyncStats = stats
+            saveSyncHistory(stats: stats, mode: mode, context: ModelContext(container), error: error)
+            syncLog.error("Library sync (\(mode.rawValue)) failed: \(error)")
+        }
+    }
+
+    // MARK: - Server Change Detection
+
+    /// Lightweight check if server data has changed since last sync.
+    /// Uses getIndexes with ifModifiedSince to avoid fetching full data.
+    private func hasServerChanged(client: SubsonicClient) async -> Bool {
+        let lastModified = UserDefaults.standard.integer(forKey: UserDefaultsKeys.lastServerModified)
+        guard lastModified > 0 else { return true }
+
+        do {
+            let indexes = try await client.getIndexes(ifModifiedSince: lastModified)
+            if let serverModified = indexes.lastModified, serverModified > lastModified {
+                return true
+            }
+            let hasContent = indexes.index?.isEmpty == false || indexes.child?.isEmpty == false
+            return hasContent
+        } catch {
+            syncLog.warning("Change detection failed: \(error.localizedDescription)")
+            return true
+        }
+    }
+
+    /// Update the stored server lastModified timestamp.
+    private func updateServerModifiedTimestamp(client: SubsonicClient) async {
+        do {
+            let indexes = try await client.getIndexes()
+            if let lastModified = indexes.lastModified {
+                UserDefaults.standard.set(lastModified, forKey: UserDefaultsKeys.lastServerModified)
+            }
+        } catch {
+            syncLog.warning("Failed to fetch server modified timestamp: \(error.localizedDescription)")
+        }
+    }
+
+    // MARK: - Albums
+
+    private func syncAlbums(client: SubsonicClient, context: ModelContext,
+                            stats: inout SyncStats, incremental: Bool) async throws {
+        syncProgress = "Syncing albums…"
+
+        // Build lookup dictionary of existing albums for O(1) access
+        let allLocal = try context.fetch(FetchDescriptor<CachedAlbum>())
+        var localMap = Dictionary(uniqueKeysWithValues: allLocal.map { ($0.id, $0) })
+
+        var offset = 0
+        var serverAlbumIds = Set<String>()
+        var totalFetched = 0
+
+        if incremental {
+            // Fetch only newest albums (added/modified recently)
+            let newestAlbums = try await client.getAlbumList(type: .newest, size: albumPageSize)
+            for album in newestAlbums {
+                serverAlbumIds.insert(album.id)
+                if let existing = localMap[album.id] {
+                    if hasAlbumChanged(existing, album) {
+                        existing.update(from: album)
+                        stats.albumsUpdated += 1
+                    }
+                } else {
+                    let cached = CachedAlbum(from: album)
+                    context.insert(cached)
+                    localMap[album.id] = cached
+                    stats.albumsAdded += 1
+                }
+            }
+            totalFetched = newestAlbums.count
+        } else {
+            // Full sync: fetch all albums
+            while true {
+                let page = try await client.getAlbumList(
+                    type: .alphabeticalByName, size: albumPageSize, offset: offset
+                )
+                if page.isEmpty { break }
+
+                for album in page {
+                    serverAlbumIds.insert(album.id)
+                    if let existing = localMap[album.id] {
+                        if hasAlbumChanged(existing, album) {
+                            existing.update(from: album)
+                            stats.albumsUpdated += 1
+                        }
+                    } else {
+                        let cached = CachedAlbum(from: album)
+                        context.insert(cached)
+                        localMap[album.id] = cached
+                        stats.albumsAdded += 1
+                    }
+                }
+
+                totalFetched += page.count
+                syncProgress = "Syncing albums… \(totalFetched)"
+                offset += page.count
+
+                if page.count < albumPageSize { break }
+            }
+
+            // Remove albums no longer on server
+            for local in allLocal where !serverAlbumIds.contains(local.id) {
+                context.delete(local)
+                stats.albumsRemoved += 1
+            }
+        }
+
+        try context.save()
+        lastSyncStats = stats
+        let added = stats.albumsAdded
+        let updated = stats.albumsUpdated
+        let removed = stats.albumsRemoved
+        syncLog.info("Synced \(totalFetched) albums (+\(added) ~\(updated) -\(removed))")
+    }
+
+    private func hasAlbumChanged(_ cached: CachedAlbum, _ server: Album) -> Bool {
+        cached.name != server.name ||
+        cached.artistName != server.artist ||
+        cached.artistId != server.artistId ||
+        cached.year != server.year ||
+        cached.genre != server.genre ||
+        cached.songCount != server.songCount ||
+        cached.duration != server.duration ||
+        cached.isStarred != (server.starred != nil) ||
+        cached.coverArtId != server.coverArt ||
+        cached.created != server.created ||
+        cached.userRating != (server.userRating ?? 0) ||
+        cached.label != server.label
+    }
+
+    // MARK: - Artists
+
+    private func syncArtists(client: SubsonicClient, context: ModelContext,
+                             stats: inout SyncStats, incremental: Bool) async throws {
+        syncProgress = "Syncing artists…"
+        let indexes = try await client.getArtists()
+        var serverArtistIds = Set<String>()
+
+        // Build lookup dictionary
+        let allLocal = try context.fetch(FetchDescriptor<CachedArtist>())
+        let localMap = Dictionary(uniqueKeysWithValues: allLocal.map { ($0.id, $0) })
+
+        for index in indexes {
+            for artist in index.artist ?? [] {
+                serverArtistIds.insert(artist.id)
+                if let existing = localMap[artist.id] {
+                    if hasArtistChanged(existing, artist) {
+                        existing.name = artist.name
+                        existing.coverArtId = artist.coverArt
+                        existing.albumCount = artist.albumCount
+                        existing.isStarred = artist.starred != nil
+                        existing.cachedAt = Date()
+                        stats.artistsUpdated += 1
+                    }
+                } else {
+                    context.insert(CachedArtist(from: artist))
+                    stats.artistsAdded += 1
+                }
+            }
+        }
+
+        // Remove artists no longer on server (only on full sync)
+        if !incremental {
+            for local in allLocal where !serverArtistIds.contains(local.id) {
+                context.delete(local)
+                stats.artistsRemoved += 1
+            }
+        }
+
+        try context.save()
+        lastSyncStats = stats
+        let artAdded = stats.artistsAdded
+        let artUpdated = stats.artistsUpdated
+        let artRemoved = stats.artistsRemoved
+        syncLog.info("Synced \(serverArtistIds.count) artists (+\(artAdded) ~\(artUpdated) -\(artRemoved))")
+    }
+
+    private func hasArtistChanged(_ cached: CachedArtist, _ server: Artist) -> Bool {
+        cached.name != server.name ||
+        cached.coverArtId != server.coverArt ||
+        cached.albumCount != server.albumCount ||
+        cached.isStarred != (server.starred != nil)
+    }
+
+    // MARK: - Songs
+
+    private func syncSongs(client: SubsonicClient, context: ModelContext,
+                           stats: inout SyncStats, incremental: Bool) async throws {
+        syncProgress = "Syncing songs…"
+
+        // Build lookup dictionary for O(1) access
+        let allLocal = try context.fetch(FetchDescriptor<CachedSong>())
+        var localMap = Dictionary(uniqueKeysWithValues: allLocal.map { ($0.id, $0) })
+
+        // Pre-fetch album map for linking
+        let allAlbums = try context.fetch(FetchDescriptor<CachedAlbum>())
+        let albumMap = Dictionary(uniqueKeysWithValues: allAlbums.map { ($0.id, $0) })
+
+        var offset = 0
+        var serverSongIds = Set<String>()
+        var totalFetched = 0
+
+        while true {
+            let result = try await client.search(
+                query: "", artistCount: 0, albumCount: 0,
+                songCount: songPageSize, songOffset: offset
+            )
+            let songs = result.song ?? []
+            if songs.isEmpty { break }
+
+            for song in songs {
+                serverSongIds.insert(song.id)
+                if let existing = localMap[song.id] {
+                    if hasSongChanged(existing, song) {
+                        updateSongFields(existing, from: song)
+                        stats.songsUpdated += 1
+                    }
+                } else {
+                    let cached = CachedSong(from: song)
+                    if let albumId = song.albumId {
+                        cached.album = albumMap[albumId]
+                    }
+                    context.insert(cached)
+                    localMap[song.id] = cached
+                    stats.songsAdded += 1
+                }
+            }
+
+            totalFetched += songs.count
+            syncProgress = "Syncing songs… \(totalFetched)"
+            offset += songs.count
+
+            if totalFetched % 2000 == 0 {
+                try context.save()
+                lastSyncStats = stats
+            }
+
+            if songs.count < songPageSize { break }
+        }
+
+        // Remove songs no longer on server (only on full sync, preserve downloads)
+        if !incremental {
+            for local in allLocal where !serverSongIds.contains(local.id) && local.download == nil {
+                context.delete(local)
+                stats.songsRemoved += 1
+            }
+        }
+
+        try context.save()
+        lastSyncStats = stats
+        await updateServerModifiedTimestamp(client: client)
+        let songAdded = stats.songsAdded
+        let songUpdated = stats.songsUpdated
+        let songRemoved = stats.songsRemoved
+        syncLog.info("Synced \(totalFetched) songs (+\(songAdded) ~\(songUpdated) -\(songRemoved))")
+    }
+
+    private func hasSongChanged(_ cached: CachedSong, _ server: Song) -> Bool {
+        cached.title != server.title ||
+        cached.artist != server.artist ||
+        cached.albumName != server.album ||
+        cached.track != server.track ||
+        cached.year != server.year ||
+        cached.genre != server.genre ||
+        cached.duration != server.duration ||
+        cached.isStarred != (server.starred != nil) ||
+        cached.coverArtId != server.coverArt ||
+        cached.bitRate != server.bitRate
+    }
+
+    private func updateSongFields(_ cached: CachedSong, from song: Song) {
+        cached.title = song.title
+        cached.artist = song.artist
+        cached.albumArtist = song.albumArtist
+        cached.albumName = song.album
+        cached.albumId = song.albumId
+        cached.artistId = song.artistId
+        cached.coverArtId = song.coverArt
+        cached.track = song.track
+        cached.discNumber = song.discNumber
+        cached.year = song.year
+        cached.genre = song.genre
+        cached.duration = song.duration
+        cached.bitRate = song.bitRate
+        cached.suffix = song.suffix
+        cached.contentType = song.contentType
+        cached.size = song.size
+        cached.isStarred = song.starred != nil
+        cached.rating = song.userRating ?? 0
+        cached.cachedAt = Date()
+    }
+
+    // MARK: - Playlists
+
+    private func syncPlaylists(client: SubsonicClient, context: ModelContext,
+                               stats: inout SyncStats) async throws {
+        syncProgress = "Syncing playlists…"
+        let playlists = try await client.getPlaylists()
+        var serverPlaylistIds = Set<String>()
+
+        let allLocal = try context.fetch(FetchDescriptor<CachedPlaylist>())
+        let localMap = Dictionary(uniqueKeysWithValues: allLocal.map { ($0.id, $0) })
+
+        // Fetch playlist details with bounded concurrency
+        let details = try await withThrowingTaskGroup(of: Playlist.self, returning: [Playlist].self) { group in
+            var results: [Playlist] = []
+            var inflight = 0
+            let maxConcurrency = 2
+
+            for playlist in playlists {
+                if inflight >= maxConcurrency {
+                    if let detail = try await group.next() {
+                        results.append(detail)
+                    }
+                    inflight -= 1
+                }
+                group.addTask {
+                    try await client.getPlaylist(id: playlist.id)
+                }
+                inflight += 1
+            }
+
+            for try await detail in group {
+                results.append(detail)
+            }
+            return results
+        }
+
+        for detail in details {
+            serverPlaylistIds.insert(detail.id)
+            upsertPlaylist(detail, context: context, localMap: localMap)
+            stats.playlistsSynced += 1
+        }
+
+        for local in allLocal where !serverPlaylistIds.contains(local.id) {
+            context.delete(local)
+        }
+
+        try context.save()
+        lastSyncStats = stats
+        syncLog.info("Synced \(playlists.count) playlists with entries")
+    }
+
+    private func upsertPlaylist(_ playlist: Playlist, context: ModelContext,
+                                localMap: [String: CachedPlaylist]) {
+        let cached: CachedPlaylist
+        if let existing = localMap[playlist.id] {
+            existing.name = playlist.name
+            existing.songCount = playlist.songCount
+            existing.duration = playlist.duration
+            existing.coverArtId = playlist.coverArt
+            existing.owner = playlist.owner
+            existing.isPublic = playlist.isPublic ?? false
+            existing.changed = playlist.changed
+            existing.cachedAt = Date()
+            cached = existing
+        } else {
+            cached = CachedPlaylist(from: playlist)
+            context.insert(cached)
+        }
+
+        for entry in cached.entries {
+            context.delete(entry)
+        }
+
+        if let songs = playlist.entry {
+            for (index, song) in songs.enumerated() {
+                let entry = CachedPlaylistEntry(songId: song.id, order: index)
+                entry.playlist = cached
+                context.insert(entry)
+            }
+        }
+    }
+
+    // MARK: - Cover Art Prefetch
+
+    /// Whether a prefetch pass already ran this session (avoids duplicate work).
+    private var didPrefetchThisSession = false
+
+    /// Warm the in-memory image cache on startup by loading all known cover art.
+    /// Images already in memory are skipped; images in disk cache load instantly.
+    /// Skipped if a prefetch already ran during sync this session.
+    func warmImageCache(client: SubsonicClient, container: ModelContainer) async {
+        guard !didPrefetchThisSession else { return }
+        let context = ModelContext(container)
+        await prefetchCoverArt(client: client, context: context)
+    }
+
+    private func prefetchCoverArt(client: SubsonicClient, context: ModelContext) async {
+        syncProgress = "Prefetching cover art…"
+
+        // Collect cover art IDs from albums and artists without loading full objects
+        var coverArtIds = Set<String>()
+
+        let albumDescriptor = FetchDescriptor<CachedAlbum>(
+            predicate: #Predicate<CachedAlbum> { $0.coverArtId != nil }
+        )
+        let albums = (try? context.fetch(albumDescriptor)) ?? []
+        for album in albums {
+            if let id = album.coverArtId { coverArtIds.insert(id) }
+        }
+
+        let artistDescriptor = FetchDescriptor<CachedArtist>(
+            predicate: #Predicate<CachedArtist> { $0.coverArtId != nil }
+        )
+        let artists = (try? context.fetch(artistDescriptor)) ?? []
+        for artist in artists {
+            if let id = artist.coverArtId { coverArtIds.insert(id) }
+        }
+
+        let total = coverArtIds.count
+        guard total > 0 else {
+            didPrefetchThisSession = true
+            return
+        }
+        syncLog.info("Prefetching \(total) cover art images")
+
+        let pipeline = ImagePipeline.shared
+        let urlMap: [(String, URL)] = coverArtIds.map { id in
+            (id, client.coverArtURL(id: id, size: 600))
+        }
+
+        var fetched = 0
+        let batchSize = 10
+        let perImageTimeout: UInt64 = 15_000_000_000 // 15 seconds
+
+        for batchStart in stride(from: 0, to: urlMap.count, by: batchSize) {
+            guard !Task.isCancelled else { break }
+            let batch = urlMap[batchStart..<min(batchStart + batchSize, urlMap.count)]
+            await withTaskGroup(of: Void.self) { group in
+                for (_, url) in batch {
+                    group.addTask {
+                        let request = ImageRequest(url: url)
+                        if pipeline.cache.containsCachedImage(for: request) { return }
+                        // Timeout prevents a single stalled request from blocking the entire prefetch
+                        await withTaskGroup(of: Void.self) { inner in
+                            inner.addTask {
+                                _ = try? await pipeline.image(for: request)
+                            }
+                            inner.addTask {
+                                try? await Task.sleep(nanoseconds: perImageTimeout)
+                            }
+                            // Return as soon as the first child completes (image loaded or timeout)
+                            await inner.next()
+                            inner.cancelAll()
+                        }
+                    }
+                }
+            }
+            fetched += batch.count
+            syncProgress = "Prefetching cover art… \(fetched)/\(total)"
+        }
+
+        didPrefetchThisSession = true
+        syncLog.info("Cover art prefetch complete: \(fetched) processed")
+    }
+
+    // MARK: - Sync History
+
+    private func saveSyncHistory(stats: SyncStats, mode: SyncMode,
+                                 context: ModelContext, error: Error? = nil) {
+        let history = SyncHistory(syncType: mode.rawValue)
+        history.durationSeconds = stats.duration
+        history.albumsAdded = stats.albumsAdded
+        history.albumsUpdated = stats.albumsUpdated
+        history.albumsRemoved = stats.albumsRemoved
+        history.artistsAdded = stats.artistsAdded
+        history.artistsUpdated = stats.artistsUpdated
+        history.artistsRemoved = stats.artistsRemoved
+        history.songsAdded = stats.songsAdded
+        history.songsUpdated = stats.songsUpdated
+        history.songsRemoved = stats.songsRemoved
+        history.playlistsSynced = stats.playlistsSynced
+        history.conflictsDetected = stats.conflictsDetected
+        history.conflictsResolved = stats.conflictsResolved
+        history.succeeded = error == nil
+        history.errorMessage = error?.localizedDescription
+        context.insert(history)
+        try? context.save()
+
+        pruneSyncHistory(context: context)
+    }
+
+    private func pruneSyncHistory(context: ModelContext) {
+        var descriptor = FetchDescriptor<SyncHistory>(
+            sortBy: [SortDescriptor(\.syncDate, order: .reverse)]
+        )
+        descriptor.fetchOffset = 50
+        do {
+            let old = try context.fetch(descriptor)
+            guard !old.isEmpty else { return }
+            for entry in old {
+                context.delete(entry)
+            }
+            try context.save()
+        } catch {
+            syncLog.warning("Failed to prune sync history: \(error.localizedDescription)")
+        }
+    }
+}

--- a/Vibrdrome/Core/Persistence/Models/CachedAlbum.swift
+++ b/Vibrdrome/Core/Persistence/Models/CachedAlbum.swift
@@ -13,6 +13,9 @@ final class CachedAlbum {
     var songCount: Int?
     var duration: Int?
     var isStarred: Bool = false
+    var created: String?
+    var userRating: Int = 0
+    var label: String?
     var cachedAt: Date = Date()
 
     var songs: [CachedSong] = []
@@ -28,5 +31,47 @@ final class CachedAlbum {
         self.songCount = album.songCount
         self.duration = album.duration
         self.isStarred = album.starred != nil
+        self.created = album.created
+        self.userRating = album.userRating ?? 0
+        self.label = album.label
+    }
+
+    /// Update existing record with fresh server data.
+    func update(from album: Album) {
+        name = album.name
+        artistName = album.artist
+        artistId = album.artistId
+        coverArtId = album.coverArt
+        year = album.year
+        genre = album.genre
+        songCount = album.songCount
+        duration = album.duration
+        isStarred = album.starred != nil
+        created = album.created
+        userRating = album.userRating ?? 0
+        label = album.label
+        cachedAt = Date()
+    }
+
+    /// Convert back to an Album value type for view compatibility.
+    func toAlbum() -> Album {
+        Album(
+            id: id,
+            name: name,
+            artist: artistName,
+            artistId: artistId,
+            coverArt: coverArtId,
+            songCount: songCount,
+            duration: duration,
+            year: year,
+            genre: genre,
+            starred: isStarred ? "true" : nil,
+            created: created,
+            userRating: userRating > 0 ? userRating : nil,
+            song: nil,
+            replayGain: nil,
+            musicBrainzId: nil,
+            recordLabels: label.map { [RecordLabel(name: $0)] }
+        )
     }
 }

--- a/Vibrdrome/Core/Persistence/Models/CachedArtist.swift
+++ b/Vibrdrome/Core/Persistence/Models/CachedArtist.swift
@@ -17,4 +17,15 @@ final class CachedArtist {
         self.albumCount = artist.albumCount
         self.isStarred = artist.starred != nil
     }
+
+    func toArtist() -> Artist {
+        Artist(
+            id: id,
+            name: name,
+            coverArt: coverArtId,
+            albumCount: albumCount,
+            starred: isStarred ? "true" : nil,
+            album: nil
+        )
+    }
 }

--- a/Vibrdrome/Core/Persistence/Models/CachedPlaylist.swift
+++ b/Vibrdrome/Core/Persistence/Models/CachedPlaylist.swift
@@ -26,6 +26,7 @@ final class CachedPlaylist {
         self.changed = playlist.changed
     }
 
+    /// Converts to a lightweight Playlist with `entry: nil`; songs are loaded separately in PlaylistDetailView.
     func toPlaylist() -> Playlist {
         Playlist(
             id: id,

--- a/Vibrdrome/Core/Persistence/Models/CachedPlaylist.swift
+++ b/Vibrdrome/Core/Persistence/Models/CachedPlaylist.swift
@@ -10,7 +10,10 @@ final class CachedPlaylist {
     var coverArtId: String?
     var owner: String?
     var isPublic: Bool = false
+    var changed: String?
     var cachedAt: Date = Date()
+
+    @Relationship(deleteRule: .cascade) var entries: [CachedPlaylistEntry] = []
 
     init(from playlist: Playlist) {
         self.id = playlist.id
@@ -20,5 +23,21 @@ final class CachedPlaylist {
         self.coverArtId = playlist.coverArt
         self.owner = playlist.owner
         self.isPublic = playlist.isPublic ?? false
+        self.changed = playlist.changed
+    }
+
+    func toPlaylist() -> Playlist {
+        Playlist(
+            id: id,
+            name: name,
+            songCount: songCount,
+            duration: duration,
+            created: nil,
+            changed: changed,
+            coverArt: coverArtId,
+            owner: owner,
+            isPublic: isPublic,
+            entry: nil
+        )
     }
 }

--- a/Vibrdrome/Core/Persistence/Models/CachedPlaylistEntry.swift
+++ b/Vibrdrome/Core/Persistence/Models/CachedPlaylistEntry.swift
@@ -1,0 +1,15 @@
+import Foundation
+import SwiftData
+
+@Model
+final class CachedPlaylistEntry {
+    var songId: String
+    var order: Int
+
+    var playlist: CachedPlaylist?
+
+    init(songId: String, order: Int) {
+        self.songId = songId
+        self.order = order
+    }
+}

--- a/Vibrdrome/Core/Persistence/Models/SyncHistory.swift
+++ b/Vibrdrome/Core/Persistence/Models/SyncHistory.swift
@@ -1,0 +1,52 @@
+import Foundation
+import SwiftData
+
+@Model
+final class SyncHistory {
+    var syncDate: Date = Date()
+    /// "full", "incremental", "background"
+    var syncType: String = "full"
+    var durationSeconds: Double = 0
+    var albumsAdded: Int = 0
+    var albumsUpdated: Int = 0
+    var albumsRemoved: Int = 0
+    var artistsAdded: Int = 0
+    var artistsUpdated: Int = 0
+    var artistsRemoved: Int = 0
+    var songsAdded: Int = 0
+    var songsUpdated: Int = 0
+    var songsRemoved: Int = 0
+    var playlistsSynced: Int = 0
+    var conflictsDetected: Int = 0
+    var conflictsResolved: Int = 0
+    var errorMessage: String?
+    var succeeded: Bool = true
+
+    init(syncType: String) {
+        self.syncType = syncType
+        self.syncDate = Date()
+    }
+
+    var totalChanges: Int {
+        albumsAdded + albumsUpdated + albumsRemoved +
+        artistsAdded + artistsUpdated + artistsRemoved +
+        songsAdded + songsUpdated + songsRemoved
+    }
+
+    var summary: String {
+        if !succeeded, let error = errorMessage {
+            return "Failed: \(error)"
+        }
+        if totalChanges == 0 {
+            return "No changes"
+        }
+        var parts: [String] = []
+        let added = albumsAdded + artistsAdded + songsAdded
+        let updated = albumsUpdated + artistsUpdated + songsUpdated
+        let removed = albumsRemoved + artistsRemoved + songsRemoved
+        if added > 0 { parts.append("+\(added)") }
+        if updated > 0 { parts.append("~\(updated)") }
+        if removed > 0 { parts.append("-\(removed)") }
+        return parts.joined(separator: " ")
+    }
+}

--- a/Vibrdrome/Core/Persistence/PersistenceController.swift
+++ b/Vibrdrome/Core/Persistence/PersistenceController.swift
@@ -33,7 +33,6 @@ final class PersistenceController {
             AlbumCollection.self,
             GenreArtwork.self,
             SyncHistory.self,
-            GenreArtwork.self,
         ])
 
         let config = ModelConfiguration(

--- a/Vibrdrome/Core/Persistence/PersistenceController.swift
+++ b/Vibrdrome/Core/Persistence/PersistenceController.swift
@@ -33,6 +33,7 @@ final class PersistenceController {
             AlbumCollection.self,
             GenreArtwork.self,
             SyncHistory.self,
+            GenreArtwork.self,
         ])
 
         let config = ModelConfiguration(

--- a/Vibrdrome/Core/Persistence/PersistenceController.swift
+++ b/Vibrdrome/Core/Persistence/PersistenceController.swift
@@ -23,6 +23,7 @@ final class PersistenceController {
             CachedAlbum.self,
             CachedSong.self,
             CachedPlaylist.self,
+            CachedPlaylistEntry.self,
             DownloadedSong.self,
             PlayHistory.self,
             ServerConfig.self,
@@ -31,6 +32,7 @@ final class PersistenceController {
             SavedQueue.self,
             AlbumCollection.self,
             GenreArtwork.self,
+            SyncHistory.self,
         ])
 
         let config = ModelConfiguration(

--- a/Vibrdrome/Features/Playlists/PlaylistDetailView.swift
+++ b/Vibrdrome/Features/Playlists/PlaylistDetailView.swift
@@ -328,15 +328,19 @@ struct PlaylistDetailView: View {
         descriptor.fetchLimit = 1
         guard let cached = try? modelContext.fetch(descriptor).first else { return nil }
 
-        // Resolve entries to songs via CachedSong
+        // Resolve entries to songs in a single fetch + dictionary lookup.
+        // Previously this did one modelContext.fetch per entry — a 1000-song playlist
+        // issued 1000 queries on the main thread.
         let sortedEntries = cached.entries.sorted { $0.order < $1.order }
+        let entrySongIds = sortedEntries.map(\.songId)
+        let idSet = Set(entrySongIds)
+        let songsDesc = FetchDescriptor<CachedSong>(
+            predicate: #Predicate<CachedSong> { idSet.contains($0.id) }
+        )
+        let cachedSongs = (try? modelContext.fetch(songsDesc)) ?? []
+        let songMap = Dictionary(uniqueKeysWithValues: cachedSongs.map { ($0.id, $0) })
         let songs: [Song] = sortedEntries.compactMap { entry in
-            let sid = entry.songId
-            var songDesc = FetchDescriptor<CachedSong>(
-                predicate: #Predicate { $0.id == sid }
-            )
-            songDesc.fetchLimit = 1
-            return try? modelContext.fetch(songDesc).first?.toSong()
+            songMap[entry.songId]?.toSong()
         }
 
         return Playlist(

--- a/Vibrdrome/Features/Playlists/PlaylistDetailView.swift
+++ b/Vibrdrome/Features/Playlists/PlaylistDetailView.swift
@@ -5,6 +5,7 @@ struct PlaylistDetailView: View {
     let playlistId: String
 
     @Environment(AppState.self) private var appState
+    @Environment(\.modelContext) private var modelContext
     @State private var playlist: Playlist?
     @State private var isLoading = true
     @State private var error: String?
@@ -303,14 +304,53 @@ struct PlaylistDetailView: View {
     }
 
     private func loadPlaylist() async {
-        isLoading = true
+        // Show cached playlist data instantly while fetching fresh
+        if playlist == nil {
+            playlist = loadCachedPlaylist()
+        }
+        isLoading = playlist == nil
         error = nil
         defer { isLoading = false }
         do {
             playlist = try await appState.subsonicClient.getPlaylist(id: playlistId)
         } catch {
-            self.error = ErrorPresenter.userMessage(for: error)
+            if playlist == nil {
+                self.error = ErrorPresenter.userMessage(for: error)
+            }
         }
+    }
+
+    private func loadCachedPlaylist() -> Playlist? {
+        let pid = playlistId
+        var descriptor = FetchDescriptor<CachedPlaylist>(
+            predicate: #Predicate { $0.id == pid }
+        )
+        descriptor.fetchLimit = 1
+        guard let cached = try? modelContext.fetch(descriptor).first else { return nil }
+
+        // Resolve entries to songs via CachedSong
+        let sortedEntries = cached.entries.sorted { $0.order < $1.order }
+        let songs: [Song] = sortedEntries.compactMap { entry in
+            let sid = entry.songId
+            var songDesc = FetchDescriptor<CachedSong>(
+                predicate: #Predicate { $0.id == sid }
+            )
+            songDesc.fetchLimit = 1
+            return try? modelContext.fetch(songDesc).first?.toSong()
+        }
+
+        return Playlist(
+            id: cached.id,
+            name: cached.name,
+            songCount: cached.songCount,
+            duration: cached.duration,
+            created: nil,
+            changed: nil,
+            coverArt: cached.coverArtId,
+            owner: cached.owner,
+            isPublic: cached.isPublic,
+            entry: songs.isEmpty ? nil : songs
+        )
     }
 
     private func toggleSelection(_ songId: String) {

--- a/Vibrdrome/Features/Settings/SettingsView.swift
+++ b/Vibrdrome/Features/Settings/SettingsView.swift
@@ -437,7 +437,15 @@ struct SettingsView: View {
                     let val = UserDefaults.standard.integer(forKey: UserDefaultsKeys.syncPollingInterval)
                     return [5, 15, 30, 60].contains(val) ? val : 15
                 },
-                set: { UserDefaults.standard.set($0, forKey: UserDefaultsKeys.syncPollingInterval) }
+                set: { newValue in
+                    UserDefaults.standard.set(newValue, forKey: UserDefaultsKeys.syncPollingInterval)
+                    // Restart the running polling task so the change takes effect immediately
+                    // rather than waiting until the next launch.
+                    appState.librarySyncManager.startPolling(
+                        client: appState.subsonicClient,
+                        container: PersistenceController.shared.container
+                    )
+                }
             )) {
                 Text("5 min").tag(5)
                 Text("15 min").tag(15)

--- a/Vibrdrome/Features/Settings/SettingsView.swift
+++ b/Vibrdrome/Features/Settings/SettingsView.swift
@@ -96,6 +96,7 @@ struct SettingsView: View {
             #endif
 
             downloadsSection
+            librarySyncSection
 
             #if os(iOS)
             carPlaySection
@@ -310,6 +311,143 @@ struct SettingsView: View {
             }
         } header: {
             settingSectionHeader("Downloads", icon: "arrow.down.circle.fill", color: .cyan)
+        }
+    }
+
+    // MARK: - Library Sync Section
+
+    private var librarySyncSection: some View {
+        Section {
+            HStack {
+                Label("Library Sync", systemImage: "arrow.triangle.2.circlepath.circle.fill")
+                Spacer()
+                if appState.librarySyncManager.isSyncing {
+                    ProgressView()
+                        .controlSize(.small)
+                } else if let lastSync = appState.librarySyncManager.lastSyncDate {
+                    Text(lastSync, style: .relative)
+                        .foregroundStyle(.secondary)
+                        .font(.caption)
+                    Text("ago")
+                        .foregroundStyle(.secondary)
+                        .font(.caption)
+                } else {
+                    Text("Never")
+                        .foregroundStyle(.secondary)
+                        .font(.caption)
+                }
+            }
+
+            if let progress = appState.librarySyncManager.syncProgress {
+                Text(progress)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            if let syncError = appState.librarySyncManager.syncError {
+                Text(syncError)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+            }
+
+            // Live sync stats during sync
+            if let stats = appState.librarySyncManager.lastSyncStats,
+               appState.librarySyncManager.isSyncing {
+                HStack(spacing: 12) {
+                    Label("+\(stats.albumsAdded + stats.artistsAdded + stats.songsAdded)", systemImage: "plus.circle")
+                        .foregroundStyle(.green)
+                    Label("~\(stats.albumsUpdated + stats.artistsUpdated + stats.songsUpdated)", systemImage: "pencil.circle")
+                        .foregroundStyle(.orange)
+                    Label("-\(stats.albumsRemoved + stats.artistsRemoved + stats.songsRemoved)", systemImage: "minus.circle")
+                        .foregroundStyle(.red)
+                }
+                .font(.caption)
+            }
+
+            // Last sync result summary
+            if let stats = appState.librarySyncManager.lastSyncStats,
+               !appState.librarySyncManager.isSyncing,
+               stats.totalChanges > 0 {
+                HStack {
+                    Text("Last sync: \(stats.totalChanges) changes in \(String(format: "%.1f", stats.duration))s")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            HStack {
+                Button {
+                    Task {
+                        await appState.librarySyncManager.sync(
+                            client: appState.subsonicClient,
+                            container: PersistenceController.shared.container
+                        )
+                    }
+                } label: {
+                    Label(
+                        appState.librarySyncManager.isSyncing ? "Syncing…" : "Full Sync",
+                        systemImage: "arrow.clockwise"
+                    )
+                }
+                .disabled(appState.librarySyncManager.isSyncing)
+                .accessibilityIdentifier("librarySyncButton")
+
+                Spacer()
+
+                Button {
+                    Task {
+                        await appState.librarySyncManager.incrementalSync(
+                            client: appState.subsonicClient,
+                            container: PersistenceController.shared.container
+                        )
+                    }
+                } label: {
+                    Label("Quick Sync", systemImage: "bolt.circle")
+                }
+                .disabled(appState.librarySyncManager.isSyncing)
+                .accessibilityIdentifier("incrementalSyncButton")
+            }
+
+            NavigationLink {
+                SyncHistoryView()
+            } label: {
+                Label("Sync History", systemImage: "clock.arrow.circlepath")
+            }
+            .accessibilityIdentifier("syncHistoryLink")
+
+            #if os(iOS)
+            Toggle(isOn: Binding(
+                get: { UserDefaults.standard.bool(forKey: UserDefaultsKeys.backgroundSyncEnabled) },
+                set: { newValue in
+                    UserDefaults.standard.set(newValue, forKey: UserDefaultsKeys.backgroundSyncEnabled)
+                    if newValue {
+                        BackgroundSyncScheduler.shared.scheduleRefresh()
+                        BackgroundSyncScheduler.shared.scheduleFullSync()
+                    } else {
+                        BackgroundSyncScheduler.shared.cancelAll()
+                    }
+                }
+            )) {
+                Label("Background Sync", systemImage: "arrow.triangle.2.circlepath")
+            }
+            #endif
+
+            Picker(selection: Binding(
+                get: {
+                    let val = UserDefaults.standard.integer(forKey: UserDefaultsKeys.syncPollingInterval)
+                    return [5, 15, 30, 60].contains(val) ? val : 15
+                },
+                set: { UserDefaults.standard.set($0, forKey: UserDefaultsKeys.syncPollingInterval) }
+            )) {
+                Text("5 min").tag(5)
+                Text("15 min").tag(15)
+                Text("30 min").tag(30)
+                Text("60 min").tag(60)
+            } label: {
+                Label("Check for Changes", systemImage: "timer")
+            }
+        } header: {
+            settingSectionHeader("Library", icon: "books.vertical.fill", color: .purple)
         }
     }
 

--- a/Vibrdrome/Features/Settings/SyncHistoryView.swift
+++ b/Vibrdrome/Features/Settings/SyncHistoryView.swift
@@ -1,0 +1,119 @@
+import SwiftData
+import SwiftUI
+
+struct SyncHistoryView: View {
+    @Query(sort: \SyncHistory.syncDate, order: .reverse) private var history: [SyncHistory]
+
+    var body: some View {
+        List {
+            if history.isEmpty {
+                ContentUnavailableView(
+                    "No Sync History",
+                    systemImage: "clock.arrow.circlepath",
+                    description: Text("Sync history will appear here after your first library sync.")
+                )
+            } else {
+                ForEach(history) { entry in
+                    SyncHistoryRow(entry: entry)
+                }
+            }
+        }
+        .navigationTitle("Sync History")
+    }
+}
+
+private struct SyncHistoryRow: View {
+    let entry: SyncHistory
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Image(systemName: entry.succeeded ? "checkmark.circle.fill" : "xmark.circle.fill")
+                    .foregroundStyle(entry.succeeded ? .green : .red)
+                    .font(.caption)
+
+                Text(entry.syncType.capitalized)
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+
+                Spacer()
+
+                Text(entry.syncDate, style: .relative)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text("ago")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            if entry.succeeded {
+                HStack(spacing: 12) {
+                    if entry.totalChanges > 0 {
+                        statsLabel(value: entry.albumsAdded + entry.artistsAdded + entry.songsAdded,
+                                   label: "added", color: .green)
+                        statsLabel(value: entry.albumsUpdated + entry.artistsUpdated + entry.songsUpdated,
+                                   label: "updated", color: .orange)
+                        statsLabel(value: entry.albumsRemoved + entry.artistsRemoved + entry.songsRemoved,
+                                   label: "removed", color: .red)
+                    } else {
+                        Text("No changes")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    Spacer()
+
+                    Text(String(format: "%.1fs", entry.durationSeconds))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                if entry.totalChanges > 0 {
+                    HStack(spacing: 8) {
+                        if entry.albumsAdded + entry.albumsUpdated + entry.albumsRemoved > 0 {
+                            Text("\(entry.albumsAdded + entry.albumsUpdated + entry.albumsRemoved) albums")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+                        if entry.artistsAdded + entry.artistsUpdated + entry.artistsRemoved > 0 {
+                            Text("\(entry.artistsAdded + entry.artistsUpdated + entry.artistsRemoved) artists")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+                        if entry.songsAdded + entry.songsUpdated + entry.songsRemoved > 0 {
+                            Text("\(entry.songsAdded + entry.songsUpdated + entry.songsRemoved) songs")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+                        if entry.playlistsSynced > 0 {
+                            Text("\(entry.playlistsSynced) playlists")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+
+                if entry.conflictsDetected > 0 {
+                    Text("\(entry.conflictsResolved)/\(entry.conflictsDetected) conflicts resolved")
+                        .font(.caption2)
+                        .foregroundStyle(.orange)
+                }
+            } else if let error = entry.errorMessage {
+                Text(error)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+                    .lineLimit(2)
+            }
+        }
+        .padding(.vertical, 2)
+    }
+
+    @ViewBuilder
+    private func statsLabel(value: Int, label: String, color: Color) -> some View {
+        if value > 0 {
+            Text("\(value) \(label)")
+                .font(.caption)
+                .foregroundStyle(color)
+        }
+    }
+}

--- a/Vibrdrome/Info.plist
+++ b/Vibrdrome/Info.plist
@@ -71,6 +71,13 @@
     <key>UIBackgroundModes</key>
     <array>
         <string>audio</string>
+        <string>fetch</string>
+        <string>processing</string>
+    </array>
+    <key>BGTaskSchedulerPermittedIdentifiers</key>
+    <array>
+        <string>com.vibrdrome.app.libraryRefresh</string>
+        <string>com.vibrdrome.app.librarySync</string>
     </array>
     <key>NSPhotoLibraryAddUsageDescription</key>
     <string>Save album artwork to your photo library</string>

--- a/Vibrdrome/Shared/Components/GenreIconView.swift
+++ b/Vibrdrome/Shared/Components/GenreIconView.swift
@@ -250,25 +250,3 @@ struct GenreIconView: View {
         }
     }
 }
-
-#if os(iOS)
-import UIKit
-
-extension GenreIconView {
-    /// Rasterized icon for surfaces that can't host SwiftUI (e.g. CarPlay CPListItem).
-    /// Uses the gradient + SF Symbol fallback — the album-art path is only
-    /// visible in SwiftUI contexts because ImageRenderer here doesn't get the
-    /// model container. Callers wanting real album art (CarPlay) should fetch
-    /// the cover art URL via SubsonicClient.coverArtURL(id:) and load the image
-    /// themselves, falling back to this method if no artwork is cached yet.
-    @MainActor
-    static func uiImage(for genre: String, size: CGSize = CGSize(width: 80, height: 80)) -> UIImage? {
-        let view = GenreIconView(genre: genre)
-            .frame(width: size.width, height: size.height)
-            .clipShape(RoundedRectangle(cornerRadius: size.width * 0.15))
-        let renderer = ImageRenderer(content: view)
-        renderer.scale = UIScreen.main.scale
-        return renderer.uiImage
-    }
-}
-#endif

--- a/Vibrdrome/Shared/Components/GenreIconView.swift
+++ b/Vibrdrome/Shared/Components/GenreIconView.swift
@@ -250,3 +250,25 @@ struct GenreIconView: View {
         }
     }
 }
+
+#if os(iOS)
+import UIKit
+
+extension GenreIconView {
+    /// Rasterized icon for surfaces that can't host SwiftUI (e.g. CarPlay CPListItem).
+    /// Uses the gradient + SF Symbol fallback — the album-art path is only
+    /// visible in SwiftUI contexts because ImageRenderer here doesn't get the
+    /// model container. Callers wanting real album art (CarPlay) should fetch
+    /// the cover art URL via SubsonicClient.coverArtURL(id:) and load the image
+    /// themselves, falling back to this method if no artwork is cached yet.
+    @MainActor
+    static func uiImage(for genre: String, size: CGSize = CGSize(width: 80, height: 80)) -> UIImage? {
+        let view = GenreIconView(genre: genre)
+            .frame(width: size.width, height: size.height)
+            .clipShape(RoundedRectangle(cornerRadius: size.width * 0.15))
+        let renderer = ImageRenderer(content: view)
+        renderer.scale = UIScreen.main.scale
+        return renderer.uiImage
+    }
+}
+#endif

--- a/Vibrdrome/Shared/Extensions/ErrorPresenter.swift
+++ b/Vibrdrome/Shared/Extensions/ErrorPresenter.swift
@@ -33,6 +33,7 @@ enum ErrorPresenter {
         case 401: return "Authentication failed. Check your credentials."
         case 403: return "Access denied. Your account may not have permission."
         case 404: return "The requested item was not found on the server."
+        case 429: return "Server is rate limiting requests. Please wait a moment and try again."
         case 500...599: return "The server encountered an error. Please try again later."
         default: return "Server returned an error (HTTP \(code))."
         }

--- a/Vibrdrome/Vibrdrome.swift
+++ b/Vibrdrome/Vibrdrome.swift
@@ -76,6 +76,15 @@ struct VibrdromeApp: App {
 
     init() {
         Self.migrateCredentialsToKeychain()
+        // BGTaskScheduler.register() MUST run synchronously during app initialization,
+        // before UIApplication finishes launching. If iOS launches the app specifically to
+        // handle a scheduled background task, registration has to already be in place or
+        // the system drops the task silently. `.onAppear` is too late.
+        // scheduleRefresh() / scheduleFullSync() stay in `.onAppear` below — those require
+        // the app to be configured (credentials loaded) and can be submitted at any time.
+        #if os(iOS)
+        BackgroundSyncScheduler.shared.registerTasks()
+        #endif
     }
 
     /// One-time migration: move Last.fm/ListenBrainz credentials from UserDefaults to Keychain.
@@ -168,7 +177,8 @@ struct VibrdromeApp: App {
                     ImagePipeline.shared = ImagePipeline(configuration: .withDataCache(name: "com.vibrdrome.images"))
                     RemoteCommandManager.shared.setup()
                     DownloadManager.shared.resumeIncompleteDownloads()
-                    BackgroundSyncScheduler.shared.registerTasks()
+                    // registerTasks() already ran synchronously in App.init(); here we just
+                    // submit the scheduled requests once credentials are confirmed loaded.
                     BackgroundSyncScheduler.shared.scheduleRefresh()
                     BackgroundSyncScheduler.shared.scheduleFullSync()
                     Task {

--- a/Vibrdrome/Vibrdrome.swift
+++ b/Vibrdrome/Vibrdrome.swift
@@ -136,6 +136,22 @@ struct VibrdromeApp: App {
                     ImagePipeline.shared = ImagePipeline(configuration: .withDataCache(name: "com.vibrdrome.images"))
                     RemoteCommandManager.shared.setup()
                     DownloadManager.shared.resumeIncompleteDownloads()
+                    Task {
+                        appState.libraryCache.rebuild(container: persistenceController.container)
+                        await appState.librarySyncManager.syncIfStale(
+                            client: appState.subsonicClient,
+                            container: persistenceController.container
+                        )
+                        appState.libraryCache.rebuild(container: persistenceController.container)
+                        appState.librarySyncManager.startPolling(
+                            client: appState.subsonicClient,
+                            container: persistenceController.container
+                        )
+                        await appState.librarySyncManager.warmImageCache(
+                            client: appState.subsonicClient,
+                            container: persistenceController.container
+                        )
+                    }
                 }
                 .onOpenURL { url in
                     handleDeepLink(url)
@@ -152,6 +168,25 @@ struct VibrdromeApp: App {
                     ImagePipeline.shared = ImagePipeline(configuration: .withDataCache(name: "com.vibrdrome.images"))
                     RemoteCommandManager.shared.setup()
                     DownloadManager.shared.resumeIncompleteDownloads()
+                    BackgroundSyncScheduler.shared.registerTasks()
+                    BackgroundSyncScheduler.shared.scheduleRefresh()
+                    BackgroundSyncScheduler.shared.scheduleFullSync()
+                    Task {
+                        appState.libraryCache.rebuild(container: persistenceController.container)
+                        await appState.librarySyncManager.syncIfStale(
+                            client: appState.subsonicClient,
+                            container: persistenceController.container
+                        )
+                        appState.libraryCache.rebuild(container: persistenceController.container)
+                        appState.librarySyncManager.startPolling(
+                            client: appState.subsonicClient,
+                            container: persistenceController.container
+                        )
+                        await appState.librarySyncManager.warmImageCache(
+                            client: appState.subsonicClient,
+                            container: persistenceController.container
+                        )
+                    }
                 }
                 .onOpenURL { url in
                     handleDeepLink(url)

--- a/VibrdromeTests/Core/LibrarySyncTests.swift
+++ b/VibrdromeTests/Core/LibrarySyncTests.swift
@@ -1,0 +1,238 @@
+import Testing
+import Foundation
+@testable import Vibrdrome
+
+/// Tests for library sync infrastructure: SyncMode, SyncStats,
+/// CachedAlbum/CachedArtist round-trip conversions, and update detection.
+struct LibrarySyncTests {
+
+    // MARK: - SyncMode
+
+    @Test func syncModeRawValues() {
+        #expect(SyncMode.full.rawValue == "full")
+        #expect(SyncMode.incremental.rawValue == "incremental")
+        #expect(SyncMode.background.rawValue == "background")
+    }
+
+    // MARK: - SyncStats
+
+    @Test func syncStatsTotalChangesEmpty() {
+        let stats = LibrarySyncManager.SyncStats()
+        #expect(stats.totalChanges == 0)
+    }
+
+    @Test func syncStatsTotalChangesAggregatesAll() {
+        var stats = LibrarySyncManager.SyncStats()
+        stats.albumsAdded = 5
+        stats.albumsUpdated = 3
+        stats.albumsRemoved = 1
+        stats.artistsAdded = 10
+        stats.artistsUpdated = 2
+        stats.artistsRemoved = 0
+        stats.songsAdded = 100
+        stats.songsUpdated = 20
+        stats.songsRemoved = 5
+        #expect(stats.totalChanges == 146)
+    }
+
+    @Test func syncStatsDuration() throws {
+        let stats = LibrarySyncManager.SyncStats()
+        // Duration is time since startTime, should be >= 0
+        #expect(stats.duration >= 0)
+    }
+
+    // MARK: - CachedAlbum Round-Trip
+
+    @Test func cachedAlbumRoundTripPreservesId() {
+        let album = makeAlbum(id: "alb-1")
+        let cached = CachedAlbum(from: album)
+        let restored = cached.toAlbum()
+        #expect(restored.id == "alb-1")
+    }
+
+    @Test func cachedAlbumRoundTripPreservesName() {
+        let album = makeAlbum(name: "OK Computer")
+        let cached = CachedAlbum(from: album)
+        let restored = cached.toAlbum()
+        #expect(restored.name == "OK Computer")
+    }
+
+    @Test func cachedAlbumRoundTripPreservesArtist() {
+        let album = makeAlbum(artist: "Radiohead")
+        let cached = CachedAlbum(from: album)
+        let restored = cached.toAlbum()
+        #expect(restored.artist == "Radiohead")
+    }
+
+    @Test func cachedAlbumRoundTripPreservesYear() {
+        let album = makeAlbum(year: 1997)
+        let cached = CachedAlbum(from: album)
+        let restored = cached.toAlbum()
+        #expect(restored.year == 1997)
+    }
+
+    @Test func cachedAlbumRoundTripPreservesGenre() {
+        let album = makeAlbum(genre: "Alternative Rock")
+        let cached = CachedAlbum(from: album)
+        let restored = cached.toAlbum()
+        #expect(restored.genre == "Alternative Rock")
+    }
+
+    @Test func cachedAlbumStarredConversion() {
+        let starred = makeAlbum(starred: "2024-01-01T00:00:00Z")
+        let cachedStarred = CachedAlbum(from: starred)
+        #expect(cachedStarred.isStarred == true)
+        #expect(cachedStarred.toAlbum().starred == "true")
+
+        let unstarred = makeAlbum(starred: nil)
+        let cachedUnstarred = CachedAlbum(from: unstarred)
+        #expect(cachedUnstarred.isStarred == false)
+        #expect(cachedUnstarred.toAlbum().starred == nil)
+    }
+
+    @Test func cachedAlbumRoundTripPreservesRating() {
+        let album = makeAlbum(userRating: 4)
+        let cached = CachedAlbum(from: album)
+        let restored = cached.toAlbum()
+        #expect(restored.userRating == 4)
+    }
+
+    @Test func cachedAlbumRoundTripNilRatingBecomesNil() {
+        let album = makeAlbum(userRating: nil)
+        let cached = CachedAlbum(from: album)
+        #expect(cached.userRating == 0)
+        let restored = cached.toAlbum()
+        #expect(restored.userRating == nil)
+    }
+
+    @Test func cachedAlbumRoundTripPreservesLabel() {
+        let album = makeAlbum(label: "XL Recordings")
+        let cached = CachedAlbum(from: album)
+        let restored = cached.toAlbum()
+        #expect(restored.label == "XL Recordings")
+    }
+
+    @Test func cachedAlbumUpdateAppliesChanges() {
+        let original = makeAlbum(id: "alb-1", name: "Old Name", year: 2020)
+        let cached = CachedAlbum(from: original)
+
+        let updated = makeAlbum(id: "alb-1", name: "New Name", year: 2024, genre: "Electronic")
+        cached.update(from: updated)
+
+        #expect(cached.name == "New Name")
+        #expect(cached.year == 2024)
+        #expect(cached.genre == "Electronic")
+    }
+
+    @Test func cachedAlbumUpdatePreservesIdOnMismatch() {
+        // update(from:) doesn't change ID — it's the caller's responsibility to match
+        let cached = CachedAlbum(from: makeAlbum(id: "alb-1"))
+        cached.update(from: makeAlbum(id: "alb-2", name: "Different"))
+        #expect(cached.id == "alb-1")
+        #expect(cached.name == "Different")
+    }
+
+    // MARK: - CachedArtist Round-Trip
+
+    @Test func cachedArtistRoundTripPreservesId() {
+        let artist = makeArtist(id: "art-1")
+        let cached = CachedArtist(from: artist)
+        let restored = cached.toArtist()
+        #expect(restored.id == "art-1")
+    }
+
+    @Test func cachedArtistRoundTripPreservesName() {
+        let artist = makeArtist(name: "Boards of Canada")
+        let cached = CachedArtist(from: artist)
+        let restored = cached.toArtist()
+        #expect(restored.name == "Boards of Canada")
+    }
+
+    @Test func cachedArtistRoundTripPreservesAlbumCount() {
+        let artist = makeArtist(albumCount: 7)
+        let cached = CachedArtist(from: artist)
+        let restored = cached.toArtist()
+        #expect(restored.albumCount == 7)
+    }
+
+    @Test func cachedArtistStarredConversion() {
+        let starred = makeArtist(starred: "2024-06-01T12:00:00Z")
+        let cached = CachedArtist(from: starred)
+        #expect(cached.isStarred == true)
+
+        let unstarred = makeArtist(starred: nil)
+        let cachedU = CachedArtist(from: unstarred)
+        #expect(cachedU.isStarred == false)
+    }
+
+    // MARK: - SyncHistory
+
+    @Test func syncHistoryTotalChanges() {
+        let history = SyncHistory(syncType: "full")
+        history.albumsAdded = 10
+        history.songsAdded = 100
+        history.artistsUpdated = 5
+        #expect(history.totalChanges == 115)
+    }
+
+    @Test func syncHistorySummaryNoChanges() {
+        let history = SyncHistory(syncType: "incremental")
+        #expect(history.summary == "No changes")
+    }
+
+    @Test func syncHistorySummaryWithChanges() {
+        let history = SyncHistory(syncType: "full")
+        history.albumsAdded = 5
+        history.songsUpdated = 10
+        history.artistsRemoved = 2
+        let summary = history.summary
+        #expect(summary.contains("+5"))
+        #expect(summary.contains("~10"))
+        #expect(summary.contains("-2"))
+    }
+
+    @Test func syncHistorySummaryOnFailure() {
+        let history = SyncHistory(syncType: "full")
+        history.succeeded = false
+        history.errorMessage = "Connection timeout"
+        #expect(history.summary == "Failed: Connection timeout")
+    }
+
+    // MARK: - Helpers
+
+    private func makeAlbum(
+        id: String = "test",
+        name: String = "Test Album",
+        artist: String? = nil,
+        artistId: String? = nil,
+        year: Int? = nil,
+        genre: String? = nil,
+        songCount: Int? = nil,
+        duration: Int? = nil,
+        starred: String? = nil,
+        userRating: Int? = nil,
+        label: String? = nil
+    ) -> Album {
+        Album(
+            id: id, name: name, artist: artist, artistId: artistId,
+            coverArt: nil, songCount: songCount, duration: duration,
+            year: year, genre: genre, starred: starred, created: nil,
+            userRating: userRating, song: nil, replayGain: nil,
+            musicBrainzId: nil,
+            recordLabels: label.map { [RecordLabel(name: $0)] }
+        )
+    }
+
+    private func makeArtist(
+        id: String = "test",
+        name: String = "Test Artist",
+        coverArt: String? = nil,
+        albumCount: Int? = nil,
+        starred: String? = nil
+    ) -> Artist {
+        Artist(
+            id: id, name: name, coverArt: coverArt,
+            albumCount: albumCount, starred: starred, album: nil
+        )
+    }
+}

--- a/VibrdromeTests/Core/LibrarySyncTests.swift
+++ b/VibrdromeTests/Core/LibrarySyncTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import Foundation
+import SwiftData
 @testable import Vibrdrome
 
 /// Tests for library sync infrastructure: SyncMode, SyncStats,
@@ -234,5 +235,70 @@ struct LibrarySyncTests {
             id: id, name: name, coverArt: coverArt,
             albumCount: albumCount, starred: starred, album: nil
         )
+    }
+
+    // MARK: - SwiftData Schema Migration
+
+    @Test func migrationFromBuild45SchemaSucceeds() throws {
+        // Use a temp file-backed store so data persists across containers
+        let storeURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("migration-test-\(UUID().uuidString).store")
+        defer { try? FileManager.default.removeItem(at: storeURL) }
+
+        // Build 45 schema — the entities that existed before 7a
+        let oldSchema = Schema([
+            DownloadedSong.self,
+            PlayHistory.self,
+            ServerConfig.self,
+            OfflinePlaylist.self,
+            PendingAction.self,
+            SavedQueue.self,
+            AlbumCollection.self,
+        ])
+        let oldConfig = ModelConfiguration(schema: oldSchema, url: storeURL)
+
+        // Phase 1: create store with old schema and seed data
+        do {
+            let oldContainer = try ModelContainer(for: oldSchema, configurations: [oldConfig])
+            let ctx = ModelContext(oldContainer)
+            let collection = AlbumCollection(name: "Test Collection", listType: .alphabeticalByName)
+            ctx.insert(collection)
+            try ctx.save()
+        }
+        // oldContainer deallocated — store is on disk
+
+        // Phase 2: reopen same store with expanded schema (7a)
+        let newSchema = Schema([
+            CachedArtist.self,
+            CachedAlbum.self,
+            CachedSong.self,
+            CachedPlaylist.self,
+            CachedPlaylistEntry.self,
+            DownloadedSong.self,
+            PlayHistory.self,
+            ServerConfig.self,
+            OfflinePlaylist.self,
+            PendingAction.self,
+            SavedQueue.self,
+            AlbumCollection.self,
+            SyncHistory.self,
+        ])
+        let newConfig = ModelConfiguration(schema: newSchema, url: storeURL)
+
+        // Lightweight migration: adding entities should not throw
+        let newContainer = try ModelContainer(for: newSchema, configurations: [newConfig])
+        let newCtx = ModelContext(newContainer)
+
+        // Verify old data survived the migration
+        let collections = try newCtx.fetch(FetchDescriptor<AlbumCollection>())
+        #expect(collections.count == 1)
+        #expect(collections.first?.name == "Test Collection")
+
+        // Verify new entities are accessible and empty
+        let albums = try newCtx.fetch(FetchDescriptor<CachedAlbum>())
+        #expect(albums.isEmpty)
+
+        let syncHistory = try newCtx.fetch(FetchDescriptor<SyncHistory>())
+        #expect(syncHistory.isEmpty)
     }
 }

--- a/VibrdromeTests/Core/SubsonicModelsTests.swift
+++ b/VibrdromeTests/Core/SubsonicModelsTests.swift
@@ -142,6 +142,15 @@ struct SubsonicModelsTests {
         #expect(album.song?.count == 2)
         #expect(album.song?[0].title == "Airbag")
         #expect(album.song?[1].title == "Paranoid Android")
+        #expect(album.userRating == nil)
+    }
+
+    @Test func albumWithUserRating() throws {
+        let json = """
+        {"id":"al-r","name":"Rated Album","userRating":4}
+        """.data(using: .utf8)!
+        let album = try JSONDecoder().decode(Album.self, from: json)
+        #expect(album.userRating == 4)
     }
 
     @Test func albumWithSongArrayOmitted() throws {


### PR DESCRIPTION
Split from #7 (1/3). Rebased onto current develop (Build 45).

**What**
Adds the sync engine and SwiftData persistence layer for offline-first library access.

**Changes**
LibrarySyncManager — incremental + full sync with progress reporting
SwiftData models — CachedAlbum, CachedArtist, CachedPlaylist, CachedPlaylistEntry, SyncHistory
BackgroundSyncScheduler — iOS BGTaskScheduler with macOS Timer fallback
LibraryDataCache — pre-computed model arrays for fast view access
SubsonicClient — paginated getAlbumList2, getArtists, search3, getPlaylists endpoints
OfflineActionQueue — conflict resolution for offline mutations
Settings UI — sync status, history view, background sync toggle
App lifecycle — sync wired into AppState.configureSubsonicClient() and Vibrdrome.swift startup
**Testing**
SubsonicModelsTests updated with new model coverage
Manual: configure server → verify initial sync completes → check sync history in Settings