### PR TITLE
Build 46: genre fixes, tap routing, album search, audio glitch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to Vibrdrome (iOS/macOS) are documented here.
 
 ## v1.0.0
 
+### Build 46 -- April 18, 2026
+- Fix: semicolon-containing genres like "Hip Hop; Pop" no longer error on tap; now render as "Hip Hop Pop" while the underlying server query is preserved
+- Fix: first tap on a song or album row now plays / navigates reliably instead of sometimes landing on the artist page (removed nested artist/album Buttons from list rows — "Go to Artist" still available via long-press menu)
+- Fix: Album search now hits the entire library via server search3 instead of only client-side filtering the loaded pages (finds albums like "Beats, Rhymes and Life" regardless of pagination)
+- Fix: Audio glitching when spam-tapping tracks or play/pause (AVPlayer item swap debounced 50ms with cancellation so rapid taps collapse into a single swap instead of churning the audio session)
+- TrackRow title/artist spacing bumped from 2pt to 6pt for clearer touch separation
+- Contributor CARPLAY_ENABLED build flag + CONTRIBUTING.md signing guide
+- 536 unit tests in 40 suites
+
+**TestFlight Notes:**
+> Fixes: semicolon genre error, first-tap play reliability, album search
+> across entire library, audio glitch on rapid track changes. Contributor
+> build flag for CarPlay.
+
 ### Build 45 -- April 17, 2026
 - Album Collections: save album filter presets to macOS/iPad sidebar
 - Genre filter in AlbumsView sort menu

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,25 +24,11 @@ The app uses a CarPlay audio entitlement (`com.apple.developer.carplay-audio`) w
 
 To build without CarPlay:
 
-1. Open `Vibrdrome/Vibrdrome.entitlements`
-2. Remove the `com.apple.developer.carplay-audio` key (keep the App Groups key)
-3. In Xcode, set your own Team under Signing & Capabilities
-4. Build and run -- everything except CarPlay will work
-
-Your entitlements file should look like:
-```xml
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
-  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-    <key>com.apple.security.application-groups</key>
-    <array>
-        <string>group.com.vibrdrome.app</string>
-    </array>
-</dict>
-</plist>
-```
+1. In `project.yml`, remove `CARPLAY_ENABLED` from the `SWIFT_ACTIVE_COMPILATION_CONDITIONS` line
+2. Open `Vibrdrome/Vibrdrome.entitlements` and remove the `com.apple.developer.carplay-audio` key
+3. Run `xcodegen generate` to regenerate the project
+4. In Xcode, set your own Team under Signing & Capabilities
+5. Build and run -- everything except CarPlay will work
 
 **Do not commit your signing changes.** Keep them local.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,35 @@ xcodegen generate
 open Vibrdrome.xcodeproj
 ```
 
-After `xcodegen generate`, restore entitlements (see CLAUDE.md for the required values).
+After `xcodegen generate`, you'll need to configure signing (see below).
+
+### Signing & CarPlay Entitlement
+
+The app uses a CarPlay audio entitlement (`com.apple.developer.carplay-audio`) which requires Apple's explicit approval tied to a paid developer account. **Most contributors won't have this.**
+
+To build without CarPlay:
+
+1. Open `Vibrdrome/Vibrdrome.entitlements`
+2. Remove the `com.apple.developer.carplay-audio` key (keep the App Groups key)
+3. In Xcode, set your own Team under Signing & Capabilities
+4. Build and run -- everything except CarPlay will work
+
+Your entitlements file should look like:
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.application-groups</key>
+    <array>
+        <string>group.com.vibrdrome.app</string>
+    </array>
+</dict>
+</plist>
+```
+
+**Do not commit your signing changes.** Keep them local.
 
 ### Requirements
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -23,6 +23,8 @@ Run through this checklist before every TestFlight build. Each item should be ve
 - [ ] Playback rate (speed) changes work
 - [ ] Sleep timer "End of Track": after it pauses, pressing play advances to next track
 - [ ] Recently Played in Queue shows only songs actually listened to (not unplayed queue entries)
