### PR TITLE
feat(macOS): Add Labels sidebar tab

### DIFF
--- a/Vibrdrome/App/AppState.swift
+++ b/Vibrdrome/App/AppState.swift
@@ -58,6 +58,12 @@ final class AppState {
         case queue, lyrics, artistInfo
     }
     var activeSidePanel: SidePanel?
+
+    /// Library sync manager.
+    let librarySyncManager = LibrarySyncManager.shared
+
+    /// Pre-computed model arrays so library tabs are instant on first tap.
+    let libraryCache = LibraryDataCache()
     var serverURL: String = ""
     var username: String = ""
     var errorMessage: String?
@@ -115,6 +121,8 @@ final class AppState {
         #if os(iOS)
         SubsonicClientProvider.shared.client = subsonicClient
         #endif
+        LibrarySyncManager.shared.client = subsonicClient
+        LibrarySyncManager.shared.container = PersistenceController.shared.container
     }
 
     func loadSavedCredentials() {

--- a/Vibrdrome/App/AppState.swift
+++ b/Vibrdrome/App/AppState.swift
@@ -52,12 +52,25 @@ final class AppState {
     }
     var pendingNowPlayingAction: NowPlayingAction?
 
-    /// Active side panel in the macOS main window (Queue / Lyrics / Artist Info).
+    /// Active side panel in the macOS main window (Queue / Lyrics / Artist Info / Album Filters).
     /// Mutually exclusive: setting one closes the others.
     enum SidePanel: String, Equatable {
-        case queue, lyrics, artistInfo
+        case queue, lyrics, artistInfo, albumFilters, artistFilters, songFilters
     }
     var activeSidePanel: SidePanel?
+
+    /// Filter state for the macOS filter sidebars.
+    var albumFilter = LibraryFilter()
+    var artistFilter = LibraryFilter()
+    var songFilter = LibraryFilter()
+
+    /// Cached albums state for back-navigation, keyed by view configuration.
+    struct AlbumsViewSnapshot {
+        var albums: [Album]
+        var hasMore: Bool
+        var scrollIndex: Int?
+    }
+    var albumsViewSnapshots: [String: AlbumsViewSnapshot] = [:]
 
     /// Library sync manager.
     let librarySyncManager = LibrarySyncManager.shared

--- a/Vibrdrome/Core/Constants/UserDefaultsKeys.swift
+++ b/Vibrdrome/Core/Constants/UserDefaultsKeys.swift
@@ -112,7 +112,6 @@ enum UserDefaultsKeys {
     static let enableLiquidGlass = "enableLiquidGlass"
     static let enableMiniPlayerTint = "enableMiniPlayerTint"
     static let albumBackgroundStyle = "albumBackgroundStyle"
-    static let gridColumnsPerRow = "gridColumnsPerRow"
     static let showLosslessBadge = "showLosslessBadge"
 
     // MARK: - Tab Bar Extended

--- a/Vibrdrome/Core/Constants/UserDefaultsKeys.swift
+++ b/Vibrdrome/Core/Constants/UserDefaultsKeys.swift
@@ -137,4 +137,12 @@ enum UserDefaultsKeys {
     static let macSidePanelMechanic = "macSidePanelMechanic"
     static let macSidePanelWidth = "macSidePanelWidth"
     static let macMiniPlayerPanelTrigger = "macMiniPlayerPanelTrigger"
+
+    // MARK: - Library Sync
+
+    static let lastLibrarySyncDate = "lastLibrarySyncDate"
+    static let lastFullSyncDate = "lastFullSyncDate"
+    static let lastServerModified = "lastServerModified"
+    static let backgroundSyncEnabled = "backgroundSyncEnabled"
+    static let syncPollingInterval = "syncPollingInterval"
 }

--- a/Vibrdrome/Core/Constants/UserDefaultsKeys.swift
+++ b/Vibrdrome/Core/Constants/UserDefaultsKeys.swift
@@ -144,4 +144,5 @@ enum UserDefaultsKeys {
     static let lastServerModified = "lastServerModified"
     static let backgroundSyncEnabled = "backgroundSyncEnabled"
     static let syncPollingInterval = "syncPollingInterval"
+    static let lastCoverArtPrefetchDate = "lastCoverArtPrefetchDate"
 }

--- a/Vibrdrome/Core/Models/LibraryFilter.swift
+++ b/Vibrdrome/Core/Models/LibraryFilter.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+/// Tri-state filter value: no filter, must be true, or must be false.
+enum TriState: String, CaseIterable, Sendable, Equatable {
+    case none, yes, no
+
+    /// Returns true if the value satisfies this filter (`.none` always passes).
+    func matches(_ value: Bool) -> Bool {
+        switch self {
+        case .none: true
+        case .yes: value
+        case .no: !value
+        }
+    }
+}
+
+/// Observable filter state for library filter sidebars (albums, artists, songs).
+/// All filtering is done locally against SwiftData.
+@Observable
+@MainActor
+final class LibraryFilter {
+    var isFavorited: TriState = .none
+    var isRated: TriState = .none
+    var isRecentlyPlayed: Bool = false
+    var selectedArtistIds: Set<String> = []
+    var selectedGenres: Set<String> = []
+    var selectedLabels: Set<String> = []
+    var year: Int?
+
+    var isActive: Bool {
+        isFavorited != .none ||
+        isRated != .none ||
+        isRecentlyPlayed ||
+        !selectedArtistIds.isEmpty ||
+        !selectedGenres.isEmpty ||
+        !selectedLabels.isEmpty ||
+        year != nil
+    }
+
+    var activeFilterCount: Int {
+        var count = 0
+        if isFavorited != .none { count += 1 }
+        if isRated != .none { count += 1 }
+        if isRecentlyPlayed { count += 1 }
+        if !selectedArtistIds.isEmpty { count += 1 }
+        if !selectedGenres.isEmpty { count += 1 }
+        if !selectedLabels.isEmpty { count += 1 }
+        if year != nil { count += 1 }
+        return count
+    }
+
+    func reset() {
+        isFavorited = .none
+        isRated = .none
+        isRecentlyPlayed = false
+        selectedArtistIds = []
+        selectedGenres = []
+        selectedLabels = []
+        year = nil
+    }
+}

--- a/Vibrdrome/Core/Models/LibraryFilter.swift
+++ b/Vibrdrome/Core/Models/LibraryFilter.swift
@@ -16,6 +16,7 @@ enum TriState: String, CaseIterable, Sendable, Equatable {
 
 /// Observable filter state for library filter sidebars (albums, artists, songs).
 /// All filtering is done locally against SwiftData.
+/// Note: Sendable conformance is implicit via @MainActor isolation (Swift 6 strict concurrency).
 @Observable
 @MainActor
 final class LibraryFilter {

--- a/Vibrdrome/Core/Networking/OfflineActionQueue.swift
+++ b/Vibrdrome/Core/Networking/OfflineActionQueue.swift
@@ -150,7 +150,7 @@ final class OfflineActionQueue {
 
     // MARK: - Flush
 
-    /// Sync all pending actions to server
+    /// Sync all pending actions to server, with conflict detection and resolution.
     func flushPending() async {
         guard !isSyncing else { return }
         isSyncing = true
@@ -164,9 +164,14 @@ final class OfflineActionQueue {
 
         guard let actions = try? context.fetch(descriptor), !actions.isEmpty else { return }
         let client = AppState.shared.subsonicClient
+
+        // Conflict resolution: collapse contradictory actions on the same target.
+        // e.g., star + unstar on the same song → last one wins.
+        let resolved = resolveConflicts(actions: actions, context: context)
+
         var synced = 0
 
-        for action in actions {
+        for action in resolved {
             do {
                 try await executeAction(action, client: client)
                 context.delete(action)
@@ -190,6 +195,56 @@ final class OfflineActionQueue {
         if synced > 0 {
             offlineLog.info("Synced \(synced) pending actions")
         }
+    }
+
+    // MARK: - Conflict Resolution
+
+    /// Collapse contradictory actions on the same target.
+    /// Uses last-write-wins: the most recent action for each target survives.
+    private func resolveConflicts(actions: [PendingAction],
+                                  context: ModelContext) -> [PendingAction] {
+        // Group by target ID
+        var grouped: [String: [PendingAction]] = [:]
+        for action in actions {
+            grouped[action.targetId, default: []].append(action)
+        }
+
+        var resolved: [PendingAction] = []
+
+        for (_, group) in grouped {
+            // Separate star/unstar pairs from other action types
+            let starActions = group.filter {
+                $0.actionType == "star" || $0.actionType == "unstar" ||
+                $0.actionType == "starAlbum" || $0.actionType == "unstarAlbum" ||
+                $0.actionType == "starArtist" || $0.actionType == "unstarArtist"
+            }
+            let otherActions = group.filter {
+                !($0.actionType == "star" || $0.actionType == "unstar" ||
+                  $0.actionType == "starAlbum" || $0.actionType == "unstarAlbum" ||
+                  $0.actionType == "starArtist" || $0.actionType == "unstarArtist")
+            }
+
+            // Other actions (scrobbles etc.) always go through
+            resolved.append(contentsOf: otherActions)
+
+            // For star/unstar, check for contradictions
+            if starActions.count > 1 {
+                // Multiple star/unstar on same target — keep only the latest
+                let sorted = starActions.sorted { $0.createdAt < $1.createdAt }
+                let winner = sorted.last!
+                offlineLog.info("Conflict resolved (last-write-wins): \(winner.actionType) wins for \(winner.targetId)")
+
+                // Delete the losers
+                for action in sorted.dropLast() {
+                    context.delete(action)
+                }
+                resolved.append(winner)
+            } else {
+                resolved.append(contentsOf: starActions)
+            }
+        }
+
+        return resolved
     }
 
     private func executeAction(_ action: PendingAction, client: SubsonicClient) async throws {

--- a/Vibrdrome/Core/Networking/SubsonicClient.swift
+++ b/Vibrdrome/Core/Networking/SubsonicClient.swift
@@ -14,6 +14,11 @@ final class SubsonicClient {
     private static let maxRetries = 3
     private static let retryDelays: [UInt64] = [1_000_000_000, 2_000_000_000, 4_000_000_000] // 1s, 2s, 4s
 
+    /// Internal marker for HTTP 429 so retry delay can honor Retry-After when present.
+    private struct RateLimitError: Error {
+        let retryAfterNanoseconds: UInt64?
+    }
+
     var isConnected: Bool = false
 
     init(baseURL: URL, username: String, password: String) {
@@ -33,6 +38,9 @@ final class SubsonicClient {
     // MARK: - Retry Logic
 
     private func isRetryable(_ error: Error) -> Bool {
+        if error is RateLimitError {
+            return true
+        }
         if let urlError = error as? URLError {
             switch urlError.code {
             case .timedOut, .networkConnectionLost, .notConnectedToInternet,
@@ -45,7 +53,7 @@ final class SubsonicClient {
         if let subsonicError = error as? SubsonicError {
             switch subsonicError {
             case .httpError(let code):
-                return code >= 500 // Only retry server errors, not 4xx
+                return code == 429 || code >= 500
             default:
                 return false
             }
@@ -53,30 +61,68 @@ final class SubsonicClient {
         return false
     }
 
+    private func retryDelayNanoseconds(for error: Error, attempt: Int) -> UInt64? {
+        guard isRetryable(error) else { return nil }
+
+        if let rateLimitError = error as? RateLimitError,
+           let retryAfter = rateLimitError.retryAfterNanoseconds {
+            return retryAfter
+        }
+
+        return Self.retryDelays[min(attempt, Self.retryDelays.count - 1)]
+    }
+
+    private func parseRetryAfterNanoseconds(from response: HTTPURLResponse) -> UInt64? {
+        guard let header = response.value(forHTTPHeaderField: "Retry-After")?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !header.isEmpty else {
+            return nil
+        }
+
+        if let seconds = TimeInterval(header), seconds > 0 {
+            return UInt64(seconds * 1_000_000_000)
+        }
+
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss z"
+
+        guard let retryDate = formatter.date(from: header) else { return nil }
+        let seconds = max(0, retryDate.timeIntervalSinceNow)
+        guard seconds > 0 else { return nil }
+        return UInt64(seconds * 1_000_000_000)
+    }
+
     // MARK: - Core Request
 
     private func request(_ endpoint: SubsonicEndpoint) async throws -> SubsonicResponseBody {
-        var lastError: Error?
-
         for attempt in 0...Self.maxRetries {
-            if attempt > 0 {
-                let delay = Self.retryDelays[min(attempt - 1, Self.retryDelays.count - 1)]
-                networkLog.info("Retry \(attempt)/\(Self.maxRetries) for \(endpoint.path) after \(delay / 1_000_000_000)s")
-                try await Task.sleep(nanoseconds: delay)
-            }
-
             do {
                 return try await performRequest(endpoint)
             } catch {
-                lastError = error
-                if !isRetryable(error) {
+                if attempt == Self.maxRetries {
+                    if error is RateLimitError {
+                        throw SubsonicError.httpError(429)
+                    }
                     throw error
                 }
-                networkLog.warning("Transient error on \(endpoint.path): \(error.localizedDescription)")
+
+                guard let delay = retryDelayNanoseconds(for: error, attempt: attempt) else {
+                    throw error
+                }
+
+                if error is RateLimitError {
+                    networkLog.warning("Rate limited on \(endpoint.path); retry \(attempt + 1)/\(Self.maxRetries) after \(delay / 1_000_000_000)s")
+                } else {
+                    networkLog.warning("Transient error on \(endpoint.path): \(error.localizedDescription)")
+                    networkLog.info("Retry \(attempt + 1)/\(Self.maxRetries) for \(endpoint.path) after \(delay / 1_000_000_000)s")
+                }
+
+                try await Task.sleep(nanoseconds: delay)
             }
         }
 
-        throw lastError!
+        throw SubsonicError.httpError(500)
     }
 
     private func performRequest(_ endpoint: SubsonicEndpoint) async throws -> SubsonicResponseBody {
@@ -97,6 +143,9 @@ final class SubsonicClient {
         guard let httpResponse = response as? HTTPURLResponse,
               (200...299).contains(httpResponse.statusCode) else {
             let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
+            if statusCode == 429, let httpResponse = response as? HTTPURLResponse {
+                throw RateLimitError(retryAfterNanoseconds: parseRetryAfterNanoseconds(from: httpResponse))
+            }
             if statusCode == 401, !AppState.shared.requiresReAuth {
                 networkLog.warning("401 Unauthorized — triggering re-authentication prompt")
                 AppState.shared.requiresReAuth = true
@@ -389,8 +438,8 @@ final class SubsonicClient {
         return body.musicFolders?.musicFolder ?? []
     }
 
-    func getIndexes(musicFolderId: String? = nil) async throws -> IndexesResponse {
-        let body = try await request(.getIndexes(musicFolderId: musicFolderId))
+    func getIndexes(musicFolderId: String? = nil, ifModifiedSince: Int? = nil) async throws -> IndexesResponse {
+        let body = try await request(.getIndexes(musicFolderId: musicFolderId, ifModifiedSince: ifModifiedSince))
         guard let indexes = body.indexes else {
             throw SubsonicError.apiError(code: 70, message: "Indexes not found")
         }

--- a/Vibrdrome/Core/Networking/SubsonicEndpoints.swift
+++ b/Vibrdrome/Core/Networking/SubsonicEndpoints.swift
@@ -51,7 +51,7 @@ enum SubsonicEndpoint: Sendable {
     case getSimilarSongs2(id: String, count: Int = 50)
     case getTopSongs(artist: String, count: Int = 50)
     case getMusicFolders
-    case getIndexes(musicFolderId: String? = nil)
+    case getIndexes(musicFolderId: String? = nil, ifModifiedSince: Int? = nil)
     case getMusicDirectory(id: String)
     case jukeboxControl(action: String, index: Int? = nil, offset: Int? = nil,
                         ids: [String]? = nil, gain: Float? = nil)
@@ -285,9 +285,10 @@ enum SubsonicEndpoint: Sendable {
                 URLQueryItem(name: "count", value: "\(count)")
             ]
 
-        case .getIndexes(let musicFolderId):
+        case .getIndexes(let musicFolderId, let ifModifiedSince):
             var items: [URLQueryItem] = []
             if let musicFolderId { items.append(URLQueryItem(name: "musicFolderId", value: musicFolderId)) }
+            if let ifModifiedSince { items.append(URLQueryItem(name: "ifModifiedSince", value: "\(ifModifiedSince)")) }
             return items
 
         case .getMusicDirectory(let id):

--- a/Vibrdrome/Core/Networking/SubsonicModels.swift
+++ b/Vibrdrome/Core/Networking/SubsonicModels.swift
@@ -137,6 +137,10 @@ struct AlbumInfo2: Decodable, Sendable {
 
 // MARK: - Album Models
 
+struct RecordLabel: Decodable, Sendable {
+    let name: String
+}
+
 struct Album: Decodable, Identifiable, Sendable {
     let id: String
     let name: String
@@ -149,8 +153,14 @@ struct Album: Decodable, Identifiable, Sendable {
     let genre: String?
     let starred: String?
     let created: String?
+    let userRating: Int?
     let song: [Song]?
     let replayGain: ReplayGain?
+    let musicBrainzId: String?
+    let recordLabels: [RecordLabel]?
+
+    /// First record label name, for convenience.
+    var label: String? { recordLabels?.first?.name }
 }
 
 struct AlbumList2Response: Decodable, Sendable {
@@ -171,7 +181,7 @@ struct TopSongsResponse: Decodable, Sendable {
 
 // MARK: - Song Model
 
-struct Song: Decodable, Identifiable, Sendable {
+struct Song: Decodable, Identifiable, Sendable, Equatable {
     let id: String
     let parent: String?
     let title: String
@@ -223,7 +233,7 @@ struct Song: Decodable, Identifiable, Sendable {
     }
 }
 
-struct ReplayGain: Decodable, Sendable {
+struct ReplayGain: Decodable, Sendable, Equatable {
     let trackGain: Double?
     let albumGain: Double?
     let trackPeak: Double?

--- a/Vibrdrome/Core/Persistence/BackgroundSyncScheduler.swift
+++ b/Vibrdrome/Core/Persistence/BackgroundSyncScheduler.swift
@@ -1,0 +1,154 @@
+#if os(iOS)
+import BackgroundTasks
+import Foundation
+import os.log
+
+private let bgSyncLog = Logger(subsystem: "com.vibrdrome.app", category: "BackgroundSync")
+
+/// Manages background library sync via BGTaskScheduler on iOS.
+/// Registers and schedules both app refresh and processing tasks.
+@MainActor
+final class BackgroundSyncScheduler {
+    static let shared = BackgroundSyncScheduler()
+
+    /// Task identifier for lightweight app refresh (incremental sync).
+    static let refreshTaskId = "com.vibrdrome.app.libraryRefresh"
+    /// Task identifier for longer processing task (full sync).
+    static let processingTaskId = "com.vibrdrome.app.librarySync"
+
+    private init() {}
+
+    /// Register background task handlers. Call once at app launch.
+    func registerTasks() {
+        BGTaskScheduler.shared.register(
+            forTaskWithIdentifier: Self.refreshTaskId,
+            using: nil
+        ) { task in
+            guard let refreshTask = task as? BGAppRefreshTask else { return }
+            Task { @MainActor in
+                await self.handleRefreshTask(refreshTask)
+            }
+        }
+
+        BGTaskScheduler.shared.register(
+            forTaskWithIdentifier: Self.processingTaskId,
+            using: nil
+        ) { task in
+            guard let processingTask = task as? BGProcessingTask else { return }
+            Task { @MainActor in
+                await self.handleProcessingTask(processingTask)
+            }
+        }
+
+        bgSyncLog.info("Registered background sync tasks")
+    }
+
+    /// Schedule the next background refresh. Call after each sync completes.
+    func scheduleRefresh() {
+        guard AppState.shared.isConfigured else { return }
+        guard UserDefaults.standard.bool(forKey: UserDefaultsKeys.backgroundSyncEnabled) else {
+            bgSyncLog.info("Background sync disabled, not scheduling refresh")
+            return
+        }
+
+        let request = BGAppRefreshTaskRequest(identifier: Self.refreshTaskId)
+        // Earliest: 1 hour from now
+        request.earliestBeginDate = Date(timeIntervalSinceNow: 3600)
+
+        do {
+            try BGTaskScheduler.shared.submit(request)
+            bgSyncLog.info("Scheduled background refresh for ~1 hour from now")
+        } catch {
+            bgSyncLog.error("Failed to schedule background refresh: \(error)")
+        }
+    }
+
+    /// Schedule a longer background processing task for full sync.
+    func scheduleFullSync() {
+        guard AppState.shared.isConfigured else { return }
+        guard UserDefaults.standard.bool(forKey: UserDefaultsKeys.backgroundSyncEnabled) else { return }
+
+        let request = BGProcessingTaskRequest(identifier: Self.processingTaskId)
+        request.requiresNetworkConnectivity = true
+        request.requiresExternalPower = false
+        // Earliest: 24 hours from now
+        request.earliestBeginDate = Date(timeIntervalSinceNow: 86400)
+
+        do {
+            try BGTaskScheduler.shared.submit(request)
+            bgSyncLog.info("Scheduled background full sync for ~24 hours from now")
+        } catch {
+            bgSyncLog.error("Failed to schedule background full sync: \(error)")
+        }
+    }
+
+    /// Cancel all pending background sync tasks.
+    func cancelAll() {
+        BGTaskScheduler.shared.cancel(taskRequestWithIdentifier: Self.refreshTaskId)
+        BGTaskScheduler.shared.cancel(taskRequestWithIdentifier: Self.processingTaskId)
+        bgSyncLog.info("Cancelled all background sync tasks")
+    }
+
+    // MARK: - Task Handlers
+
+    private func handleRefreshTask(_ task: BGAppRefreshTask) async {
+        bgSyncLog.info("Background refresh task started")
+
+        // Schedule the next refresh before doing work
+        scheduleRefresh()
+
+        let appState = AppState.shared
+        guard appState.isConfigured else {
+            bgSyncLog.info("App not configured, completing background refresh")
+            task.setTaskCompleted(success: true)
+            return
+        }
+
+        // Create a cancellation handler
+        let syncTask = Task {
+            await appState.librarySyncManager.incrementalSync(
+                client: appState.subsonicClient,
+                container: PersistenceController.shared.container
+            )
+        }
+
+        task.expirationHandler = {
+            syncTask.cancel()
+            bgSyncLog.warning("Background refresh task expired")
+        }
+
+        await syncTask.value
+        task.setTaskCompleted(success: appState.librarySyncManager.syncError == nil)
+        bgSyncLog.info("Background refresh task completed")
+    }
+
+    private func handleProcessingTask(_ task: BGProcessingTask) async {
+        bgSyncLog.info("Background processing task started")
+
+        // Schedule the next full sync
+        scheduleFullSync()
+
+        let appState = AppState.shared
+        guard appState.isConfigured else {
+            task.setTaskCompleted(success: true)
+            return
+        }
+
+        let syncTask = Task {
+            await appState.librarySyncManager.sync(
+                client: appState.subsonicClient,
+                container: PersistenceController.shared.container
+            )
+        }
+
+        task.expirationHandler = {
+            syncTask.cancel()
+            bgSyncLog.warning("Background processing task expired")
+        }
+
+        await syncTask.value
+        task.setTaskCompleted(success: appState.librarySyncManager.syncError == nil)
+        bgSyncLog.info("Background processing task completed")
+    }
+}
+#endif

--- a/Vibrdrome/Core/Persistence/LibraryDataCache.swift
+++ b/Vibrdrome/Core/Persistence/LibraryDataCache.swift
@@ -17,6 +17,8 @@ final class LibraryDataCache {
     private(set) var songFilterGenres: [String]?
 
     /// Incremented after each successful rebuild so views can detect changes via `.onChange`.
+    /// Intentionally in-session only (not persisted) — resets to 0 on launch. Views only need
+    /// to detect changes *within* a session; cross-launch staleness is handled by `LibrarySyncManager`.
     private(set) var generation: Int = 0
 
     private var buildTask: Task<Void, Never>?

--- a/Vibrdrome/Core/Persistence/LibraryDataCache.swift
+++ b/Vibrdrome/Core/Persistence/LibraryDataCache.swift
@@ -1,0 +1,118 @@
+import Foundation
+import SwiftData
+import os.log
+
+private let cacheLog = Logger(subsystem: "com.vibrdrome.app", category: "LibraryCache")
+
+/// Pre-computes converted model arrays on a background thread so library tabs
+/// are ready instantly when first selected.
+@Observable
+@MainActor
+final class LibraryDataCache {
+    private(set) var songs: [Song]?
+    private(set) var artists: [Artist]?
+    private(set) var albums: [Album]?
+    private(set) var songFilterYears: [Int]?
+    private(set) var songFilterArtists: [String]?
+    private(set) var songFilterGenres: [String]?
+
+    /// Incremented after each successful rebuild so views can detect changes via `.onChange`.
+    private(set) var generation: Int = 0
+
+    private var buildTask: Task<Void, Never>?
+
+    /// Kick off a background rebuild of all cached model arrays.
+    func rebuild(container: ModelContainer) {
+        buildTask?.cancel()
+        buildTask = Task {
+            let result = await Task.detached(priority: .userInitiated) {
+                Self.buildCache(container: container)
+            }.value
+            guard !Task.isCancelled else { return }
+            songs = result.songs
+            artists = result.artists
+            albums = result.albums
+            songFilterYears = result.years
+            songFilterArtists = result.artistNames
+            songFilterGenres = result.genres
+            generation += 1
+            cacheLog.info("Library cache ready — \(result.songs.count) songs, \(result.artists.count) artists, \(result.albums.count) albums")
+        }
+    }
+
+    /// Clear all cached data (e.g. on logout or server switch).
+    func invalidate() {
+        buildTask?.cancel()
+        songs = nil
+        artists = nil
+        albums = nil
+        songFilterYears = nil
+        songFilterArtists = nil
+        songFilterGenres = nil
+    }
+
+    // MARK: - Background Work
+
+    private struct CacheResult: Sendable {
+        let songs: [Song]
+        let artists: [Artist]
+        let albums: [Album]
+        let years: [Int]
+        let artistNames: [String]
+        let genres: [String]
+    }
+
+    nonisolated private static func buildCache(container: ModelContainer) -> CacheResult {
+        let context = ModelContext(container)
+        context.autosaveEnabled = false
+
+        // Artists
+        let artistDescriptor = FetchDescriptor<CachedArtist>(sortBy: [SortDescriptor<CachedArtist>(\.name)])
+        let convertedArtists: [Artist]
+        if let cached = try? context.fetch(artistDescriptor) {
+            convertedArtists = cached.map { $0.toArtist() }
+        } else {
+            convertedArtists = []
+        }
+
+        // Albums
+        let albumDescriptor = FetchDescriptor<CachedAlbum>(sortBy: [SortDescriptor<CachedAlbum>(\.name)])
+        let convertedAlbums: [Album]
+        if let cached = try? context.fetch(albumDescriptor) {
+            convertedAlbums = cached.map { $0.toAlbum() }
+        } else {
+            convertedAlbums = []
+        }
+
+        // Songs — single pass for conversion + filter option extraction
+        let songDescriptor = FetchDescriptor<CachedSong>(sortBy: [SortDescriptor<CachedSong>(\.title)])
+        var convertedSongs = [Song]()
+        var yearSet = Set<Int>()
+        var artistSet = Set<String>()
+        var genreSet = Set<String>()
+        if let cached = try? context.fetch(songDescriptor) {
+            convertedSongs.reserveCapacity(cached.count)
+            for item in cached {
+                convertedSongs.append(item.toSong())
+                if let year = item.year { yearSet.insert(year) }
+                if let artist = item.artist { artistSet.insert(artist) }
+                if let genre = item.genre { genreSet.insert(genre) }
+            }
+        }
+
+        let sortedYears = yearSet.sorted(by: >)
+        let sortedArtists = Array(artistSet)
+            .sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
+        let sortedGenres = Array(genreSet)
+            .sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
+
+        return CacheResult(
+            songs: convertedSongs,
+            artists: convertedArtists,
+            albums: convertedAlbums,
+            years: sortedYears,
+            artistNames: sortedArtists,
+            genres: sortedGenres
+        )
+    }
+}

--- a/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
+++ b/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
@@ -590,6 +590,12 @@ final class LibrarySyncManager {
     /// Skipped if a prefetch already ran during sync this session.
     func warmImageCache(client: SubsonicClient, container: ModelContainer) async {
         guard !didPrefetchThisSession else { return }
+        // Skip if a full prefetch completed recently (within 24 hours)
+        if let lastPrefetch = UserDefaults.standard.object(forKey: UserDefaultsKeys.lastCoverArtPrefetchDate) as? Date,
+           Date().timeIntervalSince(lastPrefetch) < 86_400 {
+            didPrefetchThisSession = true
+            return
+        }
         let context = ModelContext(container)
         await prefetchCoverArt(client: client, context: context)
     }
@@ -624,22 +630,39 @@ final class LibrarySyncManager {
         syncLog.info("Prefetching \(total) cover art images")
 
         let pipeline = ImagePipeline.shared
-        let urlMap: [(String, URL)] = coverArtIds.map { id in
-            (id, client.coverArtURL(id: id, size: 600))
+
+        // Filter out images already in memory or disk cache so we only fetch what's missing
+        let dataCache = pipeline.configuration.dataCache as? DataCache
+        let uncachedUrls: [(String, URL)] = coverArtIds.compactMap { id in
+            let url = client.coverArtURL(id: id, size: 600)
+            let request = ImageRequest(url: url)
+            if pipeline.cache.containsCachedImage(for: request) { return nil }
+            let key = pipeline.cache.makeDataCacheKey(for: request)
+            if dataCache?.containsData(for: key) == true { return nil }
+            return (id, url)
         }
 
-        var fetched = 0
+        let alreadyCached = total - uncachedUrls.count
+        guard !uncachedUrls.isEmpty else {
+            didPrefetchThisSession = true
+            UserDefaults.standard.set(Date(), forKey: UserDefaultsKeys.lastCoverArtPrefetchDate)
+            syncLog.info("Cover art prefetch skipped — all \(total) images already cached")
+            return
+        }
+
+        syncLog.info("Prefetching \(uncachedUrls.count) cover art images (\(alreadyCached) already cached)")
+
+        var fetched = alreadyCached
         let batchSize = 10
         let perImageTimeout: UInt64 = 15_000_000_000 // 15 seconds
 
-        for batchStart in stride(from: 0, to: urlMap.count, by: batchSize) {
+        for batchStart in stride(from: 0, to: uncachedUrls.count, by: batchSize) {
             guard !Task.isCancelled else { break }
-            let batch = urlMap[batchStart..<min(batchStart + batchSize, urlMap.count)]
+            let batch = uncachedUrls[batchStart..<min(batchStart + batchSize, uncachedUrls.count)]
             await withTaskGroup(of: Void.self) { group in
                 for (_, url) in batch {
                     group.addTask {
                         let request = ImageRequest(url: url)
-                        if pipeline.cache.containsCachedImage(for: request) { return }
                         // Timeout prevents a single stalled request from blocking the entire prefetch
                         await withTaskGroup(of: Void.self) { inner in
                             inner.addTask {
@@ -660,7 +683,8 @@ final class LibrarySyncManager {
         }
 
         didPrefetchThisSession = true
-        syncLog.info("Cover art prefetch complete: \(fetched) processed")
+        UserDefaults.standard.set(Date(), forKey: UserDefaultsKeys.lastCoverArtPrefetchDate)
+        syncLog.info("Cover art prefetch complete: \(fetched)/\(total) processed")
     }
 
     // MARK: - Sync History

--- a/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
+++ b/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
@@ -40,6 +40,8 @@ final class LibrarySyncManager {
     /// Polling timer for change detection while app is active.
     private var pollingTask: Task<Void, Never>?
 
+    // Page sizes for paginated API calls. 500 is a safe default for most Subsonic servers;
+    // could be made configurable per-server if needed for very large or constrained instances.
     private let albumPageSize = 500
     private let songPageSize = 500
 

--- a/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
+++ b/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
@@ -509,27 +509,29 @@ final class LibrarySyncManager {
         let allLocal = try context.fetch(FetchDescriptor<CachedPlaylist>())
         let localMap = Dictionary(uniqueKeysWithValues: allLocal.map { ($0.id, $0) })
 
-        // Fetch playlist details with bounded concurrency
-        let details = try await withThrowingTaskGroup(of: Playlist.self, returning: [Playlist].self) { group in
+        // Fetch playlist details with bounded concurrency (tolerates individual failures e.g. deleted playlists)
+        let details = await withTaskGroup(of: Playlist?.self, returning: [Playlist].self) { group in
             var results: [Playlist] = []
             var inflight = 0
             let maxConcurrency = 2
 
             for playlist in playlists {
                 if inflight >= maxConcurrency {
-                    if let detail = try await group.next() {
+                    if let detail = await group.next() ?? nil {
                         results.append(detail)
                     }
                     inflight -= 1
                 }
                 group.addTask {
-                    try await client.getPlaylist(id: playlist.id)
+                    try? await client.getPlaylist(id: playlist.id)
                 }
                 inflight += 1
             }
 
-            for try await detail in group {
-                results.append(detail)
+            for await detail in group {
+                if let detail {
+                    results.append(detail)
+                }
             }
             return results
         }

--- a/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
+++ b/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
@@ -1,0 +1,706 @@
+import Foundation
+import Nuke
+import SwiftData
+import os.log
+
+private let syncLog = Logger(subsystem: "com.vibrdrome.app", category: "LibrarySync")
+
+/// Sync mode determines the depth of library synchronization.
+enum SyncMode: String, Sendable {
+    /// Full re-sync of all metadata — catches additions, updates, and deletions.
+    case full
+    /// Lightweight sync — only fetches recently changed content.
+    case incremental
+    /// Triggered by BGTaskScheduler in the background.
+    case background
+}
+
+/// Syncs library metadata (albums, artists, songs, playlists) from the Subsonic API
+/// into SwiftData for local filtering, search, and offline support.
+@Observable
+@MainActor
+final class LibrarySyncManager {
+    static let shared = LibrarySyncManager()
+
+    /// Configured by AppState at login for convenience sync calls.
+    weak var client: SubsonicClient?
+    var container: ModelContainer?
+
+    var isSyncing = false
+    var syncProgress: String?
+    var lastSyncDate: Date? {
+        get { UserDefaults.standard.object(forKey: UserDefaultsKeys.lastLibrarySyncDate) as? Date }
+        set { UserDefaults.standard.set(newValue, forKey: UserDefaultsKeys.lastLibrarySyncDate) }
+    }
+    var syncError: String?
+
+    /// Stats from the most recent sync, updated live during sync.
+    var lastSyncStats: SyncStats?
+
+    /// Polling timer for change detection while app is active.
+    private var pollingTask: Task<Void, Never>?
+
+    private let albumPageSize = 500
+    private let songPageSize = 500
+
+    /// Stale threshold for auto-sync (24 hours).
+    private let staleInterval: TimeInterval = 86400
+    /// Interval between full syncs to catch deletions (7 days).
+    private let fullSyncInterval: TimeInterval = 604_800
+
+    // MARK: - Sync Stats
+
+    struct SyncStats: Sendable {
+        var albumsAdded = 0
+        var albumsUpdated = 0
+        var albumsRemoved = 0
+        var artistsAdded = 0
+        var artistsUpdated = 0
+        var artistsRemoved = 0
+        var songsAdded = 0
+        var songsUpdated = 0
+        var songsRemoved = 0
+        var playlistsSynced = 0
+        var conflictsDetected = 0
+        var conflictsResolved = 0
+        var startTime = Date()
+
+        var totalChanges: Int {
+            albumsAdded + albumsUpdated + albumsRemoved +
+            artistsAdded + artistsUpdated + artistsRemoved +
+            songsAdded + songsUpdated + songsRemoved
+        }
+
+        var duration: TimeInterval {
+            Date().timeIntervalSince(startTime)
+        }
+    }
+
+    // MARK: - Public API
+
+    /// Run a full library sync: albums, artists, songs, then playlists.
+    func sync(client: SubsonicClient, container: ModelContainer) async {
+        await performSync(mode: .full, client: client, container: container)
+    }
+
+    /// Run an incremental sync — only fetches changes since last sync.
+    func incrementalSync(client: SubsonicClient, container: ModelContainer) async {
+        await performSync(mode: .incremental, client: client, container: container)
+    }
+
+    /// Convenience: sync using the configured client and container.
+    func syncIfStale() async {
+        guard let client, let container else { return }
+        await syncIfStale(client: client, container: container)
+    }
+
+    /// Check if sync is stale and trigger the appropriate sync mode.
+    func syncIfStale(client: SubsonicClient, container: ModelContainer) async {
+        guard let last = lastSyncDate else {
+            await performSync(mode: .full, client: client, container: container)
+            return
+        }
+        let elapsed = Date().timeIntervalSince(last)
+        guard elapsed > staleInterval else { return }
+
+        // Check if server data actually changed before doing work
+        let serverChanged = await hasServerChanged(client: client)
+
+        if serverChanged {
+            // Use full sync if it's been over a week, otherwise incremental
+            let lastFull = UserDefaults.standard.object(forKey: UserDefaultsKeys.lastFullSyncDate) as? Date
+            let needsFullSync = lastFull == nil || Date().timeIntervalSince(lastFull!) > fullSyncInterval
+            let mode: SyncMode = needsFullSync ? .full : .incremental
+            await performSync(mode: mode, client: client, container: container)
+        } else {
+            // Server unchanged — just update the stale check timestamp
+            lastSyncDate = Date()
+            syncLog.info("Server data unchanged, skipping sync")
+        }
+    }
+
+    // MARK: - Change Detection Polling
+
+    /// Start periodic polling for server changes while the app is active.
+    func startPolling(client: SubsonicClient, container: ModelContainer) {
+        stopPolling()
+        let intervalMinutes = UserDefaults.standard.integer(forKey: UserDefaultsKeys.syncPollingInterval)
+        let interval = max(TimeInterval(intervalMinutes > 0 ? intervalMinutes : 15) * 60, 300)
+
+        pollingTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(interval))
+                guard !Task.isCancelled, let self, !self.isSyncing else { continue }
+
+                let changed = await self.hasServerChanged(client: client)
+                if changed {
+                    syncLog.info("Polling detected server changes, triggering incremental sync")
+                    await self.performSync(mode: .incremental, client: client, container: container)
+                }
+            }
+        }
+        syncLog.info("Started change detection polling every \(Int(interval))s")
+    }
+
+    /// Stop the periodic polling timer.
+    func stopPolling() {
+        pollingTask?.cancel()
+        pollingTask = nil
+    }
+
+    // MARK: - Core Sync Engine
+
+    private func performSync(mode: SyncMode, client: SubsonicClient, container: ModelContainer) async {
+        guard !isSyncing else { return }
+        isSyncing = true
+        syncError = nil
+        syncProgress = mode == .full ? "Starting full sync…" : "Starting incremental sync…"
+        var stats = SyncStats()
+        lastSyncStats = stats
+        defer {
+            isSyncing = false
+            syncProgress = nil
+        }
+
+        do {
+            let context = ModelContext(container)
+            context.autosaveEnabled = false
+
+            switch mode {
+            case .full, .background:
+                try await syncAlbums(client: client, context: context, stats: &stats, incremental: false)
+                try await syncArtists(client: client, context: context, stats: &stats, incremental: false)
+                try await syncSongs(client: client, context: context, stats: &stats, incremental: false)
+                try await syncPlaylists(client: client, context: context, stats: &stats)
+                UserDefaults.standard.set(Date(), forKey: UserDefaultsKeys.lastFullSyncDate)
+
+            case .incremental:
+                try await syncAlbums(client: client, context: context, stats: &stats, incremental: true)
+                try await syncArtists(client: client, context: context, stats: &stats, incremental: true)
+                try await syncSongs(client: client, context: context, stats: &stats, incremental: true)
+                try await syncPlaylists(client: client, context: context, stats: &stats)
+            }
+
+            try context.save()
+            lastSyncDate = Date()
+            lastSyncStats = stats
+
+            // Save sync history
+            saveSyncHistory(stats: stats, mode: mode, context: context)
+
+            syncLog.info("""
+                Library sync (\(mode.rawValue)) completed in \
+                \(String(format: "%.1f", stats.duration))s — \
+                \(stats.totalChanges) changes \
+                (+\(stats.albumsAdded + stats.artistsAdded + stats.songsAdded) \
+                ~\(stats.albumsUpdated + stats.artistsUpdated + stats.songsUpdated) \
+                -\(stats.albumsRemoved + stats.artistsRemoved + stats.songsRemoved))
+                """)
+
+            // Prefetch cover art in background after metadata sync
+            if stats.albumsAdded > 0 || stats.artistsAdded > 0 {
+                await prefetchCoverArt(client: client, context: context)
+            }
+        } catch {
+            syncError = "Sync failed: \(error.localizedDescription)"
+            lastSyncStats = stats
+            saveSyncHistory(stats: stats, mode: mode, context: ModelContext(container), error: error)
+            syncLog.error("Library sync (\(mode.rawValue)) failed: \(error)")
+        }
+    }
+
+    // MARK: - Server Change Detection
+
+    /// Lightweight check if server data has changed since last sync.
+    /// Uses getIndexes with ifModifiedSince to avoid fetching full data.
+    private func hasServerChanged(client: SubsonicClient) async -> Bool {
+        let lastModified = UserDefaults.standard.integer(forKey: UserDefaultsKeys.lastServerModified)
+        guard lastModified > 0 else { return true }
+
+        do {
+            let indexes = try await client.getIndexes(ifModifiedSince: lastModified)
+            if let serverModified = indexes.lastModified, serverModified > lastModified {
+                return true
+            }
+            let hasContent = indexes.index?.isEmpty == false || indexes.child?.isEmpty == false
+            return hasContent
+        } catch {
+            syncLog.warning("Change detection failed: \(error.localizedDescription)")
+            return true
+        }
+    }
+
+    /// Update the stored server lastModified timestamp.
+    private func updateServerModifiedTimestamp(client: SubsonicClient) async {
+        do {
+            let indexes = try await client.getIndexes()
+            if let lastModified = indexes.lastModified {
+                UserDefaults.standard.set(lastModified, forKey: UserDefaultsKeys.lastServerModified)
+            }
+        } catch {
+            syncLog.warning("Failed to fetch server modified timestamp: \(error.localizedDescription)")
+        }
+    }
+
+    // MARK: - Albums
+
+    private func syncAlbums(client: SubsonicClient, context: ModelContext,
+                            stats: inout SyncStats, incremental: Bool) async throws {
+        syncProgress = "Syncing albums…"
+
+        // Build lookup dictionary of existing albums for O(1) access
+        let allLocal = try context.fetch(FetchDescriptor<CachedAlbum>())
+        var localMap = Dictionary(uniqueKeysWithValues: allLocal.map { ($0.id, $0) })
+
+        var offset = 0
+        var serverAlbumIds = Set<String>()
+        var totalFetched = 0
+
+        if incremental {
+            // Fetch only newest albums (added/modified recently)
+            let newestAlbums = try await client.getAlbumList(type: .newest, size: albumPageSize)
+            for album in newestAlbums {
+                serverAlbumIds.insert(album.id)
+                if let existing = localMap[album.id] {
+                    if hasAlbumChanged(existing, album) {
+                        existing.update(from: album)
+                        stats.albumsUpdated += 1
+                    }
+                } else {
+                    let cached = CachedAlbum(from: album)
+                    context.insert(cached)
+                    localMap[album.id] = cached
+                    stats.albumsAdded += 1
+                }
+            }
+            totalFetched = newestAlbums.count
+        } else {
+            // Full sync: fetch all albums
+            while true {
+                let page = try await client.getAlbumList(
+                    type: .alphabeticalByName, size: albumPageSize, offset: offset
+                )
+                if page.isEmpty { break }
+
+                for album in page {
+                    serverAlbumIds.insert(album.id)
+                    if let existing = localMap[album.id] {
+                        if hasAlbumChanged(existing, album) {
+                            existing.update(from: album)
+                            stats.albumsUpdated += 1
+                        }
+                    } else {
+                        let cached = CachedAlbum(from: album)
+                        context.insert(cached)
+                        localMap[album.id] = cached
+                        stats.albumsAdded += 1
+                    }
+                }
+
+                totalFetched += page.count
+                syncProgress = "Syncing albums… \(totalFetched)"
+                offset += page.count
+
+                if page.count < albumPageSize { break }
+            }
+
+            // Remove albums no longer on server
+            for local in allLocal where !serverAlbumIds.contains(local.id) {
+                context.delete(local)
+                stats.albumsRemoved += 1
+            }
+        }
+
+        try context.save()
+        lastSyncStats = stats
+        let added = stats.albumsAdded
+        let updated = stats.albumsUpdated
+        let removed = stats.albumsRemoved
+        syncLog.info("Synced \(totalFetched) albums (+\(added) ~\(updated) -\(removed))")
+    }
+
+    private func hasAlbumChanged(_ cached: CachedAlbum, _ server: Album) -> Bool {
+        cached.name != server.name ||
+        cached.artistName != server.artist ||
+        cached.artistId != server.artistId ||
+        cached.year != server.year ||
+        cached.genre != server.genre ||
+        cached.songCount != server.songCount ||
+        cached.duration != server.duration ||
+        cached.isStarred != (server.starred != nil) ||
+        cached.coverArtId != server.coverArt ||
+        cached.created != server.created ||
+        cached.userRating != (server.userRating ?? 0) ||
+        cached.label != server.label
+    }
+
+    // MARK: - Artists
+
+    private func syncArtists(client: SubsonicClient, context: ModelContext,
+                             stats: inout SyncStats, incremental: Bool) async throws {
+        syncProgress = "Syncing artists…"
+        let indexes = try await client.getArtists()
+        var serverArtistIds = Set<String>()
+
+        // Build lookup dictionary
+        let allLocal = try context.fetch(FetchDescriptor<CachedArtist>())
+        let localMap = Dictionary(uniqueKeysWithValues: allLocal.map { ($0.id, $0) })
+
+        for index in indexes {
+            for artist in index.artist ?? [] {
+                serverArtistIds.insert(artist.id)
+                if let existing = localMap[artist.id] {
+                    if hasArtistChanged(existing, artist) {
+                        existing.name = artist.name
+                        existing.coverArtId = artist.coverArt
+                        existing.albumCount = artist.albumCount
+                        existing.isStarred = artist.starred != nil
+                        existing.cachedAt = Date()
+                        stats.artistsUpdated += 1
+                    }
+                } else {
+                    context.insert(CachedArtist(from: artist))
+                    stats.artistsAdded += 1
+                }
+            }
+        }
+
+        // Remove artists no longer on server (only on full sync)
+        if !incremental {
+            for local in allLocal where !serverArtistIds.contains(local.id) {
+                context.delete(local)
+                stats.artistsRemoved += 1
+            }
+        }
+
+        try context.save()
+        lastSyncStats = stats
+        let artAdded = stats.artistsAdded
+        let artUpdated = stats.artistsUpdated
+        let artRemoved = stats.artistsRemoved
+        syncLog.info("Synced \(serverArtistIds.count) artists (+\(artAdded) ~\(artUpdated) -\(artRemoved))")
+    }
+
+    private func hasArtistChanged(_ cached: CachedArtist, _ server: Artist) -> Bool {
+        cached.name != server.name ||
+        cached.coverArtId != server.coverArt ||
+        cached.albumCount != server.albumCount ||
+        cached.isStarred != (server.starred != nil)
+    }
+
+    // MARK: - Songs
+
+    private func syncSongs(client: SubsonicClient, context: ModelContext,
+                           stats: inout SyncStats, incremental: Bool) async throws {
+        syncProgress = "Syncing songs…"
+
+        // Build lookup dictionary for O(1) access
+        let allLocal = try context.fetch(FetchDescriptor<CachedSong>())
+        var localMap = Dictionary(uniqueKeysWithValues: allLocal.map { ($0.id, $0) })
+
+        // Pre-fetch album map for linking
+        let allAlbums = try context.fetch(FetchDescriptor<CachedAlbum>())
+        let albumMap = Dictionary(uniqueKeysWithValues: allAlbums.map { ($0.id, $0) })
+
+        var offset = 0
+        var serverSongIds = Set<String>()
+        var totalFetched = 0
+
+        while true {
+            let result = try await client.search(
+                query: "", artistCount: 0, albumCount: 0,
+                songCount: songPageSize, songOffset: offset
+            )
+            let songs = result.song ?? []
+            if songs.isEmpty { break }
+
+            for song in songs {
+                serverSongIds.insert(song.id)
+                if let existing = localMap[song.id] {
+                    if hasSongChanged(existing, song) {
+                        updateSongFields(existing, from: song)
+                        stats.songsUpdated += 1
+                    }
+                } else {
+                    let cached = CachedSong(from: song)
+                    if let albumId = song.albumId {
+                        cached.album = albumMap[albumId]
+                    }
+                    context.insert(cached)
+                    localMap[song.id] = cached
+                    stats.songsAdded += 1
+                }
+            }
+
+            totalFetched += songs.count
+            syncProgress = "Syncing songs… \(totalFetched)"
+            offset += songs.count
+
+            if totalFetched % 2000 == 0 {
+                try context.save()
+                lastSyncStats = stats
+            }
+
+            if songs.count < songPageSize { break }
+        }
+
+        // Remove songs no longer on server (only on full sync, preserve downloads)
+        if !incremental {
+            for local in allLocal where !serverSongIds.contains(local.id) && local.download == nil {
+                context.delete(local)
+                stats.songsRemoved += 1
+            }
+        }
+
+        try context.save()
+        lastSyncStats = stats
+        await updateServerModifiedTimestamp(client: client)
+        let songAdded = stats.songsAdded
+        let songUpdated = stats.songsUpdated
+        let songRemoved = stats.songsRemoved
+        syncLog.info("Synced \(totalFetched) songs (+\(songAdded) ~\(songUpdated) -\(songRemoved))")
+    }
+
+    private func hasSongChanged(_ cached: CachedSong, _ server: Song) -> Bool {
+        cached.title != server.title ||
+        cached.artist != server.artist ||
+        cached.albumName != server.album ||
+        cached.track != server.track ||
+        cached.year != server.year ||
+        cached.genre != server.genre ||
+        cached.duration != server.duration ||
+        cached.isStarred != (server.starred != nil) ||
+        cached.coverArtId != server.coverArt ||
+        cached.bitRate != server.bitRate
+    }
+
+    private func updateSongFields(_ cached: CachedSong, from song: Song) {
+        cached.title = song.title
+        cached.artist = song.artist
+        cached.albumArtist = song.albumArtist
+        cached.albumName = song.album
+        cached.albumId = song.albumId
+        cached.artistId = song.artistId
+        cached.coverArtId = song.coverArt
+        cached.track = song.track
+        cached.discNumber = song.discNumber
+        cached.year = song.year
+        cached.genre = song.genre
+        cached.duration = song.duration
+        cached.bitRate = song.bitRate
+        cached.suffix = song.suffix
+        cached.contentType = song.contentType
+        cached.size = song.size
+        cached.isStarred = song.starred != nil
+        cached.rating = song.userRating ?? 0
+        cached.cachedAt = Date()
+    }
+
+    // MARK: - Playlists
+
+    private func syncPlaylists(client: SubsonicClient, context: ModelContext,
+                               stats: inout SyncStats) async throws {
+        syncProgress = "Syncing playlists…"
+        let playlists = try await client.getPlaylists()
+        var serverPlaylistIds = Set<String>()
+
+        let allLocal = try context.fetch(FetchDescriptor<CachedPlaylist>())
+        let localMap = Dictionary(uniqueKeysWithValues: allLocal.map { ($0.id, $0) })
+
+        // Fetch playlist details with bounded concurrency
+        let details = try await withThrowingTaskGroup(of: Playlist.self, returning: [Playlist].self) { group in
+            var results: [Playlist] = []
+            var inflight = 0
+            let maxConcurrency = 2
+
+            for playlist in playlists {
+                if inflight >= maxConcurrency {
+                    if let detail = try await group.next() {
+                        results.append(detail)
+                    }
+                    inflight -= 1
+                }
+                group.addTask {
+                    try await client.getPlaylist(id: playlist.id)
+                }
+                inflight += 1
+            }
+
+            for try await detail in group {
+                results.append(detail)
+            }
+            return results
+        }
+
+        for detail in details {
+            serverPlaylistIds.insert(detail.id)
+            upsertPlaylist(detail, context: context, localMap: localMap)
+            stats.playlistsSynced += 1
+        }
+
+        for local in allLocal where !serverPlaylistIds.contains(local.id) {
+            context.delete(local)
+        }
+
+        try context.save()
+        lastSyncStats = stats
+        syncLog.info("Synced \(playlists.count) playlists with entries")
+    }
+
+    private func upsertPlaylist(_ playlist: Playlist, context: ModelContext,
+                                localMap: [String: CachedPlaylist]) {
+        let cached: CachedPlaylist
+        if let existing = localMap[playlist.id] {
+            existing.name = playlist.name
+            existing.songCount = playlist.songCount
+            existing.duration = playlist.duration
+            existing.coverArtId = playlist.coverArt
+            existing.owner = playlist.owner
+            existing.isPublic = playlist.isPublic ?? false
+            existing.changed = playlist.changed
+            existing.cachedAt = Date()
+            cached = existing
+        } else {
+            cached = CachedPlaylist(from: playlist)
+            context.insert(cached)
+        }
+
+        for entry in cached.entries {
+            context.delete(entry)
+        }
+
+        if let songs = playlist.entry {
+            for (index, song) in songs.enumerated() {
+                let entry = CachedPlaylistEntry(songId: song.id, order: index)
+                entry.playlist = cached
+                context.insert(entry)
+            }
+        }
+    }
+
+    // MARK: - Cover Art Prefetch
+
+    /// Whether a prefetch pass already ran this session (avoids duplicate work).
+    private var didPrefetchThisSession = false
+
+    /// Warm the in-memory image cache on startup by loading all known cover art.
+    /// Images already in memory are skipped; images in disk cache load instantly.
+    /// Skipped if a prefetch already ran during sync this session.
+    func warmImageCache(client: SubsonicClient, container: ModelContainer) async {
+        guard !didPrefetchThisSession else { return }
+        let context = ModelContext(container)
+        await prefetchCoverArt(client: client, context: context)
+    }
+
+    private func prefetchCoverArt(client: SubsonicClient, context: ModelContext) async {
+        syncProgress = "Prefetching cover art…"
+
+        // Collect cover art IDs from albums and artists without loading full objects
+        var coverArtIds = Set<String>()
+
+        let albumDescriptor = FetchDescriptor<CachedAlbum>(
+            predicate: #Predicate<CachedAlbum> { $0.coverArtId != nil }
+        )
+        let albums = (try? context.fetch(albumDescriptor)) ?? []
+        for album in albums {
+            if let id = album.coverArtId { coverArtIds.insert(id) }
+        }
+
+        let artistDescriptor = FetchDescriptor<CachedArtist>(
+            predicate: #Predicate<CachedArtist> { $0.coverArtId != nil }
+        )
+        let artists = (try? context.fetch(artistDescriptor)) ?? []
+        for artist in artists {
+            if let id = artist.coverArtId { coverArtIds.insert(id) }
+        }
+
+        let total = coverArtIds.count
+        guard total > 0 else {
+            didPrefetchThisSession = true
+            return
+        }
+        syncLog.info("Prefetching \(total) cover art images")
+
+        let pipeline = ImagePipeline.shared
+        let urlMap: [(String, URL)] = coverArtIds.map { id in
+            (id, client.coverArtURL(id: id, size: 600))
+        }
+
+        var fetched = 0
+        let batchSize = 10
+        let perImageTimeout: UInt64 = 15_000_000_000 // 15 seconds
+
+        for batchStart in stride(from: 0, to: urlMap.count, by: batchSize) {
+            guard !Task.isCancelled else { break }
+            let batch = urlMap[batchStart..<min(batchStart + batchSize, urlMap.count)]
+            await withTaskGroup(of: Void.self) { group in
+                for (_, url) in batch {
+                    group.addTask {
+                        let request = ImageRequest(url: url)
+                        if pipeline.cache.containsCachedImage(for: request) { return }
+                        // Timeout prevents a single stalled request from blocking the entire prefetch
+                        await withTaskGroup(of: Void.self) { inner in
+                            inner.addTask {
+                                _ = try? await pipeline.image(for: request)
+                            }
+                            inner.addTask {
+                                try? await Task.sleep(nanoseconds: perImageTimeout)
+                            }
+                            // Return as soon as the first child completes (image loaded or timeout)
+                            await inner.next()
+                            inner.cancelAll()
+                        }
+                    }
+                }
+            }
+            fetched += batch.count
+            syncProgress = "Prefetching cover art… \(fetched)/\(total)"
+        }
+
+        didPrefetchThisSession = true
+        syncLog.info("Cover art prefetch complete: \(fetched) processed")
+    }
+
+    // MARK: - Sync History
+
+    private func saveSyncHistory(stats: SyncStats, mode: SyncMode,
+                                 context: ModelContext, error: Error? = nil) {
+        let history = SyncHistory(syncType: mode.rawValue)
+        history.durationSeconds = stats.duration
+        history.albumsAdded = stats.albumsAdded
+        history.albumsUpdated = stats.albumsUpdated
+        history.albumsRemoved = stats.albumsRemoved
+        history.artistsAdded = stats.artistsAdded
+        history.artistsUpdated = stats.artistsUpdated
+        history.artistsRemoved = stats.artistsRemoved
+        history.songsAdded = stats.songsAdded
+        history.songsUpdated = stats.songsUpdated
+        history.songsRemoved = stats.songsRemoved
+        history.playlistsSynced = stats.playlistsSynced
+        history.conflictsDetected = stats.conflictsDetected
+        history.conflictsResolved = stats.conflictsResolved
+        history.succeeded = error == nil
+        history.errorMessage = error?.localizedDescription
+        context.insert(history)
+        try? context.save()
+
+        pruneSyncHistory(context: context)
+    }
+
+    private func pruneSyncHistory(context: ModelContext) {
+        var descriptor = FetchDescriptor<SyncHistory>(
+            sortBy: [SortDescriptor(\.syncDate, order: .reverse)]
+        )
+        descriptor.fetchOffset = 50
+        do {
+            let old = try context.fetch(descriptor)
+            guard !old.isEmpty else { return }
+            for entry in old {
+                context.delete(entry)
+            }
+            try context.save()
+        } catch {
+            syncLog.warning("Failed to prune sync history: \(error.localizedDescription)")
+        }
+    }
+}

--- a/Vibrdrome/Core/Persistence/Models/CachedAlbum.swift
+++ b/Vibrdrome/Core/Persistence/Models/CachedAlbum.swift
@@ -13,6 +13,9 @@ final class CachedAlbum {
     var songCount: Int?
     var duration: Int?
     var isStarred: Bool = false
+    var created: String?
+    var userRating: Int = 0
+    var label: String?
     var cachedAt: Date = Date()
 
     var songs: [CachedSong] = []
@@ -28,5 +31,47 @@ final class CachedAlbum {
         self.songCount = album.songCount
         self.duration = album.duration
         self.isStarred = album.starred != nil
+        self.created = album.created
+        self.userRating = album.userRating ?? 0
+        self.label = album.label
+    }
+
+    /// Update existing record with fresh server data.
+    func update(from album: Album) {
+        name = album.name
+        artistName = album.artist
+        artistId = album.artistId
+        coverArtId = album.coverArt
+        year = album.year
+        genre = album.genre
+        songCount = album.songCount
+        duration = album.duration
+        isStarred = album.starred != nil
+        created = album.created
+        userRating = album.userRating ?? 0
+        label = album.label
+        cachedAt = Date()
+    }
+
+    /// Convert back to an Album value type for view compatibility.
+    func toAlbum() -> Album {
+        Album(
+            id: id,
+            name: name,
+            artist: artistName,
+            artistId: artistId,
+            coverArt: coverArtId,
+            songCount: songCount,
+            duration: duration,
+            year: year,
+            genre: genre,
+            starred: isStarred ? "true" : nil,
+            created: created,
+            userRating: userRating > 0 ? userRating : nil,
+            song: nil,
+            replayGain: nil,
+            musicBrainzId: nil,
+            recordLabels: label.map { [RecordLabel(name: $0)] }
+        )
     }
 }

--- a/Vibrdrome/Core/Persistence/Models/CachedArtist.swift
+++ b/Vibrdrome/Core/Persistence/Models/CachedArtist.swift
@@ -17,4 +17,15 @@ final class CachedArtist {
         self.albumCount = artist.albumCount
         self.isStarred = artist.starred != nil
     }
+
+    func toArtist() -> Artist {
+        Artist(
+            id: id,
+            name: name,
+            coverArt: coverArtId,
+            albumCount: albumCount,
+            starred: isStarred ? "true" : nil,
+            album: nil
+        )
+    }
 }

--- a/Vibrdrome/Core/Persistence/Models/CachedPlaylist.swift
+++ b/Vibrdrome/Core/Persistence/Models/CachedPlaylist.swift
@@ -10,7 +10,10 @@ final class CachedPlaylist {
     var coverArtId: String?
     var owner: String?
     var isPublic: Bool = false
+    var changed: String?
     var cachedAt: Date = Date()
+
+    @Relationship(deleteRule: .cascade) var entries: [CachedPlaylistEntry] = []
 
     init(from playlist: Playlist) {
         self.id = playlist.id
@@ -20,5 +23,21 @@ final class CachedPlaylist {
         self.coverArtId = playlist.coverArt
         self.owner = playlist.owner
         self.isPublic = playlist.isPublic ?? false
+        self.changed = playlist.changed
+    }
+
+    func toPlaylist() -> Playlist {
+        Playlist(
+            id: id,
+            name: name,
+            songCount: songCount,
+            duration: duration,
+            created: nil,
+            changed: changed,
+            coverArt: coverArtId,
+            owner: owner,
+            isPublic: isPublic,
+            entry: nil
+        )
     }
 }

--- a/Vibrdrome/Core/Persistence/Models/CachedPlaylistEntry.swift
+++ b/Vibrdrome/Core/Persistence/Models/CachedPlaylistEntry.swift
@@ -1,0 +1,15 @@
+import Foundation
+import SwiftData
+
+@Model
+final class CachedPlaylistEntry {
+    var songId: String
+    var order: Int
+
+    var playlist: CachedPlaylist?
+
+    init(songId: String, order: Int) {
+        self.songId = songId
+        self.order = order
+    }
+}

--- a/Vibrdrome/Core/Persistence/Models/SyncHistory.swift
+++ b/Vibrdrome/Core/Persistence/Models/SyncHistory.swift
@@ -1,0 +1,52 @@
+import Foundation
+import SwiftData
+
+@Model
+final class SyncHistory {
+    var syncDate: Date = Date()
+    /// "full", "incremental", "background"
+    var syncType: String = "full"
+    var durationSeconds: Double = 0
+    var albumsAdded: Int = 0
+    var albumsUpdated: Int = 0
+    var albumsRemoved: Int = 0
+    var artistsAdded: Int = 0
+    var artistsUpdated: Int = 0
+    var artistsRemoved: Int = 0
+    var songsAdded: Int = 0
+    var songsUpdated: Int = 0
+    var songsRemoved: Int = 0
+    var playlistsSynced: Int = 0
+    var conflictsDetected: Int = 0
+    var conflictsResolved: Int = 0
+    var errorMessage: String?
+    var succeeded: Bool = true
+
+    init(syncType: String) {
+        self.syncType = syncType
+        self.syncDate = Date()
+    }
+
+    var totalChanges: Int {
+        albumsAdded + albumsUpdated + albumsRemoved +
+        artistsAdded + artistsUpdated + artistsRemoved +
+        songsAdded + songsUpdated + songsRemoved
+    }
+
+    var summary: String {
+        if !succeeded, let error = errorMessage {
+            return "Failed: \(error)"
+        }
+        if totalChanges == 0 {
+            return "No changes"
+        }
+        var parts: [String] = []
+        let added = albumsAdded + artistsAdded + songsAdded
+        let updated = albumsUpdated + artistsUpdated + songsUpdated
+        let removed = albumsRemoved + artistsRemoved + songsRemoved
+        if added > 0 { parts.append("+\(added)") }
+        if updated > 0 { parts.append("~\(updated)") }
+        if removed > 0 { parts.append("-\(removed)") }
+        return parts.joined(separator: " ")
+    }
+}

--- a/Vibrdrome/Core/Persistence/PersistenceController.swift
+++ b/Vibrdrome/Core/Persistence/PersistenceController.swift
@@ -23,6 +23,7 @@ final class PersistenceController {
             CachedAlbum.self,
             CachedSong.self,
             CachedPlaylist.self,
+            CachedPlaylistEntry.self,
             DownloadedSong.self,
             PlayHistory.self,
             ServerConfig.self,
@@ -30,6 +31,7 @@ final class PersistenceController {
             PendingAction.self,
             SavedQueue.self,
             AlbumCollection.self,
+            SyncHistory.self,
         ])
 
         let config = ModelConfiguration(

--- a/Vibrdrome/Features/Library/AlbumDetailView.swift
+++ b/Vibrdrome/Features/Library/AlbumDetailView.swift
@@ -1,10 +1,12 @@
 import SwiftUI
+import SwiftData
 import NukeUI
 
 struct AlbumDetailView: View {
     let albumId: String
 
     @Environment(AppState.self) private var appState
+    @Environment(\.modelContext) private var modelContext
     @State private var album: Album?
     @State private var albumNotes: String?
     @State private var showFullNotes = false
@@ -592,7 +594,33 @@ struct AlbumDetailView: View {
     }
 
     private func loadAlbum() async {
-        isLoading = true
+        // Show cached album header instantly if available
+        if album == nil {
+            let aid = albumId
+            let descriptor = FetchDescriptor<CachedAlbum>(
+                predicate: #Predicate { $0.id == aid }
+            )
+            if let cached = try? modelContext.fetch(descriptor).first {
+                var preview = cached.toAlbum()
+                // Attach cached songs if available
+                let songs = cached.songs
+                    .sorted { ($0.discNumber ?? 0, $0.track ?? 0) < ($1.discNumber ?? 0, $1.track ?? 0) }
+                    .map { $0.toSong() }
+                if !songs.isEmpty {
+                    preview = Album(
+                        id: preview.id, name: preview.name, artist: preview.artist,
+                        artistId: preview.artistId, coverArt: preview.coverArt,
+                        songCount: preview.songCount, duration: preview.duration,
+                        year: preview.year, genre: preview.genre, starred: preview.starred,
+                        created: preview.created, userRating: preview.userRating,
+                        song: songs, replayGain: nil, musicBrainzId: nil,
+                        recordLabels: nil
+                    )
+                }
+                album = preview
+            }
+        }
+        isLoading = album == nil
         error = nil
         defer { isLoading = false }
         do {

--- a/Vibrdrome/Features/Library/AlbumsView.swift
+++ b/Vibrdrome/Features/Library/AlbumsView.swift
@@ -8,6 +8,7 @@ struct AlbumsView: View {
     var genre: String?
     var fromYear: Int?
     var toYear: Int?
+    var label: String?
 
     @Environment(AppState.self) private var appState
     @Environment(\.modelContext) private var modelContext
@@ -62,17 +63,18 @@ struct AlbumsView: View {
     }
 
     private var cacheKey: String {
-        "\(listType.rawValue)_\(genre ?? "")_\(fromYear ?? 0)_\(toYear ?? 0)"
+        "\(listType.rawValue)_\(genre ?? "")_\(fromYear ?? 0)_\(toYear ?? 0)_\(label ?? "")"
     }
 
-    init(listType: AlbumListType, title: String = "Albums", genre: String? = nil, fromYear: Int? = nil, toYear: Int? = nil) {
+    init(listType: AlbumListType, title: String = "Albums", genre: String? = nil, fromYear: Int? = nil, toYear: Int? = nil, label: String? = nil) {
         self.listType = listType
         self.title = title
         self.genre = genre
         self.fromYear = fromYear
         self.toYear = toYear
+        self.label = label
 
-        let key = "\(listType.rawValue)_\(genre ?? "")_\(fromYear ?? 0)_\(toYear ?? 0)"
+        let key = "\(listType.rawValue)_\(genre ?? "")_\(fromYear ?? 0)_\(toYear ?? 0)_\(label ?? "")"
         if let snapshot = AppState.shared.albumsViewSnapshots[key] {
             _albums = State(initialValue: snapshot.albums)
             _hasMore = State(initialValue: snapshot.hasMore)
@@ -492,6 +494,26 @@ struct AlbumsView: View {
     }
 
     private func loadAlbums() async {
+        // Label-based loading: fetch from SwiftData cache (no API endpoint for labels)
+        if let label {
+            isLoading = true
+            defer { isLoading = false }
+            do {
+                var descriptor = FetchDescriptor<CachedAlbum>()
+                descriptor.sortBy = [SortDescriptor(\.name)]
+                let allAlbums = try modelContext.fetch(descriptor)
+                albums = allAlbums
+                    .filter { $0.label == label }
+                    .map { $0.toAlbum() }
+                hasMore = false
+                recomputeFilteredAlbums()
+                saveSnapshot()
+            } catch {
+                self.error = ErrorPresenter.userMessage(for: error)
+            }
+            return
+        }
+
         scrollLoadTask?.cancel()
         pendingPageTarget = 0
         let client = appState.subsonicClient

--- a/Vibrdrome/Features/Library/AlbumsView.swift
+++ b/Vibrdrome/Features/Library/AlbumsView.swift
@@ -1,5 +1,6 @@
 import SwiftData
 import SwiftUI
+import SwiftData
 import os.log
 
 struct AlbumsView: View {
@@ -10,7 +11,10 @@ struct AlbumsView: View {
     var toYear: Int?
 
     @Environment(AppState.self) private var appState
+    @Environment(\.modelContext) private var modelContext
     @State private var albums: [Album] = []
+    @State private var localFilteredAlbums: [Album]?
+    @State private var filterTask: Task<Void, Never>?
     @State private var isLoading = true
     @State private var error: String?
     @State private var hasMore = true
@@ -18,12 +22,16 @@ struct AlbumsView: View {
     @State private var activeListType: AlbumListType?
     @State private var clientSideSort: AlbumSortOption?
     @AppStorage("albumsViewStyle") private var showAsList = false
-    @AppStorage(UserDefaultsKeys.gridColumnsPerRow) private var gridColumns = 2
     @Environment(\.modelContext) private var modelContext
     @State private var showSaveCollection = false
     @State private var collectionName = ""
     @State private var availableGenres: [String] = []
     @State private var activeGenre: String?
+    @State private var cachedFilteredAlbums: [Album] = []
+    @State private var scrollLoadTask: Task<Void, Never>?
+    @State private var pendingPageTarget: Int = 0
+    @State private var visibleIndices: Set<Int> = []
+    @State private var restoredScrollIndex: Int?
     private let pageSize = 40
 
     enum AlbumSortOption: String, CaseIterable {
@@ -55,8 +63,30 @@ struct AlbumsView: View {
         activeGenre ?? genre
     }
 
-    private var filteredAlbums: [Album] {
-        var result = albums
+    private var cacheKey: String {
+        "\(listType.rawValue)_\(genre ?? "")_\(fromYear ?? 0)_\(toYear ?? 0)"
+    }
+
+    init(listType: AlbumListType, title: String = "Albums", genre: String? = nil, fromYear: Int? = nil, toYear: Int? = nil) {
+        self.listType = listType
+        self.title = title
+        self.genre = genre
+        self.fromYear = fromYear
+        self.toYear = toYear
+
+        let key = "\(listType.rawValue)_\(genre ?? "")_\(fromYear ?? 0)_\(toYear ?? 0)"
+        if let snapshot = AppState.shared.albumsViewSnapshots[key] {
+            _albums = State(initialValue: snapshot.albums)
+            _hasMore = State(initialValue: snapshot.hasMore)
+            _isLoading = State(initialValue: false)
+            _cachedFilteredAlbums = State(initialValue: snapshot.albums)
+            _restoredScrollIndex = State(initialValue: snapshot.scrollIndex)
+        }
+    }
+
+    private func computeFilteredAlbums() -> [Album] {
+        let source = localFilteredAlbums ?? albums
+        var result = source
         if !searchText.isEmpty {
             result = result.filter {
                 $0.name.localizedCaseInsensitiveContains(searchText) ||
@@ -111,6 +141,23 @@ struct AlbumsView: View {
             }
         }
         .toolbar {
+            #if os(macOS)
+            ToolbarItem(placement: .automatic) {
+                Button {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        if appState.activeSidePanel == .albumFilters {
+                            appState.activeSidePanel = nil
+                        } else {
+                            appState.activeSidePanel = .albumFilters
+                        }
+                    }
+                } label: {
+                    Image(systemName: appState.albumFilter.isActive ? "line.3.horizontal.decrease.circle.fill" : "line.3.horizontal.decrease.circle")
+                }
+                .accessibilityLabel("Album Filters")
+                .accessibilityIdentifier("albumFilterToggle")
+            }
+            #endif
             ToolbarItem(placement: .automatic) {
                 Button {
                     withAnimation(.easeInOut(duration: 0.2)) {
@@ -219,73 +266,105 @@ struct AlbumsView: View {
             }
             Button("Cancel", role: .cancel) { }
         }
+        .navigationDestination(for: AlbumNavItem.self) { item in
+            AlbumDetailView(albumId: item.id)
+        }
         .task {
-            await loadAlbums()
+            if albums.isEmpty {
+                await loadAlbums()
+            }
             if availableGenres.isEmpty {
                 availableGenres = (try? await appState.subsonicClient.getGenres()
                     .map(\.value).sorted()) ?? []
             }
+            #if os(macOS)
+            applyLocalFilters()
+            #endif
+            recomputeFilteredAlbums()
         }
+        .onChange(of: searchText) { recomputeFilteredAlbums() }
+        .onChange(of: clientSideSort) { recomputeFilteredAlbums() }
+        .onDisappear { saveSnapshot() }
         .refreshable {
             albums = []
             hasMore = true
             await loadAlbums()
         }
+        #if os(macOS)
+        .onChange(of: appState.albumFilter.isFavorited) { debouncedApplyLocalFilters() }
+        .onChange(of: appState.albumFilter.isRated) { debouncedApplyLocalFilters() }
+        .onChange(of: appState.albumFilter.isRecentlyPlayed) { debouncedApplyLocalFilters() }
+        .onChange(of: appState.albumFilter.selectedArtistIds) { debouncedApplyLocalFilters() }
+        .onChange(of: appState.albumFilter.selectedGenres) { debouncedApplyLocalFilters() }
+        .onChange(of: appState.albumFilter.selectedLabels) { debouncedApplyLocalFilters() }
+        .onChange(of: appState.albumFilter.year) { debouncedApplyLocalFilters() }
+        #endif
     }
 
     // MARK: - List view
 
     private var albumList: some View {
-        List {
-            ForEach(filteredAlbums) { album in
-                NavigationLink {
-                    AlbumDetailView(albumId: album.id)
-                } label: {
-                    AlbumCard(album: album)
+        ScrollViewReader { proxy in
+            List {
+                ForEach(0..<totalItemCount, id: \.self) { index in
+                    Group {
+                        if index < cachedFilteredAlbums.count {
+                            let album = cachedFilteredAlbums[index]
+                            NavigationLink(value: AlbumNavItem(id: album.id)) {
+                                AlbumCard(album: album)
+                            }
+                            .accessibilityIdentifier("albumRow_\(album.id)")
+                            .contextMenu { rowContextMenu(for: album) }
+                        } else {
+                            albumListPlaceholder
+                        }
+                    }
+                    .id(index)
+                    .onAppear {
+                        visibleIndices.insert(index)
+                        triggerLoadIfNeeded(at: index)
+                    }
+                    .onDisappear { visibleIndices.remove(index) }
                 }
-                .accessibilityIdentifier("albumRow_\(album.id)")
-                .contextMenu { rowContextMenu(for: album) }
-                .onAppear { paginateIfNeeded(album) }
             }
-
-            if isLoading && !albums.isEmpty {
-                HStack {
-                    Spacer()
-                    ProgressView()
-                    Spacer()
-                }
-            }
+            .listStyle(.plain)
+            .onAppear { restoreScroll(proxy: proxy) }
         }
-        .listStyle(.plain)
     }
 
     // MARK: - Grid view
 
-    private var gridItems: [GridItem] {
-        Array(repeating: GridItem(.flexible(), spacing: 16), count: max(2, min(10, gridColumns)))
-    }
-
     private var albumGrid: some View {
-        ScrollView {
-            LazyVGrid(columns: gridItems, spacing: 20) {
-                ForEach(filteredAlbums) { album in
-                    NavigationLink {
-                        AlbumDetailView(albumId: album.id)
-                    } label: {
-                        albumGridCard(album)
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVGrid(columns: [
+                    GridItem(.adaptive(minimum: 170, maximum: 220), spacing: 16)
+                ], spacing: 20) {
+                    ForEach(0..<totalItemCount, id: \.self) { index in
+                        Group {
+                            if index < cachedFilteredAlbums.count {
+                                let album = cachedFilteredAlbums[index]
+                                NavigationLink(value: AlbumNavItem(id: album.id)) {
+                                    albumGridCard(album)
+                                }
+                                .buttonStyle(.plain)
+                                .accessibilityIdentifier("albumCard_\(album.id)")
+                                .contextMenu { rowContextMenu(for: album) }
+                            } else {
+                                albumGridPlaceholder
+                            }
+                        }
+                        .id(index)
+                        .onAppear {
+                            visibleIndices.insert(index)
+                            triggerLoadIfNeeded(at: index)
+                        }
+                        .onDisappear { visibleIndices.remove(index) }
                     }
-                    .buttonStyle(.plain)
-                    .accessibilityIdentifier("albumCard_\(album.id)")
-                    .contextMenu { rowContextMenu(for: album) }
-                    .onAppear { paginateIfNeeded(album) }
                 }
+                .padding(16)
             }
-            .padding(16)
-
-            if isLoading && !albums.isEmpty {
-                ProgressView()
-                    .padding()
-            }
+            .onAppear { restoreScroll(proxy: proxy) }
         }
     }
 
@@ -356,13 +435,67 @@ struct AlbumsView: View {
         }
     }
 
-    private func paginateIfNeeded(_ album: Album) {
-        if album.id == albums.last?.id && hasMore {
-            Task { await loadMore() }
+    private var albumListPlaceholder: some View {
+        HStack(spacing: 12) {
+            RoundedRectangle(cornerRadius: 6)
+                .fill(.quaternary)
+                .frame(width: 56, height: 56)
+            VStack(alignment: .leading, spacing: 4) {
+                RoundedRectangle(cornerRadius: 3)
+                    .fill(.quaternary)
+                    .frame(width: 120, height: 14)
+                RoundedRectangle(cornerRadius: 3)
+                    .fill(.quaternary)
+                    .frame(width: 80, height: 12)
+            }
+            Spacer()
+        }
+    }
+
+    private var albumGridPlaceholder: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            RoundedRectangle(cornerRadius: 10)
+                .fill(.quaternary)
+                .aspectRatio(1, contentMode: .fit)
+            RoundedRectangle(cornerRadius: 3)
+                .fill(.quaternary)
+                .frame(height: 14)
+            RoundedRectangle(cornerRadius: 3)
+                .fill(.quaternary)
+                .frame(width: 80, height: 12)
+        }
+    }
+
+    private var totalItemCount: Int {
+        guard localFilteredAlbums == nil, searchText.isEmpty else { return cachedFilteredAlbums.count }
+        guard hasMore, let totalCount = appState.libraryCache.albums?.count else { return cachedFilteredAlbums.count }
+        return max(cachedFilteredAlbums.count, totalCount)
+    }
+
+    private func triggerLoadIfNeeded(at index: Int) {
+        guard localFilteredAlbums == nil, hasMore else { return }
+        if index >= cachedFilteredAlbums.count {
+            // Scrolled into placeholder territory — always update target, debounce the load
+            pendingPageTarget = max(pendingPageTarget, albums.count + (index - cachedFilteredAlbums.count) + pageSize)
+            scrollLoadTask?.cancel()
+            scrollLoadTask = Task {
+                try? await Task.sleep(for: .milliseconds(150))
+                guard !Task.isCancelled else { return }
+                await loadPages()
+            }
+        } else if !isLoading {
+            // Near end of loaded items — prefetch immediately
+            let prefetchThreshold = max(cachedFilteredAlbums.count - 30, 0)
+            if index >= prefetchThreshold {
+                pendingPageTarget = max(pendingPageTarget, albums.count + pageSize)
+                Task { await loadPages() }
+            }
         }
     }
 
     private func loadAlbums() async {
+        scrollLoadTask?.cancel()
+        pendingPageTarget = 0
         let client = appState.subsonicClient
         let sortType = effectiveListType
         let endpoint = SubsonicEndpoint.getAlbumList2(
@@ -382,6 +515,8 @@ struct AlbumsView: View {
                 fromYear: fromYear, toYear: toYear)
             albums = result
             hasMore = result.count >= pageSize
+            recomputeFilteredAlbums()
+            saveSnapshot()
         } catch {
             if albums.isEmpty {
                 self.error = ErrorPresenter.userMessage(for: error)
@@ -389,18 +524,145 @@ struct AlbumsView: View {
         }
     }
 
-    private func loadMore() async {
-        guard !isLoading else { return }
+    private func loadPages() async {
+        guard !isLoading, hasMore else { return }
         isLoading = true
-        defer { isLoading = false }
-        do {
-            let result = try await appState.subsonicClient.getAlbumList(
-                type: effectiveListType, size: pageSize, offset: albums.count, genre: effectiveGenre,
-                fromYear: fromYear, toYear: toYear)
-            albums.append(contentsOf: result)
-            hasMore = result.count >= pageSize
-        } catch {
-            hasMore = false
+        defer {
+            isLoading = false
+            // If target moved while loading, schedule another batch
+            if albums.count < pendingPageTarget, hasMore {
+                scrollLoadTask?.cancel()
+                scrollLoadTask = Task { await loadPages() }
+            }
+        }
+        while albums.count < pendingPageTarget, hasMore, !Task.isCancelled {
+            do {
+                let result = try await appState.subsonicClient.getAlbumList(
+                    type: effectiveListType, size: pageSize, offset: albums.count, genre: effectiveGenre,
+                    fromYear: fromYear, toYear: toYear)
+                albums.append(contentsOf: result)
+                hasMore = result.count >= pageSize
+            } catch {
+                hasMore = false
+                break
+            }
+        }
+        recomputeFilteredAlbums()
+        saveSnapshot()
+    }
+
+    private func recomputeFilteredAlbums() {
+        cachedFilteredAlbums = computeFilteredAlbums()
+    }
+
+    private func saveSnapshot() {
+        appState.albumsViewSnapshots[cacheKey] = AppState.AlbumsViewSnapshot(
+            albums: albums, hasMore: hasMore, scrollIndex: visibleIndices.min()
+        )
+    }
+
+    private func restoreScroll(proxy: ScrollViewProxy) {
+        if let target = restoredScrollIndex, target > 0, target < cachedFilteredAlbums.count {
+            proxy.scrollTo(target, anchor: .top)
+            restoredScrollIndex = nil
         }
     }
+
+    #if os(macOS)
+    private func debouncedApplyLocalFilters() {
+        filterTask?.cancel()
+        filterTask = Task {
+            try? await Task.sleep(for: .milliseconds(150))
+            guard !Task.isCancelled else { return }
+            applyLocalFilters()
+        }
+    }
+
+    private func applyLocalFilters() {
+        let filter = appState.albumFilter
+        guard filter.isActive else {
+            localFilteredAlbums = nil
+            recomputeFilteredAlbums()
+            return
+        }
+
+        do {
+            let recentlyPlayedAlbumIds = recentlyPlayedIds(for: filter)
+            let selectedArtistNames = selectedArtistNames(for: filter)
+            let allAlbums: [Album]
+            if let cachedAlbums = appState.libraryCache.albums {
+                allAlbums = cachedAlbums
+            } else {
+                var descriptor = FetchDescriptor<CachedAlbum>()
+                descriptor.sortBy = [SortDescriptor(\.name)]
+                allAlbums = try modelContext.fetch(descriptor).map { $0.toAlbum() }
+            }
+
+            localFilteredAlbums = allAlbums.filter {
+                albumMatchesFilter(
+                    $0,
+                    filter: filter,
+                    recentIds: recentlyPlayedAlbumIds,
+                    selectedArtistNames: selectedArtistNames
+                )
+            }
+            recomputeFilteredAlbums()
+        } catch {
+            Logger(subsystem: "com.vibrdrome.app", category: "Albums")
+                .error("Failed to apply local filters: \(error)")
+            localFilteredAlbums = nil
+        }
+    }
+
+    private func selectedArtistNames(for filter: LibraryFilter) -> Set<String> {
+        guard !filter.selectedArtistIds.isEmpty else { return [] }
+        let descriptor = FetchDescriptor<CachedArtist>()
+        let cachedArtists = (try? modelContext.fetch(descriptor)) ?? []
+        return Set(cachedArtists.compactMap { artist in
+            filter.selectedArtistIds.contains(artist.id) ? artist.name : nil
+        })
+    }
+
+    private func recentlyPlayedIds(for filter: LibraryFilter) -> Set<String>? {
+        guard filter.isRecentlyPlayed else { return nil }
+        let cutoff = Calendar.current.date(byAdding: .day, value: -30, to: Date()) ?? Date()
+        let songDescriptor = FetchDescriptor<CachedSong>(
+            predicate: #Predicate { $0.lastPlayed != nil && $0.lastPlayed! > cutoff }
+        )
+        let recentSongs = (try? modelContext.fetch(songDescriptor)) ?? []
+        return Set(recentSongs.compactMap(\.albumId))
+    }
+
+    private func albumMatchesFilter(
+        _ album: Album,
+        filter: LibraryFilter,
+        recentIds: Set<String>?,
+        selectedArtistNames: Set<String>
+    ) -> Bool {
+        guard filter.isFavorited.matches(album.starred != nil) else { return false }
+        guard filter.isRated.matches((album.userRating ?? 0) != 0) else { return false }
+        if let recentIds, !recentIds.contains(album.id) { return false }
+        if !filter.selectedArtistIds.isEmpty {
+            let matchesById = album.artistId.map { filter.selectedArtistIds.contains($0) } ?? false
+            let matchesByName = album.artist.map { selectedArtistNames.contains($0) } ?? false
+            guard matchesById || matchesByName else {
+                return false
+            }
+        }
+        if !filter.selectedGenres.isEmpty {
+            guard let genre = album.genre, filter.selectedGenres.contains(genre) else {
+                return false
+            }
+        }
+        if !filter.selectedLabels.isEmpty {
+            guard let albumLabel = album.label, filter.selectedLabels.contains(albumLabel) else {
+                return false
+            }
+        }
+        if let yearFilter = filter.year {
+            guard album.year == yearFilter else { return false }
+        }
+        return true
+    }
+    #endif
 }

--- a/Vibrdrome/Features/Library/AlbumsView.swift
+++ b/Vibrdrome/Features/Library/AlbumsView.swift
@@ -1,6 +1,5 @@
 import SwiftData
 import SwiftUI
-import SwiftData
 import os.log
 
 struct AlbumsView: View {
@@ -22,7 +21,6 @@ struct AlbumsView: View {
     @State private var activeListType: AlbumListType?
     @State private var clientSideSort: AlbumSortOption?
     @AppStorage("albumsViewStyle") private var showAsList = false
-    @Environment(\.modelContext) private var modelContext
     @State private var showSaveCollection = false
     @State private var collectionName = ""
     @State private var availableGenres: [String] = []

--- a/Vibrdrome/Features/Library/ArtistDetailView.swift
+++ b/Vibrdrome/Features/Library/ArtistDetailView.swift
@@ -1,9 +1,11 @@
 import SwiftUI
+import SwiftData
 
 struct ArtistDetailView: View {
     let artistId: String
 
     @Environment(AppState.self) private var appState
+    @Environment(\.modelContext) private var modelContext
     @State private var artist: Artist?
     @State private var topSongs: [Song] = []
     @State private var similarArtists: [Artist] = []
@@ -151,7 +153,30 @@ struct ArtistDetailView: View {
     }
 
     private func loadArtist() async {
-        isLoading = true
+        // Show cached artist with album list instantly
+        if artist == nil {
+            let aid = artistId
+            let artistDesc = FetchDescriptor<CachedArtist>(
+                predicate: #Predicate { $0.id == aid }
+            )
+            if let cached = try? modelContext.fetch(artistDesc).first {
+                // Find this artist's albums in the cache
+                let albumDesc = FetchDescriptor<CachedAlbum>(
+                    predicate: #Predicate<CachedAlbum> { $0.artistId == aid },
+                    sortBy: [SortDescriptor(\CachedAlbum.year, order: .reverse)]
+                )
+                let cachedAlbums = (try? modelContext.fetch(albumDesc)) ?? []
+                let albums = cachedAlbums.map { $0.toAlbum() }
+                artist = Artist(
+                    id: cached.id, name: cached.name,
+                    coverArt: cached.coverArtId,
+                    albumCount: cached.albumCount,
+                    starred: cached.isStarred ? "true" : nil,
+                    album: albums.isEmpty ? nil : albums
+                )
+            }
+        }
+        isLoading = artist == nil
         error = nil
         defer { isLoading = false }
         do {

--- a/Vibrdrome/Features/Library/ArtistsView.swift
+++ b/Vibrdrome/Features/Library/ArtistsView.swift
@@ -1,14 +1,19 @@
 import SwiftUI
+import SwiftData
+import os.log
 
 struct ArtistsView: View {
     @Environment(AppState.self) private var appState
+    @Environment(\.modelContext) private var modelContext
     @State private var indexes: [ArtistIndex] = []
+    @State private var localFilteredArtists: [Artist]?
+    @State private var filterTask: Task<Void, Never>?
     @State private var isLoading = true
     @State private var error: String?
     @State private var searchText = ""
     @State private var sortReversed = false
     @AppStorage("artistsViewStyle") private var showAsList = true
-    @AppStorage(UserDefaultsKeys.gridColumnsPerRow) private var gridColumns = 2
+    @State private var cachedFilteredIndexes: [(id: String, name: String, artists: [Artist])] = []
 
     enum ArtistSortOption: String, CaseIterable {
         case nameAZ, nameZA
@@ -20,7 +25,20 @@ struct ArtistsView: View {
         }
     }
 
-    private var filteredIndexes: [(id: String, name: String, artists: [Artist])] {
+    private func computeFilteredIndexes() -> [(id: String, name: String, artists: [Artist])] {
+        // When local filters are active, use flat filtered list (no index grouping)
+        if let filtered = localFilteredArtists {
+            let source: [Artist]
+            if searchText.isEmpty {
+                source = filtered
+            } else {
+                source = filtered.filter { $0.name.localizedCaseInsensitiveContains(searchText) }
+            }
+            let sorted = sortReversed ? source.reversed() : Array(source)
+            guard !sorted.isEmpty else { return [] }
+            return [("filtered", "Results", sorted)]
+        }
+
         var raw: [(id: String, name: String, artists: [Artist])]
         if searchText.isEmpty {
             raw = indexes.map { (id: $0.id, name: $0.name, artists: $0.artist ?? []) }
@@ -94,6 +112,23 @@ struct ArtistsView: View {
             }
         }
         .toolbar {
+            #if os(macOS)
+            ToolbarItem(placement: .automatic) {
+                Button {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        if appState.activeSidePanel == .artistFilters {
+                            appState.activeSidePanel = nil
+                        } else {
+                            appState.activeSidePanel = .artistFilters
+                        }
+                    }
+                } label: {
+                    Image(systemName: appState.artistFilter.isActive ? "line.3.horizontal.decrease.circle.fill" : "line.3.horizontal.decrease.circle")
+                }
+                .accessibilityLabel("Artist Filters")
+                .accessibilityIdentifier("artistFilterToggle")
+            }
+            #endif
             ToolbarItem(placement: .automatic) {
                 Button {
                     withAnimation(.easeInOut(duration: 0.2)) {
@@ -138,8 +173,20 @@ struct ArtistsView: View {
                 }
             }
         }
-        .task { await loadArtists() }
+        .task {
+            await loadArtists()
+            #if os(macOS)
+            applyLocalFilters()
+            #endif
+            recomputeFilteredIndexes()
+        }
+        .onChange(of: searchText) { recomputeFilteredIndexes() }
+        .onChange(of: sortReversed) { recomputeFilteredIndexes() }
         .refreshable { await loadArtists() }
+        #if os(macOS)
+        .onChange(of: appState.artistFilter.isFavorited) { debouncedApplyLocalFilters() }
+        .onChange(of: appState.artistFilter.selectedGenres) { debouncedApplyLocalFilters() }
+        #endif
     }
 
     // MARK: - List view
@@ -147,7 +194,7 @@ struct ArtistsView: View {
     private var artistList: some View {
         ScrollViewReader { proxy in
             List {
-                ForEach(filteredIndexes, id: \.id) { index in
+                ForEach(cachedFilteredIndexes, id: \.id) { index in
                     Section(header: Text(index.name).id(index.name)) {
                         ForEach(index.artists) { artist in
                             NavigationLink {
@@ -170,7 +217,7 @@ struct ArtistsView: View {
 
     private func sectionIndex(proxy: ScrollViewProxy) -> some View {
         VStack(spacing: 1) {
-            ForEach(filteredIndexes, id: \.id) { index in
+            ForEach(cachedFilteredIndexes, id: \.id) { index in
                 let label = sectionIndexLabel(index.name)
                 Text(label)
                     .font(.system(size: 11, weight: .bold, design: .rounded))
@@ -196,10 +243,11 @@ struct ArtistsView: View {
     private var artistGrid: some View {
         ScrollView {
             LazyVStack(alignment: .leading, spacing: 24, pinnedViews: [.sectionHeaders]) {
-                ForEach(filteredIndexes, id: \.id) { index in
+                ForEach(cachedFilteredIndexes, id: \.id) { index in
                     Section {
-                        LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 16),
-                                                 count: max(2, min(10, gridColumns))), spacing: 20) {
+                        LazyVGrid(columns: [
+                            GridItem(.adaptive(minimum: 130, maximum: 170), spacing: 16)
+                        ], spacing: 20) {
                             ForEach(index.artists) { artist in
                                 NavigationLink {
                                     ArtistDetailView(artistId: artist.id)
@@ -267,10 +315,89 @@ struct ArtistsView: View {
         defer { isLoading = false }
         do {
             indexes = try await client.getArtists()
+            recomputeFilteredIndexes()
         } catch {
             if indexes.isEmpty {
                 self.error = ErrorPresenter.userMessage(for: error)
             }
         }
     }
+
+    private func recomputeFilteredIndexes() {
+        cachedFilteredIndexes = computeFilteredIndexes()
+    }
+
+    #if os(macOS)
+    private func debouncedApplyLocalFilters() {
+        filterTask?.cancel()
+        filterTask = Task {
+            try? await Task.sleep(for: .milliseconds(150))
+            guard !Task.isCancelled else { return }
+            applyLocalFilters()
+        }
+    }
+
+    private func applyLocalFilters() {
+        let filter = appState.artistFilter
+        guard filter.isActive else {
+            localFilteredArtists = nil
+            recomputeFilteredIndexes()
+            return
+        }
+
+        do {
+            let allArtists: [Artist]
+            if let cachedArtists = appState.libraryCache.artists {
+                allArtists = cachedArtists
+            } else {
+                var descriptor = FetchDescriptor<CachedArtist>()
+                descriptor.sortBy = [SortDescriptor(\.name)]
+                allArtists = try modelContext.fetch(descriptor).map { $0.toArtist() }
+            }
+
+            // Pre-compute artist IDs that have albums matching selected genres
+            var artistIdsWithMatchingGenres: Set<String>?
+            if !filter.selectedGenres.isEmpty {
+                let allAlbums: [Album]
+                if let cachedAlbums = appState.libraryCache.albums {
+                    allAlbums = cachedAlbums
+                } else {
+                    let albumDescriptor = FetchDescriptor<CachedAlbum>()
+                    allAlbums = try modelContext.fetch(albumDescriptor).map { $0.toAlbum() }
+                }
+                var ids = Set<String>()
+                for album in allAlbums {
+                    if let genre = album.genre, filter.selectedGenres.contains(genre),
+                       let artistId = album.artistId {
+                        ids.insert(artistId)
+                    }
+                }
+                artistIdsWithMatchingGenres = ids
+            }
+
+            let filtered = allArtists.filter { artist in
+                // Favorited filter
+                switch filter.isFavorited {
+                case .yes: if artist.starred == nil { return false }
+                case .no: if artist.starred != nil { return false }
+                case .none: break
+                }
+
+                // Genre filter (via album lookup)
+                if let matchIds = artistIdsWithMatchingGenres {
+                    if !matchIds.contains(artist.id) { return false }
+                }
+
+                return true
+            }
+
+            localFilteredArtists = filtered
+            recomputeFilteredIndexes()
+        } catch {
+            Logger(subsystem: "com.vibrdrome.app", category: "Artists")
+                .error("Failed to apply local filters: \(error)")
+            localFilteredArtists = nil
+        }
+    }
+    #endif
 }

--- a/Vibrdrome/Features/Library/FavoritesView.swift
+++ b/Vibrdrome/Features/Library/FavoritesView.swift
@@ -1,29 +1,36 @@
 import SwiftUI
+import SwiftData
 
 struct FavoritesView: View {
     @Environment(AppState.self) private var appState
-    @State private var starred: Starred2?
-    @State private var isLoading = true
-    @State private var error: String?
+    @Query(filter: #Predicate<CachedArtist> { $0.isStarred }, sort: \CachedArtist.name)
+    private var starredArtists: [CachedArtist]
+    @Query(filter: #Predicate<CachedAlbum> { $0.isStarred }, sort: \CachedAlbum.name)
+    private var starredAlbums: [CachedAlbum]
+    @Query(filter: #Predicate<CachedSong> { $0.isStarred }, sort: \CachedSong.title)
+    private var starredSongs: [CachedSong]
     @State private var searchText = ""
     @State private var selectedSongs = Set<String>()
     @State private var isSelecting = false
     @State private var showBatchAddToPlaylist = false
+    @State private var cachedFilteredArtists: [Artist] = []
+    @State private var cachedFilteredAlbums: [Album] = []
+    @State private var cachedFilteredSongs: [Song] = []
 
-    private var filteredArtists: [Artist] {
-        guard let artists = starred?.artist else { return [] }
+    private func computeFilteredArtists() -> [Artist] {
+        let artists = starredArtists.map { $0.toArtist() }
         if searchText.isEmpty { return artists }
         return artists.filter { $0.name.localizedCaseInsensitiveContains(searchText) }
     }
 
-    private var filteredAlbums: [Album] {
-        guard let albums = starred?.album else { return [] }
+    private func computeFilteredAlbums() -> [Album] {
+        let albums = starredAlbums.map { $0.toAlbum() }
         if searchText.isEmpty { return albums }
         return albums.filter { $0.name.localizedCaseInsensitiveContains(searchText) }
     }
 
-    private var filteredSongs: [Song] {
-        guard let songs = starred?.song else { return [] }
+    private func computeFilteredSongs() -> [Song] {
+        let songs = starredSongs.map { $0.toSong() }
         if searchText.isEmpty { return songs }
         return songs.filter {
             $0.title.localizedCaseInsensitiveContains(searchText) ||
@@ -33,11 +40,11 @@ struct FavoritesView: View {
 
     var body: some View {
         List {
-            if starred != nil {
+            if !isEmpty {
                 // Starred Artists
-                if !filteredArtists.isEmpty {
+                if !cachedFilteredArtists.isEmpty {
                     Section("Artists") {
-                        ForEach(filteredArtists) { artist in
+                        ForEach(cachedFilteredArtists) { artist in
                             NavigationLink {
                                 ArtistDetailView(artistId: artist.id)
                             } label: {
@@ -49,9 +56,9 @@ struct FavoritesView: View {
                 }
 
                 // Starred Albums
-                if !filteredAlbums.isEmpty {
+                if !cachedFilteredAlbums.isEmpty {
                     Section("Albums") {
-                        ForEach(filteredAlbums) { album in
+                        ForEach(cachedFilteredAlbums) { album in
                             NavigationLink {
                                 AlbumDetailView(albumId: album.id)
                             } label: {
@@ -63,11 +70,11 @@ struct FavoritesView: View {
                 }
 
                 // Starred Songs
-                if !filteredSongs.isEmpty {
+                if !cachedFilteredSongs.isEmpty {
                     Section("Songs") {
                         HStack(spacing: 12) {
                             Button {
-                                AudioEngine.shared.play(song: filteredSongs[0], from: filteredSongs, at: 0)
+                                AudioEngine.shared.play(song: cachedFilteredSongs[0], from: cachedFilteredSongs, at: 0)
                             } label: {
                                 Label("Play All", systemImage: "play.fill")
                                     .font(.subheadline)
@@ -79,7 +86,7 @@ struct FavoritesView: View {
                             .accessibilityIdentifier("favPlayAllButton")
 
                             Button {
-                                let shuffled = filteredSongs.shuffled()
+                                let shuffled = cachedFilteredSongs.shuffled()
                                 AudioEngine.shared.play(song: shuffled[0], from: shuffled, at: 0)
                             } label: {
                                 Label("Shuffle", systemImage: "shuffle")
@@ -93,7 +100,7 @@ struct FavoritesView: View {
                         }
                         .listRowSeparator(.hidden)
 
-                        ForEach(Array(filteredSongs.enumerated()), id: \.element.id) { index, song in
+                        ForEach(Array(cachedFilteredSongs.enumerated()), id: \.element.id) { index, song in
                             HStack(spacing: 0) {
                                 if isSelecting {
                                     Button {
@@ -110,13 +117,13 @@ struct FavoritesView: View {
                                 }
 
                                 TrackRow(song: song, showTrackNumber: false)
-                                    .trackContextMenu(song: song, queue: filteredSongs, index: index)
+                                    .trackContextMenu(song: song, queue: cachedFilteredSongs, index: index)
                                     .accessibilityIdentifier("favSongRow_\(song.id)")
                                     .onTapGesture {
                                         if isSelecting {
                                             toggleSelection(song.id)
                                         } else {
-                                            AudioEngine.shared.play(song: song, from: filteredSongs, at: index)
+                                            AudioEngine.shared.play(song: song, from: cachedFilteredSongs, at: index)
                                         }
                                     }
                             }
@@ -124,7 +131,7 @@ struct FavoritesView: View {
 
                         // Batch action bar
                         if isSelecting && !selectedSongs.isEmpty {
-                            favoritesBatchActionBar(songs: filteredSongs)
+                            favoritesBatchActionBar(songs: cachedFilteredSongs)
                                 .listRowSeparator(.hidden)
                         }
                     }
@@ -145,18 +152,13 @@ struct FavoritesView: View {
         .navigationBarTitleDisplayMode(.inline)
         #endif
         .overlay {
-            if isLoading && starred == nil {
-                ProgressView("Loading favorites...")
-            } else if let error, starred == nil {
+            if appState.librarySyncManager.lastSyncDate == nil && isEmpty {
                 ContentUnavailableView {
-                    Label("Error", systemImage: "exclamationmark.triangle")
+                    Label("Loading Favorites", systemImage: "heart")
                 } description: {
-                    Text(error)
-                } actions: {
-                    Button("Retry") { Task { await loadStarred() } }
-                        .buttonStyle(.bordered)
+                    Text("Syncing your library...")
                 }
-            } else if !isLoading && isEmpty {
+            } else if isEmpty {
                 ContentUnavailableView {
                     Label("No Favorites", systemImage: "heart")
                 } description: {
@@ -179,7 +181,7 @@ struct FavoritesView: View {
             }
             #if os(macOS)
             ToolbarItem {
-                Button { Task { await loadStarred() } } label: {
+                Button { Task { await LibrarySyncManager.shared.syncIfStale() } } label: {
                     Label("Refresh", systemImage: "arrow.clockwise")
                 }
             }
@@ -189,8 +191,18 @@ struct FavoritesView: View {
             AddToPlaylistView(songIds: Array(selectedSongs))
                 .environment(appState)
         }
-        .task { await loadStarred() }
-        .refreshable { await loadStarred() }
+        .refreshable { await LibrarySyncManager.shared.syncIfStale() }
+        .onChange(of: searchText) { recomputeFilteredLists() }
+        .onChange(of: starredArtists) { recomputeFilteredLists() }
+        .onChange(of: starredAlbums) { recomputeFilteredLists() }
+        .onChange(of: starredSongs) { recomputeFilteredLists() }
+        .onAppear { recomputeFilteredLists() }
+    }
+
+    private func recomputeFilteredLists() {
+        cachedFilteredArtists = computeFilteredArtists()
+        cachedFilteredAlbums = computeFilteredAlbums()
+        cachedFilteredSongs = computeFilteredSongs()
     }
 
     private func toggleSelection(_ songId: String) {
@@ -211,20 +223,6 @@ struct FavoritesView: View {
     }
 
     private var isEmpty: Bool {
-        guard let starred else { return true }
-        return (starred.artist?.isEmpty ?? true) &&
-               (starred.album?.isEmpty ?? true) &&
-               (starred.song?.isEmpty ?? true)
-    }
-
-    private func loadStarred() async {
-        isLoading = true
-        error = nil
-        defer { isLoading = false }
-        do {
-            starred = try await appState.subsonicClient.getStarred()
-        } catch {
-            self.error = ErrorPresenter.userMessage(for: error)
-        }
+        starredArtists.isEmpty && starredAlbums.isEmpty && starredSongs.isEmpty
     }
 }

--- a/Vibrdrome/Features/Library/GenresView.swift
+++ b/Vibrdrome/Features/Library/GenresView.swift
@@ -1,7 +1,9 @@
+import SwiftData
 import SwiftUI
 
 struct GenresView: View {
     @Environment(AppState.self) private var appState
+    @Environment(\.modelContext) private var modelContext
     @State private var genres: [Genre] = []
     @State private var isLoading = true
     @State private var error: String?
@@ -9,7 +11,7 @@ struct GenresView: View {
     @State private var searchText = ""
     @State private var sortBy: GenreSortOption = .name
     @AppStorage("genresViewStyle") private var showAsList = true
-    @AppStorage(UserDefaultsKeys.gridColumnsPerRow) private var gridColumns = 2
+    @State private var cachedFilteredGenres: [Genre] = []
 
     enum GenreSortOption: String, CaseIterable {
         case name, songCount
@@ -21,7 +23,7 @@ struct GenresView: View {
         }
     }
 
-    private var filteredGenres: [Genre] {
+    private func computeFilteredGenres() -> [Genre] {
         let base: [Genre]
         if searchText.isEmpty {
             base = genres
@@ -116,13 +118,15 @@ struct GenresView: View {
             }
         }
         .task { await loadGenres() }
+        .onChange(of: searchText) { recomputeFilteredGenres() }
+        .onChange(of: sortBy) { recomputeFilteredGenres() }
         .refreshable { await loadGenres() }
     }
 
     // MARK: - List view
 
     private var genreList: some View {
-        List(filteredGenres) { genre in
+        List(cachedFilteredGenres) { genre in
             NavigationLink {
                 AlbumsView(listType: .byGenre, title: genre.value, genre: genre.value)
             } label: {
@@ -150,9 +154,10 @@ struct GenresView: View {
 
     private var genreGrid: some View {
         ScrollView {
-            LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 16),
-                                     count: max(2, min(10, gridColumns))), spacing: 20) {
-                ForEach(filteredGenres) { genre in
+            LazyVGrid(columns: [
+                GridItem(.adaptive(minimum: 160, maximum: 220), spacing: 16)
+            ], spacing: 20) {
+                ForEach(cachedFilteredGenres) { genre in
                     NavigationLink {
                         AlbumsView(listType: .byGenre, title: genre.value, genre: genre.value)
                     } label: {
@@ -186,13 +191,28 @@ struct GenresView: View {
         }
     }
 
+    private func recomputeFilteredGenres() {
+        cachedFilteredGenres = computeFilteredGenres()
+    }
+
     private func loadGenres() async {
         let client = appState.subsonicClient
-        // Show cached data instantly
+
+        // Try local SwiftData first — derive genres from cached songs
+        if genres.isEmpty {
+            let localGenres = deriveGenresFromCache()
+            if !localGenres.isEmpty {
+                genres = localGenres
+                recomputeFilteredGenres()
+            }
+        }
+
+        // Show cached API response if no local data
         if genres.isEmpty,
            let cached = await client.cachedResponse(for: .getGenres, ttl: 3600) {
             genres = (cached.genres?.genre ?? [])
                 .sorted { $0.value.localizedCaseInsensitiveCompare($1.value) == .orderedAscending }
+            recomputeFilteredGenres()
         }
         isLoading = genres.isEmpty
         error = nil
@@ -200,12 +220,33 @@ struct GenresView: View {
         do {
             genres = try await client.getGenres()
                 .sorted { $0.value.localizedCaseInsensitiveCompare($1.value) == .orderedAscending }
+            recomputeFilteredGenres()
             await loadGenreArt(client: client)
         } catch {
-            if genres.isEmpty {
+            // If network fails but we have local data, load art from cache
+            if !genres.isEmpty {
+                await loadGenreArt(client: client)
+            } else {
                 self.error = ErrorPresenter.userMessage(for: error)
             }
         }
+    }
+
+    private func deriveGenresFromCache() -> [Genre] {
+        // Use albums (much fewer records) to derive genre counts
+        let allAlbums = (try? modelContext.fetch(FetchDescriptor<CachedAlbum>())) ?? []
+        var genreAlbumCount: [String: Int] = [:]
+        var genreSongCount: [String: Int] = [:]
+
+        for album in allAlbums {
+            guard let genre = album.genre, !genre.isEmpty else { continue }
+            genreAlbumCount[genre, default: 0] += 1
+            genreSongCount[genre, default: 0] += album.songCount ?? 0
+        }
+
+        return genreAlbumCount.map { key, albumCount in
+            Genre(songCount: genreSongCount[key] ?? 0, albumCount: albumCount, value: key)
+        }.sorted { $0.value.localizedCaseInsensitiveCompare($1.value) == .orderedAscending }
     }
 
     private func loadGenreArt(client: SubsonicClient) async {

--- a/Vibrdrome/Features/Library/LabelsView.swift
+++ b/Vibrdrome/Features/Library/LabelsView.swift
@@ -1,0 +1,245 @@
+import SwiftData
+import SwiftUI
+
+struct LabelsView: View {
+    @Environment(AppState.self) private var appState
+    @Environment(\.modelContext) private var modelContext
+    @State private var labels: [LabelInfo] = []
+    @State private var isLoading = true
+    @State private var searchText = ""
+    @State private var sortBy: LabelSortOption = .name
+    @State private var labelArt: [String: String] = [:] // label → coverArtId
+    @AppStorage("labelsViewStyle") private var showAsList = true
+    @State private var cachedFilteredLabels: [LabelInfo] = []
+
+    struct LabelInfo: Identifiable, Hashable {
+        var id: String { name }
+        let name: String
+        let albumCount: Int
+    }
+
+    enum LabelSortOption: String, CaseIterable {
+        case name, albumCount
+        var label: String {
+            switch self {
+            case .name: "Name (A-Z)"
+            case .albumCount: "Album Count"
+            }
+        }
+    }
+
+    private func computeFilteredLabels() -> [LabelInfo] {
+        let base: [LabelInfo]
+        if searchText.isEmpty {
+            base = labels
+        } else {
+            base = labels.filter {
+                $0.name.localizedCaseInsensitiveContains(searchText)
+            }
+        }
+        switch sortBy {
+        case .name:
+            return base.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+        case .albumCount:
+            return base.sorted { $0.albumCount > $1.albumCount }
+        }
+    }
+
+    var body: some View {
+        Group {
+            if showAsList {
+                labelList
+            } else {
+                labelGrid
+            }
+        }
+        #if os(iOS)
+        .contentMargins(.bottom, 80)
+        #endif
+        .navigationTitle("Labels")
+        #if os(iOS)
+        .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .automatic), prompt: "Search Labels")
+        #else
+        .searchable(text: $searchText, prompt: "Search Labels")
+        #endif
+        #if os(iOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+        .overlay {
+            if isLoading && labels.isEmpty {
+                ProgressView("Loading labels...")
+            } else if !isLoading && labels.isEmpty {
+                ContentUnavailableView {
+                    Label("No Labels", systemImage: "tag")
+                } description: {
+                    Text("No record labels found. Sync your library to populate labels.")
+                }
+            }
+        }
+        .toolbar {
+            ToolbarItem(placement: .automatic) {
+                Button {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        showAsList.toggle()
+                    }
+                } label: {
+                    Image(systemName: showAsList ? "square.grid.2x2" : "list.bullet")
+                }
+                .accessibilityLabel(showAsList ? "Grid View" : "List View")
+                .accessibilityIdentifier("labelsViewToggle")
+            }
+            ToolbarItem(placement: .primaryAction) {
+                Menu {
+                    ForEach(LabelSortOption.allCases, id: \.self) { option in
+                        Button {
+                            sortBy = option
+                        } label: {
+                            HStack {
+                                Text(option.label)
+                                if sortBy == option {
+                                    Image(systemName: "checkmark")
+                                }
+                            }
+                        }
+                    }
+                    Divider()
+                    Button {
+                        loadLabels()
+                    } label: {
+                        Label("Refresh", systemImage: "arrow.clockwise")
+                    }
+                } label: {
+                    Image(systemName: "arrow.up.arrow.down")
+                }
+            }
+        }
+        .task { loadLabels() }
+        .onChange(of: searchText) { recomputeFilteredLabels() }
+        .onChange(of: sortBy) { recomputeFilteredLabels() }
+        .refreshable { loadLabels() }
+    }
+
+    // MARK: - List view
+
+    private var labelList: some View {
+        List(cachedFilteredLabels) { labelInfo in
+            NavigationLink {
+                AlbumsView(listType: .alphabeticalByName, title: labelInfo.name, label: labelInfo.name)
+            } label: {
+                HStack(spacing: 12) {
+                    LabelIconView(labelName: labelInfo.name, coverArtId: labelArt[labelInfo.name])
+                        .frame(width: 48, height: 48)
+                        .clipShape(RoundedRectangle(cornerRadius: 8))
+
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(labelInfo.name)
+                            .font(.body)
+                        Text(verbatim: "\(labelInfo.albumCount) albums")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                }
+            }
+            .accessibilityIdentifier("labelRow_\(labelInfo.name)")
+        }
+        .listStyle(.plain)
+    }
+
+    // MARK: - Grid view
+
+    private var labelGrid: some View {
+        ScrollView {
+            LazyVGrid(columns: [
+                GridItem(.adaptive(minimum: 160, maximum: 220), spacing: 16)
+            ], spacing: 20) {
+                ForEach(cachedFilteredLabels) { labelInfo in
+                    NavigationLink {
+                        AlbumsView(listType: .alphabeticalByName, title: labelInfo.name, label: labelInfo.name)
+                    } label: {
+                        labelCard(labelInfo)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityIdentifier("labelCard_\(labelInfo.name)")
+                }
+            }
+            .padding(16)
+        }
+    }
+
+    private func labelCard(_ labelInfo: LabelInfo) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            LabelIconView(labelName: labelInfo.name, coverArtId: labelArt[labelInfo.name])
+                .aspectRatio(1, contentMode: .fit)
+                .clipShape(RoundedRectangle(cornerRadius: 10))
+                .shadow(color: .black.opacity(0.15), radius: 6, y: 3)
+
+            Text(labelInfo.name)
+                .font(.subheadline)
+                .fontWeight(.medium)
+                .foregroundColor(.primary)
+                .lineLimit(1)
+
+            Text(verbatim: "\(labelInfo.albumCount) albums")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+        }
+    }
+
+    private func recomputeFilteredLabels() {
+        cachedFilteredLabels = computeFilteredLabels()
+    }
+
+    private func loadLabels() {
+        let allAlbums = (try? modelContext.fetch(FetchDescriptor<CachedAlbum>())) ?? []
+        var labelCounts: [String: Int] = [:]
+
+        for album in allAlbums {
+            guard let label = album.label, !label.isEmpty else { continue }
+            labelCounts[label, default: 0] += 1
+        }
+
+        labels = labelCounts.map { LabelInfo(name: $0.key, albumCount: $0.value) }
+            .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+        recomputeFilteredLabels()
+        isLoading = false
+
+        // Load cover art for top labels
+        Task {
+            await loadLabelArt(albums: allAlbums)
+        }
+    }
+
+    private func loadLabelArt(albums: [CachedAlbum]) async {
+        for labelInfo in labels.prefix(30) where labelArt[labelInfo.name] == nil {
+            if let album = albums.first(where: { $0.label == labelInfo.name && $0.coverArtId != nil }) {
+                labelArt[labelInfo.name] = album.coverArtId
+            }
+        }
+    }
+}
+
+// MARK: - Label Icon View
+
+struct LabelIconView: View {
+    let labelName: String
+    let coverArtId: String?
+
+    var body: some View {
+        if let coverArtId {
+            AlbumArtView(coverArtId: coverArtId, size: 48, cornerRadius: 8)
+        } else {
+            ZStack {
+                LinearGradient(
+                    colors: [.init(red: 0.4, green: 0.5, blue: 0.7), .init(red: 0.2, green: 0.3, blue: 0.5)],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+                Image(systemName: "tag.fill")
+                    .font(.title2)
+                    .foregroundColor(.white.opacity(0.9))
+            }
+        }
+    }
+}

--- a/Vibrdrome/Features/Library/LibraryFilterSidebarView.swift
+++ b/Vibrdrome/Features/Library/LibraryFilterSidebarView.swift
@@ -1,0 +1,393 @@
+#if os(macOS)
+import SwiftUI
+import SwiftData
+
+/// Which entity type the filter sidebar is controlling.
+enum FilterContext {
+    case album, artist, song
+}
+
+/// Feishin-style filter sidebar shown as a macOS side panel.
+/// Adapts its controls based on the entity type being filtered.
+struct LibraryFilterSidebarView: View {
+    let context: FilterContext
+
+    @Environment(AppState.self) private var appState
+    @Environment(\.modelContext) private var modelContext
+    @Query(sort: \CachedArtist.name) private var artists: [CachedArtist]
+    @State private var genres: [String] = []
+    @State private var labels: [String] = []
+
+    private var filter: LibraryFilter {
+        switch context {
+        case .album: appState.albumFilter
+        case .artist: appState.artistFilter
+        case .song: appState.songFilter
+        }
+    }
+
+    private var panelTitle: String {
+        switch context {
+        case .album: "Album Filters"
+        case .artist: "Artist Filters"
+        case .song: "Song Filters"
+        }
+    }
+
+    var body: some View {
+        SidePanelContainer(title: panelTitle, onClose: {
+            appState.activeSidePanel = nil
+        }) {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    headerButtons
+
+                    if appState.librarySyncManager.lastSyncDate == nil {
+                        syncRequiredView
+                    } else {
+                        filterControls
+                    }
+                }
+                .padding(14)
+            }
+        }
+        .task { loadCachedMetadata() }
+    }
+
+    // MARK: - Header
+
+    @ViewBuilder
+    private var headerButtons: some View {
+        HStack {
+            if filter.isActive {
+                Text("\(filter.activeFilterCount) active")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            Button("Reset") {
+                filter.reset()
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(Color.accentColor)
+            .font(.subheadline)
+            .disabled(!filter.isActive)
+        }
+    }
+
+    // MARK: - Sync Required
+
+    @ViewBuilder
+    private var syncRequiredView: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "arrow.triangle.2.circlepath")
+                .font(.largeTitle)
+                .foregroundStyle(.secondary)
+            Text("Library sync required")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            Text("Sync your library to enable filtering.")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+                .multilineTextAlignment(.center)
+            Button("Sync Now") {
+                Task {
+                    await appState.librarySyncManager.sync(
+                        client: appState.subsonicClient,
+                        container: PersistenceController.shared.container
+                    )
+                    loadCachedMetadata()
+                }
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.small)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 20)
+    }
+
+    // MARK: - Filter Controls
+
+    @ViewBuilder
+    private var filterControls: some View {
+        if let progress = appState.librarySyncManager.syncProgress {
+            HStack(spacing: 6) {
+                ProgressView()
+                    .controlSize(.small)
+                Text(progress)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+
+        @Bindable var state = appState
+
+        // Favorited — all contexts
+        favoritedControl
+
+        // Rated — album and song only
+        if context == .album || context == .song {
+            ratedControl
+        }
+
+        // Recently played — album and song only
+        if context == .album || context == .song {
+            recentlyPlayedControl
+        }
+
+        Divider()
+
+        // Artist multi-select — album and song only
+        if context == .album || context == .song {
+            artistMultiSelect
+            Divider()
+        }
+
+        // Genre multi-select — all contexts
+        genreMultiSelect
+
+        // Label multi-select — album only
+        if context == .album {
+            Divider()
+            labelMultiSelect
+        }
+
+        // Year filter — album and song only
+        if context == .album || context == .song {
+            Divider()
+            yearFilter
+        }
+    }
+
+    // MARK: - Boolean Filter Controls
+
+    @ViewBuilder
+    private var favoritedControl: some View {
+        @Bindable var state = appState
+        switch context {
+        case .album: TriStateFilterControl(label: "Is favorited", value: $state.albumFilter.isFavorited)
+        case .artist: TriStateFilterControl(label: "Is favorited", value: $state.artistFilter.isFavorited)
+        case .song: TriStateFilterControl(label: "Is favorited", value: $state.songFilter.isFavorited)
+        }
+    }
+
+    @ViewBuilder
+    private var ratedControl: some View {
+        @Bindable var state = appState
+        switch context {
+        case .album: TriStateFilterControl(label: "Is rated", value: $state.albumFilter.isRated)
+        case .song: TriStateFilterControl(label: "Is rated", value: $state.songFilter.isRated)
+        case .artist: EmptyView()
+        }
+    }
+
+    @ViewBuilder
+    private var recentlyPlayedControl: some View {
+        @Bindable var state = appState
+        HStack {
+            Text("Is recently played")
+                .font(.subheadline)
+                .fontWeight(.medium)
+            Spacer()
+            switch context {
+            case .album:
+                Toggle("", isOn: $state.albumFilter.isRecentlyPlayed)
+                    .labelsHidden().toggleStyle(.switch).controlSize(.small)
+            case .song:
+                Toggle("", isOn: $state.songFilter.isRecentlyPlayed)
+                    .labelsHidden().toggleStyle(.switch).controlSize(.small)
+            case .artist:
+                EmptyView()
+            }
+        }
+    }
+
+    // MARK: - Artist Multi-Select
+
+    @ViewBuilder
+    private var artistMultiSelect: some View {
+        @Bindable var state = appState
+        switch context {
+        case .album:
+            FilterMultiSelectList(
+                title: "Artists", items: artists,
+                selectedIds: $state.albumFilter.selectedArtistIds,
+                id: \.id, label: \.name,
+                subtitle: { a in a.albumCount.map { "\($0) album\($0 == 1 ? "" : "s")" } },
+                imageId: { $0.coverArtId }
+            )
+        case .song:
+            FilterMultiSelectList(
+                title: "Artists", items: artists,
+                selectedIds: $state.songFilter.selectedArtistIds,
+                id: \.id, label: \.name,
+                subtitle: { a in a.albumCount.map { "\($0) album\($0 == 1 ? "" : "s")" } },
+                imageId: { $0.coverArtId }
+            )
+        case .artist:
+            EmptyView()
+        }
+    }
+
+    // MARK: - Genre Multi-Select
+
+    @ViewBuilder
+    private var genreMultiSelect: some View {
+        @Bindable var state = appState
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text("Genres")
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                Spacer()
+                if !filter.selectedGenres.isEmpty {
+                    Text("\(filter.selectedGenres.count)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            switch context {
+            case .album:
+                StringFilterList(items: genres, selectedItems: $state.albumFilter.selectedGenres, placeholder: "Search genres…")
+            case .artist:
+                StringFilterList(items: genres, selectedItems: $state.artistFilter.selectedGenres, placeholder: "Search genres…")
+            case .song:
+                StringFilterList(items: genres, selectedItems: $state.songFilter.selectedGenres, placeholder: "Search genres…")
+            }
+        }
+    }
+
+    // MARK: - Label Multi-Select
+
+    @ViewBuilder
+    private var labelMultiSelect: some View {
+        @Bindable var state = appState
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text("Labels")
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                Spacer()
+                if !filter.selectedLabels.isEmpty {
+                    Text("\(filter.selectedLabels.count)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            StringFilterList(items: labels, selectedItems: $state.albumFilter.selectedLabels, placeholder: "Search labels…")
+        }
+    }
+
+    // MARK: - Year Filter
+
+    @ViewBuilder
+    private var yearFilter: some View {
+        @Bindable var state = appState
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Year")
+                .font(.subheadline)
+                .fontWeight(.medium)
+            HStack {
+                switch context {
+                case .album:
+                    TextField("e.g. 2024", value: $state.albumFilter.year, format: .number)
+                        .textFieldStyle(.roundedBorder).font(.caption)
+                case .song:
+                    TextField("e.g. 2024", value: $state.songFilter.year, format: .number)
+                        .textFieldStyle(.roundedBorder).font(.caption)
+                case .artist:
+                    EmptyView()
+                }
+                if filter.year != nil {
+                    Button {
+                        filter.year = nil
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func loadCachedMetadata() {
+        // Genres from albums (artists inherit album genres) or songs
+        let genreSet: Set<String>
+        if context == .song {
+            let songDescriptor = FetchDescriptor<CachedSong>()
+            let songs = (try? modelContext.fetch(songDescriptor)) ?? []
+            genreSet = Set(songs.compactMap(\.genre)).subtracting([""])
+        } else {
+            let descriptor = FetchDescriptor<CachedAlbum>()
+            let albums = (try? modelContext.fetch(descriptor)) ?? []
+            genreSet = Set(albums.compactMap(\.genre)).subtracting([""])
+
+            if context == .album {
+                let labelSet = Set(albums.compactMap(\.label)).subtracting([""])
+                labels = labelSet.sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
+            }
+        }
+        genres = genreSet.sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
+    }
+}
+
+// MARK: - Reusable String Filter List
+
+struct StringFilterList: View {
+    let items: [String]
+    @Binding var selectedItems: Set<String>
+    var placeholder: String = "Search…"
+    @State private var searchText = ""
+
+    private var filteredItems: [String] {
+        if searchText.isEmpty { return items }
+        return items.filter { $0.localizedCaseInsensitiveContains(searchText) }
+    }
+
+    var body: some View {
+        TextField(placeholder, text: $searchText)
+            .textFieldStyle(.roundedBorder)
+            .font(.caption)
+
+        ScrollView {
+            LazyVStack(spacing: 0) {
+                ForEach(filteredItems, id: \.self) { item in
+                    let isSelected = selectedItems.contains(item)
+                    Button {
+                        if isSelected {
+                            selectedItems.remove(item)
+                        } else {
+                            selectedItems.insert(item)
+                        }
+                    } label: {
+                        HStack {
+                            Text(item)
+                                .font(.caption)
+                                .lineLimit(1)
+                            Spacer()
+                            if isSelected {
+                                Image(systemName: "checkmark")
+                                    .font(.caption)
+                                    .foregroundStyle(Color.accentColor)
+                            }
+                        }
+                        .padding(.vertical, 4)
+                        .padding(.horizontal, 6)
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .background(isSelected ? Color.accentColor.opacity(0.1) : Color.clear)
+                }
+            }
+        }
+        .frame(height: 160)
+        .background(Color(nsColor: .controlBackgroundColor).opacity(0.5))
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+    }
+}
+#endif

--- a/Vibrdrome/Features/Library/LibraryFilterSidebarView.swift
+++ b/Vibrdrome/Features/Library/LibraryFilterSidebarView.swift
@@ -193,9 +193,11 @@ struct LibraryFilterSidebarView: View {
             case .album:
                 Toggle("", isOn: $state.albumFilter.isRecentlyPlayed)
                     .labelsHidden().toggleStyle(.switch).controlSize(.small)
+                    .accessibilityLabel("Is recently played")
             case .song:
                 Toggle("", isOn: $state.songFilter.isRecentlyPlayed)
                     .labelsHidden().toggleStyle(.switch).controlSize(.small)
+                    .accessibilityLabel("Is recently played")
             case .artist:
                 EmptyView()
             }
@@ -294,9 +296,11 @@ struct LibraryFilterSidebarView: View {
                 case .album:
                     TextField("e.g. 2024", value: $state.albumFilter.year, format: .number)
                         .textFieldStyle(.roundedBorder).font(.caption)
+                        .accessibilityLabel("Filter by year")
                 case .song:
                     TextField("e.g. 2024", value: $state.songFilter.year, format: .number)
                         .textFieldStyle(.roundedBorder).font(.caption)
+                        .accessibilityLabel("Filter by year")
                 case .artist:
                     EmptyView()
                 }
@@ -308,6 +312,7 @@ struct LibraryFilterSidebarView: View {
                             .foregroundStyle(.secondary)
                     }
                     .buttonStyle(.plain)
+                    .accessibilityLabel("Clear year filter")
                 }
             }
         }
@@ -382,6 +387,9 @@ struct StringFilterList: View {
                     }
                     .buttonStyle(.plain)
                     .background(isSelected ? Color.accentColor.opacity(0.1) : Color.clear)
+                    .accessibilityLabel(item)
+                    .accessibilityValue(isSelected ? "Selected" : "Not selected")
+                    .accessibilityAddTraits(isSelected ? .isSelected : [])
                 }
             }
         }

--- a/Vibrdrome/Features/Library/LibraryView.swift
+++ b/Vibrdrome/Features/Library/LibraryView.swift
@@ -4,6 +4,7 @@ import NukeUI
 
 struct LibraryView: View {
     @Environment(AppState.self) private var appState
+    @Environment(\.modelContext) private var modelContext
     @Binding var navPath: NavigationPath
     @State private var recentAlbums: [Album] = []
     @State private var frequentAlbums: [Album] = []
@@ -623,18 +624,22 @@ struct LibraryView: View {
     private func fetchSections(client: SubsonicClient, skipCache: Bool = false) async {
         let folder = folderId
 
-        // Show cached data instantly (only for unfiltered/default)
+        // Show local cache data instantly (Recently Added + Starred from SwiftData)
         if folder == nil, !skipCache {
-            if let cached = await client.cachedResponse(
-                for: .getAlbumList2(type: .newest, size: 10, offset: 0), ttl: 300) {
-                recentAlbums = cached.albumList2?.album ?? []
+            if recentAlbums.isEmpty {
+                var desc = FetchDescriptor<CachedAlbum>(sortBy: [SortDescriptor(\CachedAlbum.created, order: .reverse)])
+                desc.fetchLimit = 10
+                if let cached = try? modelContext.fetch(desc), !cached.isEmpty {
+                    recentAlbums = cached.map { $0.toAlbum() }
+                }
             }
-            if let cached = await client.cachedResponse(
-                for: .getAlbumList2(type: .frequent, size: 10, offset: 0), ttl: 900) {
-                frequentAlbums = cached.albumList2?.album ?? []
-            }
-            if let cached = await client.cachedResponse(for: .getStarred2(), ttl: 300) {
-                if var songs = cached.starred2?.song, !songs.isEmpty {
+            if starredSongs.isEmpty {
+                let starredDesc = FetchDescriptor<CachedSong>(
+                    predicate: #Predicate<CachedSong> { $0.isStarred },
+                    sortBy: [SortDescriptor(\CachedSong.title)]
+                )
+                if let fetched = try? modelContext.fetch(starredDesc), !fetched.isEmpty {
+                    var songs = fetched.map { $0.toSong() }
                     songs.shuffle()
                     starredSongs = Array(songs.prefix(15))
                 }

--- a/Vibrdrome/Features/Library/PlayHistoryView.swift
+++ b/Vibrdrome/Features/Library/PlayHistoryView.swift
@@ -4,18 +4,22 @@ import SwiftData
 struct PlayHistoryView: View {
     @Environment(\.modelContext) private var modelContext
     @Query(sort: \PlayHistory.playedAt, order: .reverse) private var allPlays: [PlayHistory]
+    @State private var cachedTodayCount: Int = 0
+    @State private var cachedWeekCount: Int = 0
+    @State private var cachedTopArtists: [(String, Int)] = []
+    @State private var cachedTopAlbums: [(String, String?, Int)] = []
 
     var body: some View {
         List {
-            if !todayPlays.isEmpty {
+            if cachedTodayCount > 0 {
                 statsSection
             }
 
-            if !topArtists.isEmpty {
+            if !cachedTopArtists.isEmpty {
                 topArtistsSection
             }
 
-            if !topAlbums.isEmpty {
+            if !cachedTopAlbums.isEmpty {
                 topAlbumsSection
             }
 
@@ -39,40 +43,35 @@ struct PlayHistoryView: View {
                 }
             }
         }
+        .onChange(of: allPlays) { recomputeStats() }
+        .onAppear { recomputeStats() }
     }
 
     // MARK: - Computed Data
 
-    private var todayPlays: [PlayHistory] {
-        allPlays.filter { Calendar.current.isDateInToday($0.playedAt) }
-    }
-
-    private var weekPlays: [PlayHistory] {
+    private func recomputeStats() {
         let weekAgo = Calendar.current.date(byAdding: .day, value: -7, to: .now) ?? .now
-        return allPlays.filter { $0.playedAt >= weekAgo }
-    }
+        let weekPlays = allPlays.filter { $0.playedAt >= weekAgo }
 
-    private var topArtists: [(String, Int)] {
-        let week = weekPlays
-        var counts: [String: Int] = [:]
-        for play in week {
+        cachedTodayCount = allPlays.filter { Calendar.current.isDateInToday($0.playedAt) }.count
+        cachedWeekCount = weekPlays.count
+
+        var artistCounts: [String: Int] = [:]
+        for play in weekPlays {
             if let artist = play.artistName {
-                counts[artist, default: 0] += 1
+                artistCounts[artist, default: 0] += 1
             }
         }
-        return counts.sorted { $0.value > $1.value }.prefix(5).map { ($0.key, $0.value) }
-    }
+        cachedTopArtists = artistCounts.sorted { $0.value > $1.value }.prefix(5).map { ($0.key, $0.value) }
 
-    private var topAlbums: [(String, String?, Int)] {
-        let week = weekPlays
-        var counts: [String: (artist: String?, count: Int)] = [:]
-        for play in week {
+        var albumCounts: [String: (artist: String?, count: Int)] = [:]
+        for play in weekPlays {
             if let album = play.albumName {
-                let existing = counts[album]
-                counts[album] = (play.artistName, (existing?.count ?? 0) + 1)
+                let existing = albumCounts[album]
+                albumCounts[album] = (play.artistName, (existing?.count ?? 0) + 1)
             }
         }
-        return counts.sorted { $0.value.count > $1.value.count }
+        cachedTopAlbums = albumCounts.sorted { $0.value.count > $1.value.count }
             .prefix(5)
             .map { ($0.key, $0.value.artist, $0.value.count) }
     }
@@ -82,8 +81,8 @@ struct PlayHistoryView: View {
     private var statsSection: some View {
         Section {
             HStack(spacing: 24) {
-                statBadge(value: todayPlays.count, label: "Today")
-                statBadge(value: weekPlays.count, label: "This Week")
+                statBadge(value: cachedTodayCount, label: "Today")
+                statBadge(value: cachedWeekCount, label: "This Week")
                 statBadge(value: allPlays.count, label: "All Time")
             }
             .frame(maxWidth: .infinity)
@@ -106,7 +105,7 @@ struct PlayHistoryView: View {
 
     private var topArtistsSection: some View {
         Section("Top Artists This Week") {
-            ForEach(topArtists, id: \.0) { artist, count in
+            ForEach(cachedTopArtists, id: \.0) { artist, count in
                 HStack {
                     Text(artist)
                         .font(.body)
@@ -121,7 +120,7 @@ struct PlayHistoryView: View {
 
     private var topAlbumsSection: some View {
         Section("Top Albums This Week") {
-            ForEach(topAlbums, id: \.0) { album, artist, count in
+            ForEach(cachedTopAlbums, id: \.0) { album, artist, count in
                 HStack {
                     VStack(alignment: .leading, spacing: 2) {
                         Text(album)

--- a/Vibrdrome/Features/Library/SidebarContentView.swift
+++ b/Vibrdrome/Features/Library/SidebarContentView.swift
@@ -49,7 +49,7 @@ struct SidebarContentView: View {
     private var engine: AudioEngine { AudioEngine.shared }
 
     enum SidebarItem: String, CaseIterable, Hashable {
-        case artists, albums, songs, genres, favorites, recentlyAdded, mostPlayed, recentlyPlayed
+        case artists, albums, songs, genres, labels, favorites, recentlyAdded, mostPlayed, recentlyPlayed
         case bookmarks, folders
         case search
         case playlists
@@ -77,6 +77,10 @@ struct SidebarContentView: View {
                         .tag(SidebarItem.songs.rawValue)
                     Label("Genres", systemImage: "guitars")
                         .tag(SidebarItem.genres.rawValue)
+                    #if os(macOS)
+                    Label("Labels", systemImage: "tag")
+                        .tag(SidebarItem.labels.rawValue)
+                    #endif
                     Label("Favorites", systemImage: "heart.fill")
                         .tag(SidebarItem.favorites.rawValue)
                     Label("Recently Added", systemImage: "clock")
@@ -277,6 +281,12 @@ struct SidebarContentView: View {
             SongsView()
         case .genres:
             GenresView()
+        case .labels:
+            #if os(macOS)
+            LabelsView()
+            #else
+            EmptyView()
+            #endif
         case .favorites:
             FavoritesView()
         case .recentlyAdded:

--- a/Vibrdrome/Features/Library/SidebarContentView.swift
+++ b/Vibrdrome/Features/Library/SidebarContentView.swift
@@ -152,7 +152,7 @@ struct SidebarContentView: View {
             .navigationTitle("Vibrdrome")
         } detail: {
             #if os(macOS)
-            HStack(spacing: 0) {
+            GeometryReader { geometry in
                 NavigationStack(path: $detailPath) {
                     detailView
                         .navigationDestination(for: SidebarNavRoute.self) { route in
@@ -166,15 +166,17 @@ struct SidebarContentView: View {
                             }
                         }
                 }
-
+                .environment(\.contentWidth, geometry.size.width)
+            }
+            .inspector(isPresented: Binding(
+                get: { appState.activeSidePanel != nil },
+                set: { if !$0 { appState.activeSidePanel = nil } }
+            )) {
                 if let panel = appState.activeSidePanel {
-                    Divider()
                     sidePanelView(for: panel)
-                        .frame(width: sidePanelWidth)
-                        .transition(.move(edge: .trailing).combined(with: .opacity))
                 }
             }
-            .animation(.easeInOut(duration: 0.2), value: appState.activeSidePanel)
+            .inspectorColumnWidth(min: 280, ideal: sidePanelWidth, max: 500)
             #else
             NavigationStack(path: $detailPath) {
                 detailView
@@ -195,6 +197,22 @@ struct SidebarContentView: View {
             if !detailPath.isEmpty {
                 detailPath = NavigationPath()
             }
+            #if os(macOS)
+            // Auto-switch filter panel when a filter panel is already open
+            if let panel = appState.activeSidePanel,
+               panel == .albumFilters || panel == .artistFilters || panel == .songFilters {
+                switch SidebarItem(rawValue: selectionRaw) {
+                case .albums, .recentlyAdded, .mostPlayed, .recentlyPlayed:
+                    appState.activeSidePanel = .albumFilters
+                case .artists:
+                    appState.activeSidePanel = .artistFilters
+                case .songs:
+                    appState.activeSidePanel = .songFilters
+                default:
+                    appState.activeSidePanel = nil
+                }
+            }
+            #endif
         }
         .onChange(of: appState.pendingNavigation) { _, newValue in
             guard let nav = newValue else { return }
@@ -308,6 +326,12 @@ struct SidebarContentView: View {
             LyricsPanelView()
         case .artistInfo:
             ArtistInfoPanelView()
+        case .albumFilters:
+            LibraryFilterSidebarView(context: .album)
+        case .artistFilters:
+            LibraryFilterSidebarView(context: .artist)
+        case .songFilters:
+            LibraryFilterSidebarView(context: .song)
         }
     }
     #endif

--- a/Vibrdrome/Features/Library/SongsView.swift
+++ b/Vibrdrome/Features/Library/SongsView.swift
@@ -1,9 +1,15 @@
 import NukeUI
 import SwiftUI
+import SwiftData
+import os.log
 
 struct SongsView: View {
     @Environment(AppState.self) private var appState
+    @Environment(\.modelContext) private var modelContext
     @State private var songs: [Song] = []
+    @State private var titleSongCount: Int?
+    @State private var localFilteredSongs: [Song]?
+    @State private var filterTask: Task<Void, Never>?
     @State private var isLoading = true
     @State private var hasMore = false
     @State private var searchText = ""
@@ -15,8 +21,10 @@ struct SongsView: View {
     @State private var filterArtist: String?
     @AppStorage(UserDefaultsKeys.showAlbumArtInLists) private var showAlbumArtInLists: Bool = true
     @AppStorage("songsViewStyle") private var showAsList = true
-    @AppStorage(UserDefaultsKeys.gridColumnsPerRow) private var gridColumns = 2
     @State private var sortBy: SongSortOption = .title
+    @State private var cachedDisplayedSongs: [Song] = []
+    @State private var scrollLoadTask: Task<Void, Never>?
+    @State private var pendingPageTarget: Int = 0
 
     private let pageSize = 500
 
@@ -46,8 +54,13 @@ struct SongsView: View {
         filterYear != nil || filterGenre != nil || filterArtist != nil
     }
 
-    private var displayedSongs: [Song] {
-        var base = searchText.count >= 2 ? searchResults : songs
+    private func computeDisplayedSongs() -> [Song] {
+        var base: [Song]
+        #if os(macOS)
+        base = localFilteredSongs ?? (searchText.count >= 2 ? searchResults : songs)
+        #else
+        base = searchText.count >= 2 ? searchResults : songs
+        #endif
         if let filterYear {
             base = base.filter { $0.year == filterYear }
         }
@@ -82,7 +95,7 @@ struct SongsView: View {
                 songGrid
             }
         }
-        .navigationTitle(songs.isEmpty ? "Songs" : "Songs (\(songs.count))")
+        .navigationTitle(titleSongCount.map { "Songs (\($0))" } ?? "Songs")
         #if os(iOS)
         .navigationBarTitleDisplayMode(.inline)
         #endif
@@ -94,6 +107,7 @@ struct SongsView: View {
         .onChange(of: searchText) { _, query in
             guard query.count >= 2 else {
                 searchResults = []
+                recomputeDisplayedSongs()
                 return
             }
             isSearching = true
@@ -104,11 +118,29 @@ struct SongsView: View {
                     let result = try await appState.subsonicClient.search(
                         query: query, artistCount: 0, albumCount: 0, songCount: 50)
                     searchResults = result.song ?? []
+                    recomputeDisplayedSongs()
                 } catch {}
                 isSearching = false
             }
         }
         .toolbar {
+            #if os(macOS)
+            ToolbarItem(placement: .automatic) {
+                Button {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        if appState.activeSidePanel == .songFilters {
+                            appState.activeSidePanel = nil
+                        } else {
+                            appState.activeSidePanel = .songFilters
+                        }
+                    }
+                } label: {
+                    Image(systemName: appState.songFilter.isActive ? "line.3.horizontal.decrease.circle.fill" : "line.3.horizontal.decrease.circle")
+                }
+                .accessibilityLabel("Song Filters")
+                .accessibilityIdentifier("songFilterToggle")
+            }
+            #endif
             ToolbarItem(placement: .automatic) {
                 Button {
                     withAnimation(.easeInOut(duration: 0.2)) {
@@ -217,7 +249,27 @@ struct SongsView: View {
         .task {
             await loadSongs()
             await loadGenres()
+            refreshTitleSongCount()
+            #if os(macOS)
+            applyLocalFilters()
+            #endif
+            recomputeDisplayedSongs()
         }
+        .onChange(of: sortBy) { recomputeDisplayedSongs() }
+        .onChange(of: filterYear) { recomputeDisplayedSongs() }
+        .onChange(of: filterGenre) { recomputeDisplayedSongs() }
+        .onChange(of: filterArtist) { recomputeDisplayedSongs() }
+        .onChange(of: appState.libraryCache.generation) { _, _ in
+            refreshTitleSongCount()
+        }
+        #if os(macOS)
+        .onChange(of: appState.songFilter.isFavorited) { debouncedApplyLocalFilters() }
+        .onChange(of: appState.songFilter.isRated) { debouncedApplyLocalFilters() }
+        .onChange(of: appState.songFilter.isRecentlyPlayed) { debouncedApplyLocalFilters() }
+        .onChange(of: appState.songFilter.selectedArtistIds) { debouncedApplyLocalFilters() }
+        .onChange(of: appState.songFilter.selectedGenres) { debouncedApplyLocalFilters() }
+        .onChange(of: appState.songFilter.year) { debouncedApplyLocalFilters() }
+        #endif
     }
 
     // MARK: - Active Filter Chips
@@ -358,32 +410,27 @@ struct SongsView: View {
                     .listRowInsets(EdgeInsets(top: 4, leading: 16, bottom: 4, trailing: 16))
             }
 
-            if !displayedSongs.isEmpty {
+            if !cachedDisplayedSongs.isEmpty {
                 playShuffleBar
                     .listRowSeparator(.hidden)
             }
 
-            ForEach(Array(displayedSongs.enumerated()), id: \.element.id) { index, song in
-                songRow(song)
-                    .contentShape(Rectangle())
-                    .onTapGesture {
-                        AudioEngine.shared.play(song: song, from: displayedSongs, at: index)
+            ForEach(0..<totalItemCount, id: \.self) { index in
+                Group {
+                    if index < cachedDisplayedSongs.count {
+                        let song = cachedDisplayedSongs[index]
+                        songRow(song)
+                            .contentShape(Rectangle())
+                            .onTapGesture {
+                                AudioEngine.shared.play(song: song, from: cachedDisplayedSongs, at: index)
+                            }
+                            .accessibilityIdentifier("songRow_\(song.id)")
+                            .trackContextMenu(song: song)
+                    } else {
+                        songListPlaceholder
                     }
-                    .accessibilityIdentifier("songRow_\(song.id)")
-                    .trackContextMenu(song: song)
-                    .onAppear {
-                        if searchText.isEmpty && hasMore && !isLoading && song.id == songs.last?.id {
-                            Task { await loadMore() }
-                        }
-                    }
-            }
-
-            if isLoading {
-                HStack {
-                    Spacer()
-                    ProgressView()
-                    Spacer()
                 }
+                .onAppear { triggerLoadIfNeeded(at: index) }
             }
         }
     }
@@ -398,33 +445,33 @@ struct SongsView: View {
                         .padding(.horizontal, 16)
                 }
 
-                if !displayedSongs.isEmpty {
+                if !cachedDisplayedSongs.isEmpty {
                     playShuffleBar
                         .padding(.horizontal, 16)
                 }
 
-                LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 16),
-                                         count: max(2, min(10, gridColumns))), spacing: 20) {
-                    ForEach(Array(displayedSongs.enumerated()), id: \.element.id) { index, song in
-                        songCard(song)
-                            .contentShape(Rectangle())
-                            .onTapGesture {
-                                AudioEngine.shared.play(song: song, from: displayedSongs, at: index)
+                LazyVGrid(columns: [
+                    GridItem(.adaptive(minimum: 160, maximum: 200), spacing: 16)
+                ], spacing: 20) {
+                    ForEach(0..<totalItemCount, id: \.self) { index in
+                        Group {
+                            if index < cachedDisplayedSongs.count {
+                                let song = cachedDisplayedSongs[index]
+                                songCard(song)
+                                    .contentShape(Rectangle())
+                                    .onTapGesture {
+                                        AudioEngine.shared.play(song: song, from: cachedDisplayedSongs, at: index)
+                                    }
+                                    .accessibilityIdentifier("songCard_\(song.id)")
+                                    .trackContextMenu(song: song)
+                            } else {
+                                songGridPlaceholder
                             }
-                            .accessibilityIdentifier("songCard_\(song.id)")
-                            .trackContextMenu(song: song)
-                            .onAppear {
-                                if searchText.isEmpty && hasMore && !isLoading && song.id == songs.last?.id {
-                                    Task { await loadMore() }
-                                }
-                            }
+                        }
+                        .onAppear { triggerLoadIfNeeded(at: index) }
                     }
                 }
                 .padding(16)
-
-                if isLoading {
-                    ProgressView().padding()
-                }
             }
         }
     }
@@ -432,7 +479,7 @@ struct SongsView: View {
     private var playShuffleBar: some View {
         HStack(spacing: 12) {
             Button {
-                let songs = displayedSongs
+                let songs = cachedDisplayedSongs
                 AudioEngine.shared.play(song: songs[0], from: songs, at: 0)
             } label: {
                 Label("Play All", systemImage: "play.fill")
@@ -445,7 +492,7 @@ struct SongsView: View {
             .accessibilityIdentifier("songsPlayAllButton")
 
             Button {
-                let shuffled = displayedSongs.shuffled()
+                let shuffled = cachedDisplayedSongs.shuffled()
                 AudioEngine.shared.play(song: shuffled[0], from: shuffled, at: 0)
             } label: {
                 Label("Shuffle", systemImage: "shuffle")
@@ -506,6 +553,8 @@ struct SongsView: View {
     }
 
     private func loadSongs() async {
+        scrollLoadTask?.cancel()
+        pendingPageTarget = 0
         isLoading = true
         songs = []
         defer { isLoading = false }
@@ -515,21 +564,188 @@ struct SongsView: View {
             )
             songs = result.song ?? []
             hasMore = (result.song?.count ?? 0) >= pageSize
+            refreshTitleSongCount()
+            recomputeDisplayedSongs()
         } catch {}
     }
 
-    private func loadMore() async {
+    private func loadPages() async {
         guard hasMore, !isLoading else { return }
         isLoading = true
-        defer { isLoading = false }
-        do {
-            let result = try await appState.subsonicClient.search(
-                query: "", artistCount: 0, albumCount: 0,
-                songCount: pageSize, songOffset: songs.count
-            )
-            let newSongs = result.song ?? []
-            songs.append(contentsOf: newSongs)
-            hasMore = newSongs.count >= pageSize
-        } catch {}
+        // Accumulate into local array to avoid multiple @State updates triggering re-renders
+        var accumulated = songs
+        var stillHasMore = hasMore
+        while accumulated.count < pendingPageTarget, stillHasMore, !Task.isCancelled {
+            do {
+                let result = try await appState.subsonicClient.search(
+                    query: "", artistCount: 0, albumCount: 0,
+                    songCount: pageSize, songOffset: accumulated.count
+                )
+                let newSongs = result.song ?? []
+                accumulated.append(contentsOf: newSongs)
+                stillHasMore = newSongs.count >= pageSize
+            } catch {
+                stillHasMore = false
+                break
+            }
+        }
+        // Single state update instead of one per page
+        songs = accumulated
+        hasMore = stillHasMore
+        isLoading = false
+        recomputeDisplayedSongs()
+        refreshTitleSongCount()
+        if songs.count < pendingPageTarget, hasMore {
+            scrollLoadTask?.cancel()
+            scrollLoadTask = Task { await loadPages() }
+        }
     }
+
+    private func refreshTitleSongCount() {
+        if let cachedSongs = appState.libraryCache.songs, !cachedSongs.isEmpty {
+            titleSongCount = cachedSongs.count
+            return
+        }
+
+        let descriptor = FetchDescriptor<CachedSong>()
+        if let cachedCount = try? modelContext.fetchCount(descriptor), cachedCount > 0 {
+            titleSongCount = cachedCount
+            return
+        }
+
+        titleSongCount = songs.isEmpty ? nil : songs.count
+    }
+
+    private var songListPlaceholder: some View {
+        HStack(spacing: 12) {
+            RoundedRectangle(cornerRadius: 4)
+                .fill(.quaternary)
+                .frame(width: 40, height: 40)
+            VStack(alignment: .leading, spacing: 4) {
+                RoundedRectangle(cornerRadius: 3)
+                    .fill(.quaternary)
+                    .frame(width: 140, height: 14)
+                RoundedRectangle(cornerRadius: 3)
+                    .fill(.quaternary)
+                    .frame(width: 100, height: 12)
+            }
+            Spacer()
+        }
+    }
+
+    private var songGridPlaceholder: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            RoundedRectangle(cornerRadius: 10)
+                .fill(.quaternary)
+                .aspectRatio(1, contentMode: .fit)
+            RoundedRectangle(cornerRadius: 3)
+                .fill(.quaternary)
+                .frame(height: 14)
+            RoundedRectangle(cornerRadius: 3)
+                .fill(.quaternary)
+                .frame(width: 80, height: 12)
+        }
+    }
+
+    private var totalItemCount: Int {
+        guard localFilteredSongs == nil, searchText.isEmpty else { return cachedDisplayedSongs.count }
+        guard hasMore, let totalCount = appState.libraryCache.songs?.count else { return cachedDisplayedSongs.count }
+        return max(songs.count, totalCount)
+    }
+
+    private func triggerLoadIfNeeded(at index: Int) {
+        guard localFilteredSongs == nil, searchText.isEmpty, hasMore else { return }
+        if index >= songs.count {
+            // Scrolled into placeholder territory — always update target, debounce the load
+            pendingPageTarget = max(pendingPageTarget, songs.count + (index - songs.count) + pageSize)
+            scrollLoadTask?.cancel()
+            scrollLoadTask = Task {
+                try? await Task.sleep(for: .milliseconds(150))
+                guard !Task.isCancelled else { return }
+                await loadPages()
+            }
+        } else if !isLoading {
+            // Near end of loaded items — prefetch immediately
+            let prefetchThreshold = max(songs.count - 10, 0)
+            if index >= prefetchThreshold {
+                pendingPageTarget = max(pendingPageTarget, songs.count + pageSize)
+                Task { await loadPages() }
+            }
+        }
+    }
+
+    private func recomputeDisplayedSongs() {
+        cachedDisplayedSongs = computeDisplayedSongs()
+    }
+
+    #if os(macOS)
+    private func debouncedApplyLocalFilters() {
+        filterTask?.cancel()
+        filterTask = Task {
+            try? await Task.sleep(for: .milliseconds(150))
+            guard !Task.isCancelled else { return }
+            applyLocalFilters()
+        }
+    }
+
+    private func applyLocalFilters() {
+        let filter = appState.songFilter
+        guard filter.isActive else {
+            localFilteredSongs = nil
+            recomputeDisplayedSongs()
+            return
+        }
+
+        do {
+            let allSongs: [Song]
+            if let cachedSongs = appState.libraryCache.songs {
+                allSongs = cachedSongs
+            } else {
+                var descriptor = FetchDescriptor<CachedSong>()
+                descriptor.sortBy = [SortDescriptor(\.title)]
+                allSongs = try modelContext.fetch(descriptor).map { $0.toSong() }
+            }
+
+            let recentSongIds = recentlyPlayedSongIds(for: filter)
+            localFilteredSongs = allSongs.filter { songMatchesFilter($0, filter: filter, recentIds: recentSongIds) }
+            recomputeDisplayedSongs()
+        } catch {
+            Logger(subsystem: "com.vibrdrome.app", category: "Songs")
+                .error("Failed to apply local filters: \(error)")
+            localFilteredSongs = nil
+        }
+    }
+
+    private func recentlyPlayedSongIds(for filter: LibraryFilter) -> Set<String>? {
+        guard filter.isRecentlyPlayed else { return nil }
+        let cutoff = Calendar.current.date(byAdding: .day, value: -30, to: Date()) ?? Date()
+        let descriptor = FetchDescriptor<CachedSong>(
+            predicate: #Predicate { $0.lastPlayed != nil && $0.lastPlayed! > cutoff }
+        )
+        let recentSongs = (try? modelContext.fetch(descriptor)) ?? []
+        return Set(recentSongs.map(\.id))
+    }
+
+    private func songMatchesFilter(
+        _ song: Song, filter: LibraryFilter, recentIds: Set<String>?
+    ) -> Bool {
+        guard filter.isFavorited.matches(song.starred != nil) else { return false }
+        guard filter.isRated.matches((song.userRating ?? 0) != 0) else { return false }
+        if let recentIds, !recentIds.contains(song.id) { return false }
+        if !filter.selectedArtistIds.isEmpty {
+            guard let artistId = song.artistId, filter.selectedArtistIds.contains(artistId) else {
+                return false
+            }
+        }
+        if !filter.selectedGenres.isEmpty {
+            guard let genre = song.genre, filter.selectedGenres.contains(genre) else {
+                return false
+            }
+        }
+        if let yearFilter = filter.year {
+            guard song.year == yearFilter else { return false }
+        }
+        return true
+    }
+    #endif
 }

--- a/Vibrdrome/Features/Playlists/PlaylistDetailView.swift
+++ b/Vibrdrome/Features/Playlists/PlaylistDetailView.swift
@@ -5,6 +5,7 @@ struct PlaylistDetailView: View {
     let playlistId: String
 
     @Environment(AppState.self) private var appState
+    @Environment(\.modelContext) private var modelContext
     @State private var playlist: Playlist?
     @State private var isLoading = true
     @State private var error: String?
@@ -303,14 +304,53 @@ struct PlaylistDetailView: View {
     }
 
     private func loadPlaylist() async {
-        isLoading = true
+        // Show cached playlist data instantly while fetching fresh
+        if playlist == nil {
+            playlist = loadCachedPlaylist()
+        }
+        isLoading = playlist == nil
         error = nil
         defer { isLoading = false }
         do {
             playlist = try await appState.subsonicClient.getPlaylist(id: playlistId)
         } catch {
-            self.error = ErrorPresenter.userMessage(for: error)
+            if playlist == nil {
+                self.error = ErrorPresenter.userMessage(for: error)
+            }
         }
+    }
+
+    private func loadCachedPlaylist() -> Playlist? {
+        let pid = playlistId
+        var descriptor = FetchDescriptor<CachedPlaylist>(
+            predicate: #Predicate { $0.id == pid }
+        )
+        descriptor.fetchLimit = 1
+        guard let cached = try? modelContext.fetch(descriptor).first else { return nil }
+
+        // Resolve entries to songs via CachedSong
+        let sortedEntries = cached.entries.sorted { $0.order < $1.order }
+        let songs: [Song] = sortedEntries.compactMap { entry in
+            let sid = entry.songId
+            var songDesc = FetchDescriptor<CachedSong>(
+                predicate: #Predicate { $0.id == sid }
+            )
+            songDesc.fetchLimit = 1
+            return try? modelContext.fetch(songDesc).first?.toSong()
+        }
+
+        return Playlist(
+            id: cached.id,
+            name: cached.name,
+            songCount: cached.songCount,
+            duration: cached.duration,
+            created: nil,
+            changed: nil,
+            coverArt: cached.coverArtId,
+            owner: cached.owner,
+            isPublic: cached.isPublic,
+            entry: songs.isEmpty ? nil : songs
+        )
     }
 
     private func toggleSelection(_ songId: String) {

--- a/Vibrdrome/Features/Playlists/PlaylistsView.swift
+++ b/Vibrdrome/Features/Playlists/PlaylistsView.swift
@@ -9,7 +9,6 @@ struct PlaylistsView: View {
     @State private var showCreateSheet = false
     @State private var showSmartSheet = false
     @AppStorage("playlistViewStyle") private var showAsList = false
-    @AppStorage(UserDefaultsKeys.gridColumnsPerRow) private var gridColumns = 2
     @State private var searchText = ""
     @State private var sortBy: PlaylistSortOption = .name
 
@@ -250,8 +249,9 @@ struct PlaylistsView: View {
     // MARK: - Playlist Grid
 
     private var playlistGrid: some View {
-        LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 16),
-                                 count: max(2, min(10, gridColumns))), spacing: 20) {
+        LazyVGrid(columns: [
+            GridItem(.adaptive(minimum: 180, maximum: 240), spacing: 16)
+        ], spacing: 20) {
             ForEach(filteredPlaylists) { playlist in
                 NavigationLink {
                     PlaylistDetailView(playlistId: playlist.id)
@@ -316,9 +316,11 @@ struct PlaylistsView: View {
 
     private func playlistCard(_ playlist: Playlist) -> some View {
         VStack(alignment: .leading, spacing: 8) {
-            PlaylistMosaicView(playlist: playlist, size: Theme.playlistCardSize, cornerRadius: 12)
-                .frame(maxWidth: .infinity)
-                .shadow(color: .black.opacity(0.15), radius: 6, y: 3)
+            GeometryReader { geo in
+                PlaylistMosaicView(playlist: playlist, size: geo.size.width, cornerRadius: 12)
+            }
+            .aspectRatio(1, contentMode: .fit)
+            .shadow(color: .black.opacity(0.15), radius: 6, y: 3)
 
             Text(playlist.name)
                 .font(.subheadline)

--- a/Vibrdrome/Features/Radio/RadioView.swift
+++ b/Vibrdrome/Features/Radio/RadioView.swift
@@ -10,7 +10,6 @@ struct RadioView: View {
     @State private var showAddSheet = false
     @State private var showSearchSheet = false
     @AppStorage("radioViewStyle") private var showAsList = false
-    @AppStorage(UserDefaultsKeys.gridColumnsPerRow) private var gridColumns = 2
 
     private var engine: AudioEngine { AudioEngine.shared }
 
@@ -246,8 +245,9 @@ struct RadioView: View {
     }
 
     private var stationGrid: some View {
-        LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 16),
-                                 count: max(2, min(10, gridColumns))), spacing: 16) {
+        LazyVGrid(columns: [
+            GridItem(.adaptive(minimum: 160, maximum: 220), spacing: 16)
+        ], spacing: 16) {
             ForEach(Array(filteredStations.enumerated()), id: \.element.id) { index, station in
                 stationCardView(station, colorIndex: index)
             }

--- a/Vibrdrome/Features/Search/SearchView+Filters.swift
+++ b/Vibrdrome/Features/Search/SearchView+Filters.swift
@@ -1,3 +1,4 @@
+import SwiftData
 import SwiftUI
 
 // MARK: - Filter UI & Logic
@@ -185,6 +186,15 @@ extension SearchView {
     }
 
     func loadGenres() async {
+        // Try local SwiftData first — fetch album genres (much smaller than all songs)
+        let albums = (try? modelContext.fetch(FetchDescriptor<CachedAlbum>())) ?? []
+        let localGenres = Set(albums.compactMap(\.genre).filter { !$0.isEmpty })
+        if !localGenres.isEmpty {
+            availableGenres = localGenres.sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
+            return
+        }
+
+        // Fall back to API
         do {
             let genres = try await appState.subsonicClient.getGenres()
             availableGenres = genres

--- a/Vibrdrome/Features/Search/SearchView.swift
+++ b/Vibrdrome/Features/Search/SearchView.swift
@@ -6,7 +6,7 @@ private let maxRecentSearches = 10
 
 struct SearchView: View {
     @Environment(AppState.self) var appState
-    @Environment(\.modelContext) private var modelContext
+    @Environment(\.modelContext) var modelContext
     @State private var query = ""
     @State private var results: SearchResult3?
     @State private var isSearching = false
@@ -366,6 +366,12 @@ struct SearchView: View {
         try? await Task.sleep(for: .milliseconds(300))
         guard !Task.isCancelled else { return }
 
+        // Show local results instantly while waiting for network
+        let localResults = searchLocally(query: query)
+        if let localResults, resultCount(localResults) > 0, results == nil {
+            results = localResults
+        }
+
         isSearching = true
         defer { isSearching = false }
 
@@ -401,16 +407,63 @@ struct SearchView: View {
             results = searchResults
         } catch {
             guard !Task.isCancelled else { return }
-            // Offline fallback: search downloaded songs locally
-            let offlineResults = searchDownloadsLocally(query: query)
-            if let songs = offlineResults, !songs.isEmpty {
+            // Offline fallback: search cached library locally
+            let offlineResults = searchLocally(query: query)
+                ?? searchDownloadsLocally(query: query).map {
+                    SearchResult3(artist: nil, album: nil, song: $0)
+                }
+            if let offlineResults, resultCount(offlineResults) > 0 {
                 searchError = nil
-                results = SearchResult3(artist: nil, album: nil, song: songs)
+                results = offlineResults
             } else {
                 searchError = ErrorPresenter.userMessage(for: error)
                 results = nil
             }
         }
+    }
+
+    private func searchLocally(query: String) -> SearchResult3? {
+        let q = query
+
+        // Search cached songs using predicate
+        var songDescriptor = FetchDescriptor<CachedSong>(
+            predicate: #Predicate<CachedSong> {
+                $0.title.localizedStandardContains(q)
+                || ($0.artist?.localizedStandardContains(q) ?? false)
+                || ($0.albumName?.localizedStandardContains(q) ?? false)
+            }
+        )
+        songDescriptor.fetchLimit = 40
+        let matchedSongs = ((try? modelContext.fetch(songDescriptor)) ?? []).map { $0.toSong() }
+
+        // Search cached albums using predicate
+        var albumDescriptor = FetchDescriptor<CachedAlbum>(
+            predicate: #Predicate<CachedAlbum> {
+                $0.name.localizedStandardContains(q)
+                || ($0.artistName?.localizedStandardContains(q) ?? false)
+            }
+        )
+        albumDescriptor.fetchLimit = 20
+        let matchedAlbums = ((try? modelContext.fetch(albumDescriptor)) ?? []).map { $0.toAlbum() }
+
+        // Search cached artists using predicate
+        var artistDescriptor = FetchDescriptor<CachedArtist>(
+            predicate: #Predicate<CachedArtist> {
+                $0.name.localizedStandardContains(q)
+            }
+        )
+        artistDescriptor.fetchLimit = 20
+        let matchedArtists = ((try? modelContext.fetch(artistDescriptor)) ?? []).map { $0.toArtist() }
+
+        guard !matchedSongs.isEmpty || !matchedAlbums.isEmpty || !matchedArtists.isEmpty else {
+            return nil
+        }
+
+        return SearchResult3(
+            artist: matchedArtists.isEmpty ? nil : Array(matchedArtists),
+            album: matchedAlbums.isEmpty ? nil : Array(matchedAlbums),
+            song: matchedSongs.isEmpty ? nil : Array(matchedSongs)
+        )
     }
 
     private func searchDownloadsLocally(query: String) -> [Song]? {

--- a/Vibrdrome/Features/Settings/AppearanceSettingsView.swift
+++ b/Vibrdrome/Features/Settings/AppearanceSettingsView.swift
@@ -116,8 +116,6 @@ struct AppearanceSettingsView: View {
 
     // MARK: - Lists Section
 
-    @AppStorage(UserDefaultsKeys.gridColumnsPerRow) private var gridColumns = 2
-
     private var listsSection: some View {
         Section {
             Toggle(isOn: $showAlbumArtInLists) {
@@ -125,22 +123,6 @@ struct AppearanceSettingsView: View {
                     .foregroundColor(.primary)
             }
             .accessibilityIdentifier("albumArtInListsToggle")
-
-            Picker(selection: $gridColumns) {
-                Text("2").tag(2)
-                Text("3").tag(3)
-                Text("4").tag(4)
-                Text("5").tag(5)
-                Text("6").tag(6)
-                #if os(macOS)
-                Text("8").tag(8)
-                Text("10").tag(10)
-                #endif
-            } label: {
-                Label("Grid Columns", systemImage: "square.grid.2x2")
-                    .foregroundColor(.primary)
-            }
-            .accessibilityIdentifier("gridColumnsPicker")
         } header: {
             settingSectionHeader("Lists", icon: "list.bullet", color: .green)
         }

--- a/Vibrdrome/Features/Settings/SettingsView.swift
+++ b/Vibrdrome/Features/Settings/SettingsView.swift
@@ -87,6 +87,7 @@ struct SettingsView: View {
             #endif
 
             downloadsSection
+            librarySyncSection
 
             #if os(iOS)
             NavigationLink {
@@ -308,6 +309,143 @@ struct SettingsView: View {
             }
         } header: {
             settingSectionHeader("Downloads", icon: "arrow.down.circle.fill", color: .cyan)
+        }
+    }
+
+    // MARK: - Library Sync Section
+
+    private var librarySyncSection: some View {
+        Section {
+            HStack {
+                Label("Library Sync", systemImage: "arrow.triangle.2.circlepath.circle.fill")
+                Spacer()
+                if appState.librarySyncManager.isSyncing {
+                    ProgressView()
+                        .controlSize(.small)
+                } else if let lastSync = appState.librarySyncManager.lastSyncDate {
+                    Text(lastSync, style: .relative)
+                        .foregroundStyle(.secondary)
+                        .font(.caption)
+                    Text("ago")
+                        .foregroundStyle(.secondary)
+                        .font(.caption)
+                } else {
+                    Text("Never")
+                        .foregroundStyle(.secondary)
+                        .font(.caption)
+                }
+            }
+
+            if let progress = appState.librarySyncManager.syncProgress {
+                Text(progress)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            if let syncError = appState.librarySyncManager.syncError {
+                Text(syncError)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+            }
+
+            // Live sync stats during sync
+            if let stats = appState.librarySyncManager.lastSyncStats,
+               appState.librarySyncManager.isSyncing {
+                HStack(spacing: 12) {
+                    Label("+\(stats.albumsAdded + stats.artistsAdded + stats.songsAdded)", systemImage: "plus.circle")
+                        .foregroundStyle(.green)
+                    Label("~\(stats.albumsUpdated + stats.artistsUpdated + stats.songsUpdated)", systemImage: "pencil.circle")
+                        .foregroundStyle(.orange)
+                    Label("-\(stats.albumsRemoved + stats.artistsRemoved + stats.songsRemoved)", systemImage: "minus.circle")
+                        .foregroundStyle(.red)
+                }
+                .font(.caption)
+            }
+
+            // Last sync result summary
+            if let stats = appState.librarySyncManager.lastSyncStats,
+               !appState.librarySyncManager.isSyncing,
+               stats.totalChanges > 0 {
+                HStack {
+                    Text("Last sync: \(stats.totalChanges) changes in \(String(format: "%.1f", stats.duration))s")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            HStack {
+                Button {
+                    Task {
+                        await appState.librarySyncManager.sync(
+                            client: appState.subsonicClient,
+                            container: PersistenceController.shared.container
+                        )
+                    }
+                } label: {
+                    Label(
+                        appState.librarySyncManager.isSyncing ? "Syncing…" : "Full Sync",
+                        systemImage: "arrow.clockwise"
+                    )
+                }
+                .disabled(appState.librarySyncManager.isSyncing)
+                .accessibilityIdentifier("librarySyncButton")
+
+                Spacer()
+
+                Button {
+                    Task {
+                        await appState.librarySyncManager.incrementalSync(
+                            client: appState.subsonicClient,
+                            container: PersistenceController.shared.container
+                        )
+                    }
+                } label: {
+                    Label("Quick Sync", systemImage: "bolt.circle")
+                }
+                .disabled(appState.librarySyncManager.isSyncing)
+                .accessibilityIdentifier("incrementalSyncButton")
+            }
+
+            NavigationLink {
+                SyncHistoryView()
+            } label: {
+                Label("Sync History", systemImage: "clock.arrow.circlepath")
+            }
+            .accessibilityIdentifier("syncHistoryLink")
+
+            #if os(iOS)
+            Toggle(isOn: Binding(
+                get: { UserDefaults.standard.bool(forKey: UserDefaultsKeys.backgroundSyncEnabled) },
+                set: { newValue in
+                    UserDefaults.standard.set(newValue, forKey: UserDefaultsKeys.backgroundSyncEnabled)
+                    if newValue {
+                        BackgroundSyncScheduler.shared.scheduleRefresh()
+                        BackgroundSyncScheduler.shared.scheduleFullSync()
+                    } else {
+                        BackgroundSyncScheduler.shared.cancelAll()
+                    }
+                }
+            )) {
+                Label("Background Sync", systemImage: "arrow.triangle.2.circlepath")
+            }
+            #endif
+
+            Picker(selection: Binding(
+                get: {
+                    let val = UserDefaults.standard.integer(forKey: UserDefaultsKeys.syncPollingInterval)
+                    return [5, 15, 30, 60].contains(val) ? val : 15
+                },
+                set: { UserDefaults.standard.set($0, forKey: UserDefaultsKeys.syncPollingInterval) }
+            )) {
+                Text("5 min").tag(5)
+                Text("15 min").tag(15)
+                Text("30 min").tag(30)
+                Text("60 min").tag(60)
+            } label: {
+                Label("Check for Changes", systemImage: "timer")
+            }
+        } header: {
+            settingSectionHeader("Library", icon: "books.vertical.fill", color: .purple)
         }
     }
 

--- a/Vibrdrome/Features/Settings/SyncHistoryView.swift
+++ b/Vibrdrome/Features/Settings/SyncHistoryView.swift
@@ -1,0 +1,119 @@
+import SwiftData
+import SwiftUI
+
+struct SyncHistoryView: View {
+    @Query(sort: \SyncHistory.syncDate, order: .reverse) private var history: [SyncHistory]
+
+    var body: some View {
+        List {
+            if history.isEmpty {
+                ContentUnavailableView(
+                    "No Sync History",
+                    systemImage: "clock.arrow.circlepath",
+                    description: Text("Sync history will appear here after your first library sync.")
+                )
+            } else {
+                ForEach(history) { entry in
+                    SyncHistoryRow(entry: entry)
+                }
+            }
+        }
+        .navigationTitle("Sync History")
+    }
+}
+
+private struct SyncHistoryRow: View {
+    let entry: SyncHistory
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Image(systemName: entry.succeeded ? "checkmark.circle.fill" : "xmark.circle.fill")
+                    .foregroundStyle(entry.succeeded ? .green : .red)
+                    .font(.caption)
+
+                Text(entry.syncType.capitalized)
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+
+                Spacer()
+
+                Text(entry.syncDate, style: .relative)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text("ago")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            if entry.succeeded {
+                HStack(spacing: 12) {
+                    if entry.totalChanges > 0 {
+                        statsLabel(value: entry.albumsAdded + entry.artistsAdded + entry.songsAdded,
+                                   label: "added", color: .green)
+                        statsLabel(value: entry.albumsUpdated + entry.artistsUpdated + entry.songsUpdated,
+                                   label: "updated", color: .orange)
+                        statsLabel(value: entry.albumsRemoved + entry.artistsRemoved + entry.songsRemoved,
+                                   label: "removed", color: .red)
+                    } else {
+                        Text("No changes")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    Spacer()
+
+                    Text(String(format: "%.1fs", entry.durationSeconds))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                if entry.totalChanges > 0 {
+                    HStack(spacing: 8) {
+                        if entry.albumsAdded + entry.albumsUpdated + entry.albumsRemoved > 0 {
+                            Text("\(entry.albumsAdded + entry.albumsUpdated + entry.albumsRemoved) albums")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+                        if entry.artistsAdded + entry.artistsUpdated + entry.artistsRemoved > 0 {
+                            Text("\(entry.artistsAdded + entry.artistsUpdated + entry.artistsRemoved) artists")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+                        if entry.songsAdded + entry.songsUpdated + entry.songsRemoved > 0 {
+                            Text("\(entry.songsAdded + entry.songsUpdated + entry.songsRemoved) songs")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+                        if entry.playlistsSynced > 0 {
+                            Text("\(entry.playlistsSynced) playlists")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+
+                if entry.conflictsDetected > 0 {
+                    Text("\(entry.conflictsResolved)/\(entry.conflictsDetected) conflicts resolved")
+                        .font(.caption2)
+                        .foregroundStyle(.orange)
+                }
+            } else if let error = entry.errorMessage {
+                Text(error)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+                    .lineLimit(2)
+            }
+        }
+        .padding(.vertical, 2)
+    }
+
+    @ViewBuilder
+    private func statsLabel(value: Int, label: String, color: Color) -> some View {
+        if value > 0 {
+            Text("\(value) \(label)")
+                .font(.caption)
+                .foregroundStyle(color)
+        }
+    }
+}

--- a/Vibrdrome/Info.plist
+++ b/Vibrdrome/Info.plist
@@ -71,6 +71,13 @@
     <key>UIBackgroundModes</key>
     <array>
         <string>audio</string>
+        <string>fetch</string>
+        <string>processing</string>
+    </array>
+    <key>BGTaskSchedulerPermittedIdentifiers</key>
+    <array>
+        <string>com.vibrdrome.app.libraryRefresh</string>
+        <string>com.vibrdrome.app.librarySync</string>
     </array>
     <key>NSPhotoLibraryAddUsageDescription</key>
     <string>Save album artwork to your photo library</string>

--- a/Vibrdrome/Shared/Components/AlbumArtImageCache.swift
+++ b/Vibrdrome/Shared/Components/AlbumArtImageCache.swift
@@ -1,0 +1,20 @@
+import Nuke
+import Foundation
+
+@MainActor
+final class AlbumArtImageCache {
+    static let shared = AlbumArtImageCache()
+    private let cache = NSCache<NSString, PlatformImage>()
+
+    private init() {
+        cache.countLimit = 300
+    }
+
+    func image(for coverArtId: String) -> PlatformImage? {
+        cache.object(forKey: coverArtId as NSString)
+    }
+
+    func store(_ image: PlatformImage, for coverArtId: String) {
+        cache.setObject(image, forKey: coverArtId as NSString)
+    }
+}

--- a/Vibrdrome/Shared/Components/AlbumArtImageCache.swift
+++ b/Vibrdrome/Shared/Components/AlbumArtImageCache.swift
@@ -1,6 +1,22 @@
 import Nuke
 import Foundation
 
+/// Synchronous in-memory image cache layered on top of Nuke's async pipeline.
+///
+/// **Why this exists alongside Nuke's built-in cache:**
+/// Nuke's `ImagePipeline` cache is asynchronous — even a memory-cache hit goes through
+/// an async request/response cycle, which causes a brief placeholder flash on every
+/// SwiftUI re-render (e.g. scrolling a grid, switching tabs, or state changes that
+/// trigger view identity updates). This NSCache provides an *instant, synchronous*
+/// lookup path: if the cover art was loaded during this session, `AlbumArtView` can
+/// display it immediately without a loading state or fade-in transition.
+///
+/// The two caches serve different roles:
+/// - **Nuke pipeline cache**: disk + memory, handles network fetching, deduplication,
+///   and progressive decoding. Source of truth for loading images.
+/// - **AlbumArtImageCache**: session-scoped, synchronous, display-only. Populated as
+///   a side effect when Nuke finishes loading. Avoids re-entering Nuke's async path
+///   for images we've already rendered this session.
 @MainActor
 final class AlbumArtImageCache {
     static let shared = AlbumArtImageCache()

--- a/Vibrdrome/Shared/Components/AlbumArtView.swift
+++ b/Vibrdrome/Shared/Components/AlbumArtView.swift
@@ -1,23 +1,34 @@
 import SwiftUI
+import Nuke
 import NukeUI
 
-struct AlbumArtView: View {
+struct AlbumArtView: View, Equatable {
     let coverArtId: String?
     var size: CGFloat = 50
     var cornerRadius: CGFloat = 6
 
     @Environment(AppState.self) private var appState
 
+    nonisolated static func == (lhs: AlbumArtView, rhs: AlbumArtView) -> Bool {
+        lhs.coverArtId == rhs.coverArtId && lhs.size == rhs.size && lhs.cornerRadius == rhs.cornerRadius
+    }
+
     var body: some View {
         if let coverArtId {
+            let hasCached = AlbumArtImageCache.shared.image(for: coverArtId) != nil
             LazyImage(url: appState.subsonicClient.coverArtURL(id: coverArtId, size: Int(size * 2))) { state in
                 if let image = state.image {
                     image.resizable().aspectRatio(contentMode: .fill)
-                        .transition(.opacity.animation(.easeIn(duration: 0.2)))
+                        .transition(hasCached ? .identity : .opacity.animation(.easeIn(duration: 0.2)))
+                        .onAppear {
+                            if let platformImage = state.imageContainer?.image {
+                                AlbumArtImageCache.shared.store(platformImage, for: coverArtId)
+                            }
+                        }
                 } else if state.error != nil {
-                    placeholderView
+                    cachedOrPlaceholder(for: coverArtId)
                 } else {
-                    placeholderView
+                    cachedOrPlaceholder(for: coverArtId)
                 }
             }
             .frame(width: size, height: size)
@@ -29,6 +40,17 @@ struct AlbumArtView: View {
         }
     }
 
+    @ViewBuilder
+    private func cachedOrPlaceholder(for id: String) -> some View {
+        if let cached = AlbumArtImageCache.shared.image(for: id) {
+            Image(platformImage: cached)
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+        } else {
+            placeholderView
+        }
+    }
+
     private var placeholderView: some View {
         RoundedRectangle(cornerRadius: cornerRadius)
             .fill(.quaternary)
@@ -37,5 +59,15 @@ struct AlbumArtView: View {
                 Image(systemName: "music.note")
                     .foregroundStyle(.secondary)
             }
+    }
+}
+
+private extension Image {
+    init(platformImage: PlatformImage) {
+        #if os(iOS)
+        self.init(uiImage: platformImage)
+        #else
+        self.init(nsImage: platformImage)
+        #endif
     }
 }

--- a/Vibrdrome/Shared/Components/FilterMultiSelectList.swift
+++ b/Vibrdrome/Shared/Components/FilterMultiSelectList.swift
@@ -1,0 +1,112 @@
+import SwiftUI
+
+/// A searchable, scrollable multi-select list for filter sidebars.
+/// Each item has a label, optional subtitle, optional image, and a checkmark when selected.
+struct FilterMultiSelectList<T: Identifiable & Hashable>: View {
+    let title: String
+    let items: [T]
+    @Binding var selectedIds: Set<String>
+    let id: KeyPath<T, String>
+    let label: KeyPath<T, String>
+    let subtitle: ((T) -> String?)?
+    let imageId: ((T) -> String?)?
+
+    @State private var searchText = ""
+
+    init(
+        title: String,
+        items: [T],
+        selectedIds: Binding<Set<String>>,
+        id: KeyPath<T, String>,
+        label: KeyPath<T, String>,
+        subtitle: ((T) -> String?)? = nil,
+        imageId: ((T) -> String?)? = nil
+    ) {
+        self.title = title
+        self.items = items
+        self._selectedIds = selectedIds
+        self.id = id
+        self.label = label
+        self.subtitle = subtitle
+        self.imageId = imageId
+    }
+
+    private var filteredItems: [T] {
+        if searchText.isEmpty { return items }
+        return items.filter { $0[keyPath: label].localizedCaseInsensitiveContains(searchText) }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text(title)
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                Spacer()
+                if !selectedIds.isEmpty {
+                    Text("\(selectedIds.count)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            TextField("Search \(title.lowercased())…", text: $searchText)
+                .textFieldStyle(.roundedBorder)
+                .font(.caption)
+
+            ScrollView {
+                LazyVStack(spacing: 0) {
+                    ForEach(filteredItems, id: id) { item in
+                        let itemId = item[keyPath: self.id]
+                        let isSelected = selectedIds.contains(itemId)
+                        Button {
+                            if isSelected {
+                                selectedIds.remove(itemId)
+                            } else {
+                                selectedIds.insert(itemId)
+                            }
+                        } label: {
+                            HStack(spacing: 8) {
+                                if let imageId, let artId = imageId(item) {
+                                    AlbumArtView(coverArtId: artId, size: 30, cornerRadius: 4)
+                                }
+
+                                VStack(alignment: .leading, spacing: 1) {
+                                    Text(item[keyPath: label])
+                                        .font(.caption)
+                                        .lineLimit(1)
+                                    if let subtitle, let sub = subtitle(item) {
+                                        Text(sub)
+                                            .font(.caption2)
+                                            .foregroundStyle(.secondary)
+                                            .lineLimit(1)
+                                    }
+                                }
+
+                                Spacer()
+
+                                if isSelected {
+                                    Image(systemName: "checkmark")
+                                        .font(.caption)
+                                        .foregroundStyle(Color.accentColor)
+                                }
+                            }
+                            .padding(.vertical, 4)
+                            .padding(.horizontal, 6)
+                            .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
+                        .background(isSelected ? Color.accentColor.opacity(0.1) : Color.clear)
+                    }
+                }
+            }
+            .frame(height: 200)
+            #if os(macOS)
+            .background(Color(nsColor: .controlBackgroundColor).opacity(0.5))
+            #else
+            .background(Color(.systemBackground).opacity(0.5))
+            #endif
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+        }
+    }
+}

--- a/Vibrdrome/Shared/Components/FilterMultiSelectList.swift
+++ b/Vibrdrome/Shared/Components/FilterMultiSelectList.swift
@@ -53,6 +53,7 @@ struct FilterMultiSelectList<T: Identifiable & Hashable>: View {
             TextField("Search \(title.lowercased())…", text: $searchText)
                 .textFieldStyle(.roundedBorder)
                 .font(.caption)
+                .accessibilityLabel("Search \(title.lowercased())")
 
             ScrollView {
                 LazyVStack(spacing: 0) {
@@ -97,6 +98,9 @@ struct FilterMultiSelectList<T: Identifiable & Hashable>: View {
                         }
                         .buttonStyle(.plain)
                         .background(isSelected ? Color.accentColor.opacity(0.1) : Color.clear)
+                        .accessibilityLabel(item[keyPath: label])
+                        .accessibilityValue(isSelected ? "Selected" : "Not selected")
+                        .accessibilityAddTraits(isSelected ? .isSelected : [])
                     }
                 }
             }

--- a/Vibrdrome/Shared/Components/TrackContextMenu.swift
+++ b/Vibrdrome/Shared/Components/TrackContextMenu.swift
@@ -18,6 +18,7 @@ struct TrackContextMenuModifier: ViewModifier, Equatable {
             .contextMenu {
                 TrackContextMenuContent(
                     song: song, queue: queue, index: index,
+                    onRemove: onRemove,
                     showAddToPlaylist: $showAddToPlaylist
                 )
             }
@@ -32,6 +33,7 @@ private struct TrackContextMenuContent: View {
     let song: Song
     var queue: [Song]?
     var index: Int?
+    var onRemove: (() -> Void)?
     @Binding var showAddToPlaylist: Bool
 
     @Environment(AppState.self) private var appState

--- a/Vibrdrome/Shared/Components/TrackContextMenu.swift
+++ b/Vibrdrome/Shared/Components/TrackContextMenu.swift
@@ -1,26 +1,42 @@
 import SwiftUI
 import os.log
 
-struct TrackContextMenuModifier: ViewModifier {
+struct TrackContextMenuModifier: ViewModifier, Equatable {
     let song: Song
     var queue: [Song]?
     var index: Int?
     var onRemove: (() -> Void)?
 
-    @Environment(AppState.self) private var appState
     @State private var showAddToPlaylist = false
+
+    nonisolated static func == (lhs: TrackContextMenuModifier, rhs: TrackContextMenuModifier) -> Bool {
+        lhs.song == rhs.song && lhs.index == rhs.index
+    }
 
     func body(content: Content) -> some View {
         content
-            .contextMenu { contextMenuItems }
+            .contextMenu {
+                TrackContextMenuContent(
+                    song: song, queue: queue, index: index,
+                    showAddToPlaylist: $showAddToPlaylist
+                )
+            }
             .sheet(isPresented: $showAddToPlaylist) {
                 AddToPlaylistView(songIds: [song.id])
-                    .environment(appState)
             }
     }
+}
 
-    @ViewBuilder
-    private var contextMenuItems: some View {
+/// Lazy inner view — `@Environment(AppState.self)` is only resolved when the context menu opens.
+private struct TrackContextMenuContent: View {
+    let song: Song
+    var queue: [Song]?
+    var index: Int?
+    @Binding var showAddToPlaylist: Bool
+
+    @Environment(AppState.self) private var appState
+
+    var body: some View {
         playbackActions
         Divider()
         libraryActions

--- a/Vibrdrome/Shared/Components/TriStateFilterControl.swift
+++ b/Vibrdrome/Shared/Components/TriStateFilterControl.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+/// A button-group control with Yes / No options for tri-state filtering.
+/// Tapping the active button deselects it (returns to .none).
+/// When .none is active, neither button is highlighted.
+struct TriStateFilterControl: View {
+    let label: String
+    @Binding var value: TriState
+
+    var body: some View {
+        HStack {
+            Text(label)
+                .font(.subheadline)
+                .fontWeight(.medium)
+            Spacer()
+            HStack(spacing: 1) {
+                filterButton("Yes", state: .yes)
+                filterButton("No", state: .no)
+            }
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+        }
+    }
+
+    private func filterButton(_ title: String, state: TriState) -> some View {
+        let isActive = value == state
+        return Button {
+            withAnimation(.easeInOut(duration: 0.15)) {
+                value = isActive ? .none : state
+            }
+        } label: {
+            Text(title)
+                .font(.caption)
+                .fontWeight(isActive ? .semibold : .regular)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 5)
+                .background(isActive ? Color.accentColor : Color.secondary.opacity(0.15))
+                .foregroundStyle(isActive ? .white : .secondary)
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/Vibrdrome/Shared/Components/TriStateFilterControl.swift
+++ b/Vibrdrome/Shared/Components/TriStateFilterControl.swift
@@ -37,5 +37,8 @@ struct TriStateFilterControl: View {
                 .foregroundStyle(isActive ? .white : .secondary)
         }
         .buttonStyle(.plain)
+        .accessibilityLabel("\(label) \(title)")
+        .accessibilityValue(isActive ? "Active" : "Inactive")
+        .accessibilityAddTraits(isActive ? .isSelected : [])
     }
 }

--- a/Vibrdrome/Shared/Extensions/ContentWidth+Environment.swift
+++ b/Vibrdrome/Shared/Extensions/ContentWidth+Environment.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+private struct ContentWidthKey: EnvironmentKey {
+    static let defaultValue: CGFloat = 0
+}
+
+extension EnvironmentValues {
+    var contentWidth: CGFloat {
+        get { self[ContentWidthKey.self] }
+        set { self[ContentWidthKey.self] = newValue }
+    }
+}

--- a/Vibrdrome/Shared/Extensions/ErrorPresenter.swift
+++ b/Vibrdrome/Shared/Extensions/ErrorPresenter.swift
@@ -33,6 +33,7 @@ enum ErrorPresenter {
         case 401: return "Authentication failed. Check your credentials."
         case 403: return "Access denied. Your account may not have permission."
         case 404: return "The requested item was not found on the server."
+        case 429: return "Server is rate limiting requests. Please wait a moment and try again."
         case 500...599: return "The server encountered an error. Please try again later."
         default: return "Server returned an error (HTTP \(code))."
         }

--- a/Vibrdrome/Vibrdrome.swift
+++ b/Vibrdrome/Vibrdrome.swift
@@ -115,7 +115,12 @@ struct VibrdromeApp: App {
                 .dynamicTypeSize(textSize)
                 .environment(\.legibilityWeight, boldText ? .bold : .regular)
                 .onAppear {
-                    ImagePipeline.shared = ImagePipeline(configuration: .withDataCache(name: "com.vibrdrome.images"))
+                    ImagePipeline.shared = ImagePipeline {
+                        let dataCache = try? DataCache(name: "com.vibrdrome.images")
+                        // macOS has more disk space; 1 GB covers most libraries
+                        dataCache?.sizeLimit = 1024 * 1024 * 1024 // 1 GB
+                        if let dataCache { $0.dataCache = dataCache }
+                    }
                     RemoteCommandManager.shared.setup()
                     DownloadManager.shared.resumeIncompleteDownloads()
                     Task {

--- a/Vibrdrome/Vibrdrome.swift
+++ b/Vibrdrome/Vibrdrome.swift
@@ -118,6 +118,22 @@ struct VibrdromeApp: App {
                     ImagePipeline.shared = ImagePipeline(configuration: .withDataCache(name: "com.vibrdrome.images"))
                     RemoteCommandManager.shared.setup()
                     DownloadManager.shared.resumeIncompleteDownloads()
+                    Task {
+                        appState.libraryCache.rebuild(container: persistenceController.container)
+                        await appState.librarySyncManager.syncIfStale(
+                            client: appState.subsonicClient,
+                            container: persistenceController.container
+                        )
+                        appState.libraryCache.rebuild(container: persistenceController.container)
+                        appState.librarySyncManager.startPolling(
+                            client: appState.subsonicClient,
+                            container: persistenceController.container
+                        )
+                        await appState.librarySyncManager.warmImageCache(
+                            client: appState.subsonicClient,
+                            container: persistenceController.container
+                        )
+                    }
                 }
                 .onOpenURL { url in
                     handleDeepLink(url)
@@ -134,6 +150,25 @@ struct VibrdromeApp: App {
                     ImagePipeline.shared = ImagePipeline(configuration: .withDataCache(name: "com.vibrdrome.images"))
                     RemoteCommandManager.shared.setup()
                     DownloadManager.shared.resumeIncompleteDownloads()
+                    BackgroundSyncScheduler.shared.registerTasks()
+                    BackgroundSyncScheduler.shared.scheduleRefresh()
+                    BackgroundSyncScheduler.shared.scheduleFullSync()
+                    Task {
+                        appState.libraryCache.rebuild(container: persistenceController.container)
+                        await appState.librarySyncManager.syncIfStale(
+                            client: appState.subsonicClient,
+                            container: persistenceController.container
+                        )
+                        appState.libraryCache.rebuild(container: persistenceController.container)
+                        appState.librarySyncManager.startPolling(
+                            client: appState.subsonicClient,
+                            container: persistenceController.container
+                        )
+                        await appState.librarySyncManager.warmImageCache(
+                            client: appState.subsonicClient,
+                            container: persistenceController.container
+                        )
+                    }
                 }
                 .onOpenURL { url in
                     handleDeepLink(url)

--- a/VibrdromeTests/Core/LibrarySyncTests.swift
+++ b/VibrdromeTests/Core/LibrarySyncTests.swift
@@ -1,0 +1,238 @@
+import Testing
+import Foundation
+@testable import Vibrdrome
+
+/// Tests for library sync infrastructure: SyncMode, SyncStats,
+/// CachedAlbum/CachedArtist round-trip conversions, and update detection.
+struct LibrarySyncTests {
+
+    // MARK: - SyncMode
+
+    @Test func syncModeRawValues() {
+        #expect(SyncMode.full.rawValue == "full")
+        #expect(SyncMode.incremental.rawValue == "incremental")
+        #expect(SyncMode.background.rawValue == "background")
+    }
+
+    // MARK: - SyncStats
+
+    @Test func syncStatsTotalChangesEmpty() {
+        let stats = LibrarySyncManager.SyncStats()
+        #expect(stats.totalChanges == 0)
+    }
+
+    @Test func syncStatsTotalChangesAggregatesAll() {
+        var stats = LibrarySyncManager.SyncStats()
+        stats.albumsAdded = 5
+        stats.albumsUpdated = 3
+        stats.albumsRemoved = 1
+        stats.artistsAdded = 10
+        stats.artistsUpdated = 2
+        stats.artistsRemoved = 0
+        stats.songsAdded = 100
+        stats.songsUpdated = 20
+        stats.songsRemoved = 5
+        #expect(stats.totalChanges == 146)
+    }
+
+    @Test func syncStatsDuration() throws {
+        let stats = LibrarySyncManager.SyncStats()
+        // Duration is time since startTime, should be >= 0
+        #expect(stats.duration >= 0)
+    }
+
+    // MARK: - CachedAlbum Round-Trip
+
+    @Test func cachedAlbumRoundTripPreservesId() {
+        let album = makeAlbum(id: "alb-1")
+        let cached = CachedAlbum(from: album)
+        let restored = cached.toAlbum()
+        #expect(restored.id == "alb-1")
+    }
+
+    @Test func cachedAlbumRoundTripPreservesName() {
+        let album = makeAlbum(name: "OK Computer")
+        let cached = CachedAlbum(from: album)
+        let restored = cached.toAlbum()
+        #expect(restored.name == "OK Computer")
+    }
+
+    @Test func cachedAlbumRoundTripPreservesArtist() {
+        let album = makeAlbum(artist: "Radiohead")
+        let cached = CachedAlbum(from: album)
+        let restored = cached.toAlbum()
+        #expect(restored.artist == "Radiohead")
+    }
+
+    @Test func cachedAlbumRoundTripPreservesYear() {
+        let album = makeAlbum(year: 1997)
+        let cached = CachedAlbum(from: album)
+        let restored = cached.toAlbum()
+        #expect(restored.year == 1997)
+    }
+
+    @Test func cachedAlbumRoundTripPreservesGenre() {
+        let album = makeAlbum(genre: "Alternative Rock")
+        let cached = CachedAlbum(from: album)
+        let restored = cached.toAlbum()
+        #expect(restored.genre == "Alternative Rock")
+    }
+
+    @Test func cachedAlbumStarredConversion() {
+        let starred = makeAlbum(starred: "2024-01-01T00:00:00Z")
+        let cachedStarred = CachedAlbum(from: starred)
+        #expect(cachedStarred.isStarred == true)
+        #expect(cachedStarred.toAlbum().starred == "true")
+
+        let unstarred = makeAlbum(starred: nil)
+        let cachedUnstarred = CachedAlbum(from: unstarred)
+        #expect(cachedUnstarred.isStarred == false)
+        #expect(cachedUnstarred.toAlbum().starred == nil)
+    }
+
+    @Test func cachedAlbumRoundTripPreservesRating() {
+        let album = makeAlbum(userRating: 4)
+        let cached = CachedAlbum(from: album)
+        let restored = cached.toAlbum()
+        #expect(restored.userRating == 4)
+    }
+
+    @Test func cachedAlbumRoundTripNilRatingBecomesNil() {
+        let album = makeAlbum(userRating: nil)
+        let cached = CachedAlbum(from: album)
+        #expect(cached.userRating == 0)
+        let restored = cached.toAlbum()
+        #expect(restored.userRating == nil)
+    }
+
+    @Test func cachedAlbumRoundTripPreservesLabel() {
+        let album = makeAlbum(label: "XL Recordings")
+        let cached = CachedAlbum(from: album)
+        let restored = cached.toAlbum()
+        #expect(restored.label == "XL Recordings")
+    }
+
+    @Test func cachedAlbumUpdateAppliesChanges() {
+        let original = makeAlbum(id: "alb-1", name: "Old Name", year: 2020)
+        let cached = CachedAlbum(from: original)
+
+        let updated = makeAlbum(id: "alb-1", name: "New Name", year: 2024, genre: "Electronic")
+        cached.update(from: updated)
+
+        #expect(cached.name == "New Name")
+        #expect(cached.year == 2024)
+        #expect(cached.genre == "Electronic")
+    }
+
+    @Test func cachedAlbumUpdatePreservesIdOnMismatch() {
+        // update(from:) doesn't change ID — it's the caller's responsibility to match
+        let cached = CachedAlbum(from: makeAlbum(id: "alb-1"))
+        cached.update(from: makeAlbum(id: "alb-2", name: "Different"))
+        #expect(cached.id == "alb-1")
+        #expect(cached.name == "Different")
+    }
+
+    // MARK: - CachedArtist Round-Trip
+
+    @Test func cachedArtistRoundTripPreservesId() {
+        let artist = makeArtist(id: "art-1")
+        let cached = CachedArtist(from: artist)
+        let restored = cached.toArtist()
+        #expect(restored.id == "art-1")
+    }
+
+    @Test func cachedArtistRoundTripPreservesName() {
+        let artist = makeArtist(name: "Boards of Canada")
+        let cached = CachedArtist(from: artist)
+        let restored = cached.toArtist()
+        #expect(restored.name == "Boards of Canada")
+    }
+
+    @Test func cachedArtistRoundTripPreservesAlbumCount() {
+        let artist = makeArtist(albumCount: 7)
+        let cached = CachedArtist(from: artist)
+        let restored = cached.toArtist()
+        #expect(restored.albumCount == 7)
+    }
+
+    @Test func cachedArtistStarredConversion() {
+        let starred = makeArtist(starred: "2024-06-01T12:00:00Z")
+        let cached = CachedArtist(from: starred)
+        #expect(cached.isStarred == true)
+
+        let unstarred = makeArtist(starred: nil)
+        let cachedU = CachedArtist(from: unstarred)
+        #expect(cachedU.isStarred == false)
+    }
+
+    // MARK: - SyncHistory
+
+    @Test func syncHistoryTotalChanges() {
+        let history = SyncHistory(syncType: "full")
+        history.albumsAdded = 10
+        history.songsAdded = 100
+        history.artistsUpdated = 5
+        #expect(history.totalChanges == 115)
+    }
+
+    @Test func syncHistorySummaryNoChanges() {
+        let history = SyncHistory(syncType: "incremental")
+        #expect(history.summary == "No changes")
+    }
+
+    @Test func syncHistorySummaryWithChanges() {
+        let history = SyncHistory(syncType: "full")
+        history.albumsAdded = 5
+        history.songsUpdated = 10
+        history.artistsRemoved = 2
+        let summary = history.summary
+        #expect(summary.contains("+5"))
+        #expect(summary.contains("~10"))
+        #expect(summary.contains("-2"))
+    }
+
+    @Test func syncHistorySummaryOnFailure() {
+        let history = SyncHistory(syncType: "full")
+        history.succeeded = false
+        history.errorMessage = "Connection timeout"
+        #expect(history.summary == "Failed: Connection timeout")
+    }
+
+    // MARK: - Helpers
+
+    private func makeAlbum(
+        id: String = "test",
+        name: String = "Test Album",
+        artist: String? = nil,
+        artistId: String? = nil,
+        year: Int? = nil,
+        genre: String? = nil,
+        songCount: Int? = nil,
+        duration: Int? = nil,
+        starred: String? = nil,
+        userRating: Int? = nil,
+        label: String? = nil
+    ) -> Album {
+        Album(
+            id: id, name: name, artist: artist, artistId: artistId,
+            coverArt: nil, songCount: songCount, duration: duration,
+            year: year, genre: genre, starred: starred, created: nil,
+            userRating: userRating, song: nil, replayGain: nil,
+            musicBrainzId: nil,
+            recordLabels: label.map { [RecordLabel(name: $0)] }
+        )
+    }
+
+    private func makeArtist(
+        id: String = "test",
+        name: String = "Test Artist",
+        coverArt: String? = nil,
+        albumCount: Int? = nil,
+        starred: String? = nil
+    ) -> Artist {
+        Artist(
+            id: id, name: name, coverArt: coverArt,
+            albumCount: albumCount, starred: starred, album: nil
+        )
+    }
+}

--- a/VibrdromeTests/Core/SubsonicModelsTests.swift
+++ b/VibrdromeTests/Core/SubsonicModelsTests.swift
@@ -142,6 +142,15 @@ struct SubsonicModelsTests {
         #expect(album.song?.count == 2)
         #expect(album.song?[0].title == "Airbag")
         #expect(album.song?[1].title == "Paranoid Android")
+        #expect(album.userRating == nil)
+    }
+
+    @Test func albumWithUserRating() throws {
+        let json = """
+        {"id":"al-r","name":"Rated Album","userRating":4}
+        """.data(using: .utf8)!
+        let album = try JSONDecoder().decode(Album.self, from: json)
+        #expect(album.userRating == 4)
     }
 
     @Test func albumWithSongArrayOmitted() throws {

--- a/VibrdromeTests/Features/LibraryFilterTests.swift
+++ b/VibrdromeTests/Features/LibraryFilterTests.swift
@@ -1,0 +1,149 @@
+import Testing
+@testable import Vibrdrome
+
+struct LibraryFilterTests {
+
+    // MARK: - TriState
+
+    @Test func triStateAllCases() {
+        #expect(TriState.allCases == [.none, .yes, .no])
+    }
+
+    @Test func triStateRawValues() {
+        #expect(TriState.none.rawValue == "none")
+        #expect(TriState.yes.rawValue == "yes")
+        #expect(TriState.no.rawValue == "no")
+    }
+
+    // MARK: - TriState.matches
+
+    @Test func triStateNoneMatchesAnything() {
+        #expect(TriState.none.matches(true))
+        #expect(TriState.none.matches(false))
+    }
+
+    @Test func triStateYesMatchesTrueOnly() {
+        #expect(TriState.yes.matches(true))
+        #expect(!TriState.yes.matches(false))
+    }
+
+    @Test func triStateNoMatchesFalseOnly() {
+        #expect(TriState.no.matches(false))
+        #expect(!TriState.no.matches(true))
+    }
+
+    // MARK: - LibraryFilter initial state
+
+    @Test func initialStateIsInactive() {
+        let filter = LibraryFilter()
+        #expect(!filter.isActive)
+        #expect(filter.activeFilterCount == 0)
+        #expect(filter.isFavorited == .none)
+        #expect(filter.isRated == .none)
+        #expect(!filter.isRecentlyPlayed)
+        #expect(filter.selectedArtistIds.isEmpty)
+        #expect(filter.selectedGenres.isEmpty)
+        #expect(filter.selectedLabels.isEmpty)
+        #expect(filter.year == nil)
+    }
+
+    // MARK: - isActive detection
+
+    @Test func isActiveWhenFavoritedSet() {
+        let filter = LibraryFilter()
+        filter.isFavorited = .yes
+        #expect(filter.isActive)
+        #expect(filter.activeFilterCount == 1)
+    }
+
+    @Test func isActiveWhenRatedSet() {
+        let filter = LibraryFilter()
+        filter.isRated = .no
+        #expect(filter.isActive)
+        #expect(filter.activeFilterCount == 1)
+    }
+
+    @Test func isActiveWhenRecentlyPlayedSet() {
+        let filter = LibraryFilter()
+        filter.isRecentlyPlayed = true
+        #expect(filter.isActive)
+        #expect(filter.activeFilterCount == 1)
+    }
+
+    @Test func isActiveWhenArtistsSelected() {
+        let filter = LibraryFilter()
+        filter.selectedArtistIds = ["artist-1"]
+        #expect(filter.isActive)
+        #expect(filter.activeFilterCount == 1)
+    }
+
+    @Test func isActiveWhenGenresSelected() {
+        let filter = LibraryFilter()
+        filter.selectedGenres = ["Electronic", "Jazz"]
+        #expect(filter.isActive)
+        #expect(filter.activeFilterCount == 1)
+    }
+
+    @Test func isActiveWhenLabelsSelected() {
+        let filter = LibraryFilter()
+        filter.selectedLabels = ["Sony Music"]
+        #expect(filter.isActive)
+        #expect(filter.activeFilterCount == 1)
+    }
+
+    @Test func isActiveWhenYearSet() {
+        let filter = LibraryFilter()
+        filter.year = 2024
+        #expect(filter.isActive)
+        #expect(filter.activeFilterCount == 1)
+    }
+
+    // MARK: - activeFilterCount with multiple filters
+
+    @Test func multipleFiltersCountCorrectly() {
+        let filter = LibraryFilter()
+        filter.isFavorited = .yes
+        filter.isRated = .yes
+        filter.isRecentlyPlayed = true
+        filter.selectedArtistIds = ["a1"]
+        filter.selectedGenres = ["Rock"]
+        filter.selectedLabels = ["Atlantic"]
+        filter.year = 2020
+        #expect(filter.activeFilterCount == 7)
+    }
+
+    // MARK: - Reset
+
+    @Test func resetClearsAllFilters() {
+        let filter = LibraryFilter()
+        filter.isFavorited = .yes
+        filter.isRated = .no
+        filter.isRecentlyPlayed = true
+        filter.selectedArtistIds = ["a1", "a2"]
+        filter.selectedGenres = ["Rock"]
+        filter.selectedLabels = ["Def Jam"]
+        filter.year = 1997
+
+        filter.reset()
+
+        #expect(!filter.isActive)
+        #expect(filter.activeFilterCount == 0)
+        #expect(filter.isFavorited == .none)
+        #expect(filter.isRated == .none)
+        #expect(!filter.isRecentlyPlayed)
+        #expect(filter.selectedArtistIds.isEmpty)
+        #expect(filter.selectedGenres.isEmpty)
+        #expect(filter.selectedLabels.isEmpty)
+        #expect(filter.year == nil)
+    }
+
+    // MARK: - TriState none does not count as active
+
+    @Test func triStateNoneIsNotActive() {
+        let filter = LibraryFilter()
+        filter.isFavorited = .none
+        filter.isRated = .none
+        #expect(!filter.isActive)
+        #expect(filter.activeFilterCount == 0)
+    }
+}


### PR DESCRIPTION
Hinges on #22 
Adds a "Labels" section to the macOS sidebar that lets users browse albums by record label.

**Changes**
New: LabelsView.swift — Displays all record labels derived from the SwiftData CachedAlbum cache, with list/grid toggle, search, and sort (name / album count). Each label shows a cover art thumbnail from one of its albums.
Modified: AlbumsView.swift — Added label: String? parameter. When set, albums are loaded from SwiftData cache filtered by label (no Subsonic API endpoint exists for labels).
Modified: SidebarContentView.swift — Added labels case to SidebarItem and a sidebar entry wrapped in #if os(macOS).
**Scope**
macOS only — no changes to the iOS tab bar, settings, or UserDefaults keys.
Requires a library sync to populate label data from album metadata.