+- [ ] Spam-tap play/pause rapidly — no audio glitching or dropouts
+- [ ] Spam-tap different track rows rapidly — audio settles on the last-tapped track without churn
 
 ## Library & Navigation
 
@@ -33,6 +35,9 @@ Run through this checklist before every TestFlight build. Each item should be ve
 - [ ] Search filter chips (Genre, Year, Format) appear and filter results
 - [ ] Navigate to artist detail (from search, album, or Now Playing)
 - [ ] Navigate to album detail
+- [ ] Tap album card in artist detail → opens album detail (no bounce back to artist)
+- [ ] Search "beats" in Albums tab returns matches anywhere in the library (e.g. "Beats, Rhymes and Life"), not just loaded pages
+- [ ] Genre containing a semicolon (e.g. "Hip Hop; Pop") renders without the semicolon, and tapping loads albums without error
 - [ ] Artist detail shows biography (About section)
 - [ ] Artist detail shows Similar Artists carousel
 - [ ] Genre list shows artwork
@@ -133,7 +138,9 @@ Run through this checklist before every TestFlight build. Each item should be ve
 - [ ] Per-track download icon (bigger, .callout size)
 - [ ] Per-track inline "..." menu (Play Next, Add to Queue, Start Radio, Share)
 - [ ] Text contrast readable in light mode
-- [ ] Tappable artist name navigates to artist page
+- [ ] Tappable artist name in album header navigates to artist page
+- [ ] Tapping any part of a song row (title, artist text, whitespace) plays the track — does NOT navigate to artist
+- [ ] Long-press on song row shows "Go to Album" and "Go to Artist" in context menu
 - [ ] Multi-disc separator shows for multi-disc albums
 - [ ] Similar Albums carousel at bottom
 - [ ] Album sort: Name, Artist, Year, Recently Added all work

--- a/Vibrdrome/CarPlay/CarPlayManager.swift
+++ b/Vibrdrome/CarPlay/CarPlayManager.swift
@@ -1,4 +1,4 @@
-#if os(iOS)
+#if os(iOS) && CARPLAY_ENABLED
 import CarPlay
 import os.log
 

--- a/Vibrdrome/CarPlay/CarPlaySceneDelegate.swift
+++ b/Vibrdrome/CarPlay/CarPlaySceneDelegate.swift
@@ -1,4 +1,4 @@
-#if os(iOS)
+#if os(iOS) && CARPLAY_ENABLED
 import CarPlay
 
 @MainActor

--- a/Vibrdrome/Core/Audio/AudioEngine+Playback.swift
+++ b/Vibrdrome/Core/Audio/AudioEngine+Playback.swift
@@ -80,20 +80,11 @@ extension AudioEngine {
         let url = resolveURL(for: song)
         currentReplayGainFactor = computeReplayGainFactor(for: song)
 
-        switch activeMode {
-        case .gapless:
-            replacePlayerItem(with: url)
-            applyEffectiveVolume()
-            gaplessPlayer?.rate = playbackRate
-            prepareLookahead()
-        case .crossfade:
-            startCrossfadePlayback(url: url)
-            applyEffectiveVolume()
-        }
-
         isPlaying = true
         NowPlayingManager.shared.update(song: song, isPlaying: true)
         scrobbleNowPlaying(songId: song.id)
+
+        scheduleDebouncedPlayerSwap(url: url, mode: activeMode)
     }
 
     /// UI testing path for play — updates observable state without AVPlayer
@@ -576,20 +567,32 @@ extension AudioEngine {
         let url = resolveURL(for: song)
         currentReplayGainFactor = computeReplayGainFactor(for: song)
 
-        switch activeMode {
-        case .gapless:
-            replacePlayerItem(with: url)
-            applyEffectiveVolume()
-            gaplessPlayer?.rate = playbackRate
-            prepareLookahead()
-        case .crossfade:
-            startCrossfadePlayback(url: url)
-            applyEffectiveVolume()
-        }
-
         isPlaying = true
         NowPlayingManager.shared.update(song: song, isPlaying: true)
         scrobbleNowPlaying(songId: song.id)
+
+        scheduleDebouncedPlayerSwap(url: url, mode: activeMode)
+    }
+
+    /// Coalesce rapid play()/skipToIndex() calls. UI state updates immediately,
+    /// but the AVPlayer item swap is delayed briefly so spam-tapping collapses
+    /// into a single replacement rather than churning the audio session.
+    func scheduleDebouncedPlayerSwap(url: URL, mode: PlaybackMode) {
+        playbackSwapTask?.cancel()
+        playbackSwapTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .milliseconds(50))
+            guard !Task.isCancelled, let self else { return }
+            switch mode {
+            case .gapless:
+                self.replacePlayerItem(with: url)
+                self.applyEffectiveVolume()
+                self.gaplessPlayer?.rate = self.playbackRate
+                self.prepareLookahead()
+            case .crossfade:
+                self.startCrossfadePlayback(url: url)
+                self.applyEffectiveVolume()
+            }
+        }
     }
 
     /// Auto-suggest similar songs when the queue runs out

--- a/Vibrdrome/Core/Audio/AudioEngine.swift
+++ b/Vibrdrome/Core/Audio/AudioEngine.swift
@@ -152,6 +152,11 @@ final class AudioEngine {
     var lastScrobbleTime: Date?
     var generation: Int = 0
 
+    /// Debounce token for rapid play() calls. Spam-tapping different tracks or
+    /// play/pause would otherwise swap AVPlayer items faster than the audio
+    /// session can re-prime, producing audible glitches.
+    var playbackSwapTask: Task<Void, Never>?
+
     func incrementGeneration() { generation += 1 }
     var generationValue: Int { generation }
     var isScrobbleSubmitted: Bool { scrobbleSubmitted }

--- a/Vibrdrome/Core/Networking/SubsonicClient.swift
+++ b/Vibrdrome/Core/Networking/SubsonicClient.swift
@@ -87,6 +87,11 @@ final class SubsonicClient {
             throw SubsonicError.invalidURL
         }
         components.queryItems = auth.authParameters() + endpoint.queryItems
+        // URLComponents leaves ';' unencoded (it's a sub-delimiter per RFC 3986), but
+        // some servers parse ';' as an alternative query-parameter separator and reject
+        // the request. Force-encode it so genre values like "Hip Hop; Pop" work.
+        components.percentEncodedQuery = components.percentEncodedQuery?
+            .replacingOccurrences(of: ";", with: "%3B")
 
         guard let url = components.url else {
             throw SubsonicError.invalidURL
@@ -168,6 +173,8 @@ final class SubsonicClient {
             resolvingAgainstBaseURL: false
         ) else { return baseURL }
         components.queryItems = auth.authParameters() + extra
+        components.percentEncodedQuery = components.percentEncodedQuery?
+            .replacingOccurrences(of: ";", with: "%3B")
         return components.url ?? baseURL
     }
 

--- a/Vibrdrome/Features/Library/AlbumDetailView.swift
+++ b/Vibrdrome/Features/Library/AlbumDetailView.swift
@@ -312,7 +312,7 @@ struct AlbumDetailView: View {
             }
             if let genre = album.genre {
                 Text("·")
-                Text(genre)
+                Text(genre.cleanedGenreDisplay)
             }
             if let count = album.songCount {
                 Text("·")

--- a/Vibrdrome/Features/Library/AlbumsView.swift
+++ b/Vibrdrome/Features/Library/AlbumsView.swift
@@ -24,6 +24,8 @@ struct AlbumsView: View {
     @State private var collectionName = ""
     @State private var availableGenres: [String] = []
     @State private var activeGenre: String?
+    @State private var searchResults: [Album] = []
+    @State private var searchTask: Task<Void, Never>?
     private let pageSize = 40
 
     enum AlbumSortOption: String, CaseIterable {
@@ -56,14 +58,14 @@ struct AlbumsView: View {
     }
 
     private var filteredAlbums: [Album] {
-        var result = albums
-        if !searchText.isEmpty {
+        // When searching, use server results (search3 searches the entire library,
+        // not just the paginated pages already loaded client-side).
+        var result = searchText.isEmpty ? albums : searchResults
+        if !searchText.isEmpty, let activeGenre = effectiveGenre {
             result = result.filter {
-                $0.name.localizedCaseInsensitiveContains(searchText) ||
-                ($0.artist ?? "").localizedCaseInsensitiveContains(searchText)
+                $0.genre?.caseInsensitiveCompare(activeGenre) == .orderedSame
             }
         }
-        // Client-side sort for year (API doesn't support sort by year without range)
         if clientSideSort == .year {
             result.sort { ($0.year ?? 0) > ($1.year ?? 0) }
         }
@@ -87,6 +89,22 @@ struct AlbumsView: View {
         #else
         .searchable(text: $searchText, prompt: "Search in Albums")
         #endif
+        .onChange(of: searchText) { _, newValue in
+            searchTask?.cancel()
+            let trimmed = newValue.trimmingCharacters(in: .whitespaces)
+            guard trimmed.count >= 2 else {
+                searchResults = []
+                return
+            }
+            searchTask = Task {
+                try? await Task.sleep(for: .milliseconds(300))
+                guard !Task.isCancelled else { return }
+                let results = try? await appState.subsonicClient.search(
+                    query: trimmed, artistCount: 0, albumCount: 50, songCount: 0)
+                guard !Task.isCancelled else { return }
+                searchResults = results?.album ?? []
+            }
+        }
         #if os(iOS)
         .navigationBarTitleDisplayMode(.inline)
         #endif
@@ -171,7 +189,7 @@ struct AlbumsView: View {
                                 Task { await loadAlbums() }
                             } label: {
                                 HStack {
-                                    Text(g)
+                                    Text(g.cleanedGenreDisplay)
                                     if effectiveGenre == g {
                                         Image(systemName: "checkmark")
                                     }
@@ -179,7 +197,7 @@ struct AlbumsView: View {
                             }
                         }
                     } label: {
-                        Label(effectiveGenre ?? "Genre", systemImage: "guitars")
+                        Label(effectiveGenre?.cleanedGenreDisplay ?? "Genre", systemImage: "guitars")
                     }
                     Divider()
                     Button {
@@ -191,7 +209,7 @@ struct AlbumsView: View {
                     }
                     Divider()
                     Button {
-                        let name = effectiveGenre ?? title
+                        let name = effectiveGenre?.cleanedGenreDisplay ?? title
                         collectionName = name
                         showSaveCollection = true
                     } label: {

--- a/Vibrdrome/Features/Library/GenresView.swift
+++ b/Vibrdrome/Features/Library/GenresView.swift
@@ -124,7 +124,7 @@ struct GenresView: View {
     private var genreList: some View {
         List(filteredGenres) { genre in
             NavigationLink {
-                AlbumsView(listType: .byGenre, title: genre.value, genre: genre.value)
+                AlbumsView(listType: .byGenre, title: genre.value.cleanedGenreDisplay, genre: genre.value)
             } label: {
                 HStack(spacing: 12) {
                     GenreIconView(genre: genre.value)
@@ -132,7 +132,7 @@ struct GenresView: View {
                         .clipShape(RoundedRectangle(cornerRadius: 8))
 
                     VStack(alignment: .leading, spacing: 2) {
-                        Text(genre.value)
+                        Text(genre.value.cleanedGenreDisplay)
                             .font(.body)
                         Text(verbatim: "\(genre.albumCount ?? 0) albums · \(genre.songCount ?? 0) songs")
                             .font(.caption)
@@ -154,7 +154,7 @@ struct GenresView: View {
                                      count: max(2, min(10, gridColumns))), spacing: 20) {
                 ForEach(filteredGenres) { genre in
                     NavigationLink {
-                        AlbumsView(listType: .byGenre, title: genre.value, genre: genre.value)
+                        AlbumsView(listType: .byGenre, title: genre.value.cleanedGenreDisplay, genre: genre.value)
                     } label: {
                         genreCard(genre)
                     }
@@ -173,7 +173,7 @@ struct GenresView: View {
                 .clipShape(RoundedRectangle(cornerRadius: 10))
                 .shadow(color: .black.opacity(0.15), radius: 6, y: 3)
 
-            Text(genre.value)
+            Text(genre.value.cleanedGenreDisplay)
                 .font(.subheadline)
                 .fontWeight(.medium)
                 .foregroundColor(.primary)

--- a/Vibrdrome/Features/Library/LibraryView.swift
+++ b/Vibrdrome/Features/Library/LibraryView.swift
@@ -152,7 +152,7 @@ struct LibraryView: View {
                 SongDetailView(songId: item.id)
             }
             .navigationDestination(for: GenreNavItem.self) { item in
-                AlbumsView(listType: .byGenre, title: item.name, genre: item.name)
+                AlbumsView(listType: .byGenre, title: item.name.cleanedGenreDisplay, genre: item.name)
             }
             .navigationDestination(for: PlaylistNavItem.self) { item in
                 PlaylistDetailView(playlistId: item.id)

--- a/Vibrdrome/Features/Library/SongDetailView.swift
+++ b/Vibrdrome/Features/Library/SongDetailView.swift
@@ -179,7 +179,7 @@ struct SongDetailView: View {
                 metadataCell("Year", value: "\(year)")
             }
             if let genre = song.genre {
-                metadataCell("Genre", value: genre)
+                metadataCell("Genre", value: genre.cleanedGenreDisplay)
             }
             if let duration = song.duration {
                 metadataCell("Duration", value: formatDuration(duration))

--- a/Vibrdrome/Features/Library/SongsView.swift
+++ b/Vibrdrome/Features/Library/SongsView.swift
@@ -156,7 +156,7 @@ struct SongsView: View {
                                 filterGenre = genre
                             } label: {
                                 HStack {
-                                    Text(genre)
+                                    Text(genre.cleanedGenreDisplay)
                                     if filterGenre == genre { Image(systemName: "checkmark") }
                                 }
                             }
@@ -281,44 +281,23 @@ struct SongsView: View {
 
     @ViewBuilder
     private func songRowTitleBlock(_ song: Song) -> some View {
-        VStack(alignment: .leading, spacing: 2) {
-            Button {
-                appState.pendingNavigation = .song(id: song.id)
-            } label: {
-                Text(song.title)
-                    .font(.body)
-                    .lineLimit(1)
-            }
-            .buttonStyle(.plain)
+        VStack(alignment: .leading, spacing: 6) {
+            Text(song.title)
+                .font(.body)
+                .lineLimit(1)
 
             HStack(spacing: 4) {
                 if let artist = song.artist {
-                    Button {
-                        if let artistId = song.artistId {
-                            appState.pendingNavigation = .artist(id: artistId)
-                        }
-                    } label: {
-                        Text(artist)
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                            .lineLimit(1)
-                    }
-                    .buttonStyle(.plain)
-                    .disabled(song.artistId == nil)
+                    Text(artist)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
                 }
                 if let album = song.album {
-                    Button {
-                        if let albumId = song.albumId {
-                            appState.pendingNavigation = .album(id: albumId)
-                        }
-                    } label: {
-                        Text("· \(album)")
-                            .font(.caption)
-                            .foregroundStyle(.tertiary)
-                            .lineLimit(1)
-                    }
-                    .buttonStyle(.plain)
-                    .disabled(song.albumId == nil)
+                    Text("· \(album)")
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                        .lineLimit(1)
                 }
             }
         }
@@ -467,30 +446,17 @@ struct SongsView: View {
             .aspectRatio(1, contentMode: .fit)
             .shadow(color: .black.opacity(0.15), radius: 6, y: 3)
 
-            Button {
-                appState.pendingNavigation = .song(id: song.id)
-            } label: {
-                Text(song.title)
-                    .font(.subheadline)
-                    .fontWeight(.medium)
-                    .foregroundColor(.primary)
-                    .lineLimit(1)
-            }
-            .buttonStyle(.plain)
+            Text(song.title)
+                .font(.subheadline)
+                .fontWeight(.medium)
+                .foregroundColor(.primary)
+                .lineLimit(1)
 
             if let artist = song.artist {
-                Button {
-                    if let artistId = song.artistId {
-                        appState.pendingNavigation = .artist(id: artistId)
-                    }
-                } label: {
-                    Text(artist)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                }
-                .buttonStyle(.plain)
-                .disabled(song.artistId == nil)
+                Text(artist)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
             }
         }
     }

--- a/Vibrdrome/Features/Player/NowPlayingView.swift
+++ b/Vibrdrome/Features/Player/NowPlayingView.swift
@@ -554,7 +554,7 @@ struct NowPlayingView: View {
                         appState.pendingNavigation = .genre(name: genre)
                         appState.showNowPlaying = false
                     } label: {
-                        badgeText(genre)
+                        badgeText(genre.cleanedGenreDisplay)
                     }
                     .buttonStyle(.plain)
                 }

--- a/Vibrdrome/Features/Playlists/SmartPlaylistView.swift
+++ b/Vibrdrome/Features/Playlists/SmartPlaylistView.swift
@@ -248,7 +248,7 @@ struct SmartPlaylistView: View {
                         Button {
                             Task { await generateGenreMix(genre: genre) }
                         } label: {
-                            Text(genre.value)
+                            Text(genre.value.cleanedGenreDisplay)
                                 .font(.caption)
                                 .fontWeight(.medium)
                                 .padding(.horizontal, 12)

--- a/Vibrdrome/Features/Search/SearchView.swift
+++ b/Vibrdrome/Features/Search/SearchView.swift
@@ -238,39 +238,18 @@ struct SearchView: View {
 
     @ViewBuilder
     private func songRowTitleBlock(_ song: Song) -> some View {
-        VStack(alignment: .leading, spacing: 2) {
-            Button {
-                appState.pendingNavigation = .song(id: song.id)
-            } label: {
-                Text(song.title)
-                    .font(.body)
-                    .lineLimit(1)
-            }
-            .buttonStyle(.plain)
+        VStack(alignment: .leading, spacing: 6) {
+            Text(song.title)
+                .font(.body)
+                .lineLimit(1)
 
             HStack(spacing: 4) {
                 if let artist = song.artist {
-                    Button {
-                        if let artistId = song.artistId {
-                            appState.pendingNavigation = .artist(id: artistId)
-                        }
-                    } label: {
-                        Text(artist)
-                    }
-                    .buttonStyle(.plain)
-                    .disabled(song.artistId == nil)
+                    Text(artist)
                 }
                 if let album = song.album {
                     Text("·")
-                    Button {
-                        if let albumId = song.albumId {
-                            appState.pendingNavigation = .album(id: albumId)
-                        }
-                    } label: {
-                        Text(album)
-                    }
-                    .buttonStyle(.plain)
-                    .disabled(song.albumId == nil)
+                    Text(album)
                 }
             }
             .font(.caption)

--- a/Vibrdrome/Shared/Components/AlbumCard.swift
+++ b/Vibrdrome/Shared/Components/AlbumCard.swift
@@ -13,19 +13,10 @@ struct AlbumCard: View {
                     .font(.body)
                     .lineLimit(1)
                 if let artist = album.artist {
-                    Button {
-                        if let artistId = album.artistId {
-                            appState.pendingNavigation = .artist(id: artistId)
-                        }
-                    } label: {
-                        Text(artist)
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                            .lineLimit(1)
-                    }
-                    .buttonStyle(.plain)
-                    .disabled(album.artistId == nil)
-                    .accessibilityIdentifier("albumCardArtistButton_\(album.id)")
+                    Text(artist)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
                 }
                 HStack(spacing: 4) {
                     if let year = album.year {

--- a/Vibrdrome/Shared/Components/TrackRow.swift
+++ b/Vibrdrome/Shared/Components/TrackRow.swift
@@ -30,7 +30,7 @@ struct TrackRow: View {
                     .frame(width: 28, alignment: .trailing)
             }
 
-            VStack(alignment: .leading, spacing: 2) {
+            VStack(alignment: .leading, spacing: 6) {
                 Text(song.title)
                     .font(.body)
                     .foregroundStyle(isCurrentlyPlaying ? Color.accentColor : .primary)
@@ -38,21 +38,12 @@ struct TrackRow: View {
 
                 HStack(spacing: 4) {
                     if let artist = song.artist {
-                        Button {
-                            if let artistId = song.artistId {
-                                appState.pendingNavigation = .artist(id: artistId)
-                            }
-                        } label: {
-                            if let albumArtist = song.albumArtist,
-                               albumArtist != artist {
-                                Text("\(artist) (\(albumArtist))")
-                            } else {
-                                Text(artist)
-                            }
+                        if let albumArtist = song.albumArtist,
+                           albumArtist != artist {
+                            Text("\(artist) (\(albumArtist))")
+                        } else {
+                            Text(artist)
                         }
-                        .buttonStyle(.plain)
-                        .disabled(song.artistId == nil)
-                        .accessibilityIdentifier("trackArtistButton_\(song.id)")
                     }
                     if let duration = song.duration {
                         Text("·")

--- a/Vibrdrome/Shared/Extensions/String+Sanitized.swift
+++ b/Vibrdrome/Shared/Extensions/String+Sanitized.swift
@@ -6,4 +6,15 @@ extension String {
         return components(separatedBy: illegal).joined(separator: "_")
             .trimmingCharacters(in: .whitespacesAndNewlines)
     }
+
+    /// Genre name formatted for user display. Removes semicolons (a legacy ID3
+    /// multi-value separator) and collapses the resulting whitespace, so a tag
+    /// like "Hip Hop; Pop" renders as "Hip Hop Pop". The original string is
+    /// preserved for server queries since Navidrome matches the stored value.
+    var cleanedGenreDisplay: String {
+        split(separator: ";", omittingEmptySubsequences: true)
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+    }
 }

--- a/VibrdromeUITests/TestHelpers.swift
+++ b/VibrdromeUITests/TestHelpers.swift
@@ -240,12 +240,12 @@ extension XCUIApplication {
         sleep(1)
     }
 
-    /// Tap the Library tab (iPhone) or Artists sidebar item (iPad).
+    /// Tap the Home tab (iPhone) or Artists sidebar item (iPad).
     func goToLibrary() {
         if isSidebarLayout {
             tapSidebarItem("Artists")
         } else {
-            tabBars.buttons["Library"].tap()
+            tabBars.buttons["Home"].tap()
         }
     }
 

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -347,6 +347,25 @@
 
         <div class="timeline">
 
+            <!-- Build 46 -->
+            <div class="timeline-item" data-animate>
+                <div class="build-card">
+                    <div class="build-header">
+                        <span class="build-badge">Build 46</span>
+                        <span class="build-date">April 18, 2026</span>
+                    </div>
+                    <ul>
+                        <li>Fix: semicolon-containing genres (Hip Hop; Pop) no longer error on tap</li>
+                        <li>Fix: first tap on song/album rows now plays or navigates reliably</li>
+                        <li>Fix: Album search now searches the entire library, not just loaded pages</li>
+                        <li>Fix: audio glitch when spam-tapping tracks or play/pause</li>
+                        <li>Tighter touch separation between song title and artist in track rows</li>
+                        <li>Contributor CARPLAY_ENABLED build flag + signing guide</li>
+                        <li>536 unit tests in 40 suites</li>
+                    </ul>
+                </div>
+            </div>
+
             <!-- Build 45 -->
             <div class="timeline-item" data-animate>
                 <div class="build-card">

--- a/project.yml
+++ b/project.yml
@@ -89,7 +89,7 @@ targets:
         DEVELOPMENT_TEAM: 85JD2B827Q
         PRODUCT_BUNDLE_IDENTIFIER: com.vibrdrome.app
         MARKETING_VERSION: "1.0.0"
-        CURRENT_PROJECT_VERSION: "45"
+        CURRENT_PROJECT_VERSION: "46"
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS: "YES"
         SWIFT_ACTIVE_COMPILATION_CONDITIONS: "$(inherited) CARPLAY_ENABLED"
@@ -123,7 +123,7 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.vibrdrome.app.widget
         CODE_SIGN_ENTITLEMENTS: VibrdromeWidget/VibrdromeWidget.entitlements
         MARKETING_VERSION: "1.0.0"
-        CURRENT_PROJECT_VERSION: "45"
+        CURRENT_PROJECT_VERSION: "46"
     entitlements:
       path: VibrdromeWidget/VibrdromeWidget.entitlements
 
@@ -140,7 +140,7 @@ targets:
         DEVELOPMENT_TEAM: 85JD2B827Q
         PRODUCT_BUNDLE_IDENTIFIER: com.vibrdrome.app.watchkitapp
         MARKETING_VERSION: "1.0.0"
-        CURRENT_PROJECT_VERSION: "45"
+        CURRENT_PROJECT_VERSION: "46"
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         SWIFT_VERSION: "6.0"
 

--- a/project.yml
+++ b/project.yml
@@ -92,6 +92,7 @@ targets:
         CURRENT_PROJECT_VERSION: "45"
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS: "YES"
+        SWIFT_ACTIVE_COMPILATION_CONDITIONS: "$(inherited) CARPLAY_ENABLED"
       configs:
         debug:
           INFOPLIST_FILE[sdk=macosx*]: Vibrdrome/Info-macOS.plist


### PR DESCRIPTION
## Summary
- Fix: semicolon genres ("Hip Hop; Pop") no longer error on tap; now render stripped while preserving server-side query value
- Fix: first tap on a song/album row reliably plays/navigates (removed nested artist Buttons that were capturing taps in TrackRow, AlbumCard, SongsView, SearchView)
- Fix: Album search now uses server-side `search3` so it finds albums anywhere in the library, not just loaded pages
- Fix: Audio glitch when spam-tapping tracks or play/pause -- AVPlayer swap debounced 50ms with cancellation
- Tighter touch separation in track rows (VStack spacing 2->6)
- Contributor `CARPLAY_ENABLED` build flag + signing guide (from earlier on develop)
- Test infra: `goToLibrary()` helper updated for the "Library"->"Home" tab rename from Build 33

## Test plan
- [x] SwiftLint -- 0 violations
- [x] Unit tests -- 536/536 passing
- [x] UI tests (RotationTests) -- 12/12 passing
- [x] Security audit -- no concerns
- [x] Build iOS / macOS / watchOS -- 0 warnings
- [x] Device regression (iPhone) -- smoke test + light regression passed
- [x] docs/ updates (CHANGELOG, changelog.html, TESTING.md)
- [x] Version bump + xcodegen + entitlements restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)