### PR TITLE
Build 47: Library tab, favorites rework, album art genres, CarPlay audio fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to Vibrdrome (iOS/macOS) are documented here.
 
 ## v1.0.0
 
+### Build 47 -- April 18, 2026
+- New Library tab (Apple Music-style): single entry point with Playlists / Artists / Albums / Songs / Genres / Downloaded + Recently Added carousel
+- Default tab bar layout: Home, Favorites, Library, Search, Radio (applies to new installs; existing users can rearrange in Settings > Tab Bar)
+- Favorites tab reworked: Songs / Albums / Artists segmented picker, grid-list toggle per category
+- New Home carousels: Favorite Albums and Featured Genre (daily rotating)
+- Album detail and Artist detail now have a heart button to favorite/unfavorite
+- Artists and Albums views: filter menu for All / Favorites / Downloaded
+- Genre list now uses real album artwork (cover art of a representative album per genre) instead of generated icons
+- CarPlay genre list shows matching album art
+- CarPlay random-pause fix: audio resumes after interruptions (Siri, calls, messages) even when iOS omits the shouldResume hint
+- CarPlay route-change fix: no longer pauses on transient head-unit route hiccups
+- Large section headings across Home, Genres, Artists, Albums, Songs, Favorites, Generations
+- Tab Bar settings moved to the same level as Player and Appearance
+- Home tab's header: tighter spacing between Settings gear and profile icon; tab-bar settings label corrected from "Library" to "Home"
+- macOS: window title removed from next to traffic lights
+- iPad landscape mini player no longer stretches full-width
+- Initial server setup screen now has a Server Name field (previously only available when editing an existing server)
+- 536 unit tests in 40 suites
+
+**TestFlight Notes:**
+> Apple Music-style Library tab, favorite albums/artists, favorites segments
+> and grid view, album art on genres and CarPlay, CarPlay audio resume fix,
+> home carousels, filter menus, iPad landscape mini-player width.
+
 ### Build 46 -- April 18, 2026
 - Fix: semicolon-containing genres like "Hip Hop; Pop" no longer error on tap; now render as "Hip Hop Pop" while the underlying server query is preserved
 - Fix: first tap on a song or album row now plays / navigates reliably instead of sometimes landing on the artist page (removed nested artist/album Buttons from list rows — "Go to Artist" still available via long-press menu)

--- a/TESTING.md
+++ b/TESTING.md
@@ -38,6 +38,15 @@ Run through this checklist before every TestFlight build. Each item should be ve
 - [ ] Tap album card in artist detail → opens album detail (no bounce back to artist)
 - [ ] Search "beats" in Albums tab returns matches anywhere in the library (e.g. "Beats, Rhymes and Life"), not just loaded pages
 - [ ] Genre containing a semicolon (e.g. "Hip Hop; Pop") renders without the semicolon, and tapping loads albums without error
+- [ ] Library tab shows Playlists / Artists / Albums / Songs / Genres / Downloaded list + Recently Added carousel
+- [ ] Favorites tab has Songs / Albums / Artists segmented picker and grid-list toggle on Albums/Artists
+- [ ] Heart button on Album Detail toolbar favorites the album (verify in Favorites tab)
+- [ ] Heart button on Artist Detail toolbar favorites the artist (verify in Favorites tab)
+- [ ] Artists and Albums toolbar filter menu (All / Favorites / Downloaded) filters the list correctly
+- [ ] Genres list shows real album artwork (not AI icons); no flickering when new artwork loads
+- [ ] Home tab shows Favorite Albums and Featured Genre carousels when data is available
+- [ ] CarPlay genres list shows album art
+- [ ] After phone call or Siri-read text, CarPlay playback resumes automatically
 - [ ] Artist detail shows biography (About section)
 - [ ] Artist detail shows Similar Artists carousel
 - [ ] Genre list shows artwork

--- a/Vibrdrome/App/AppState.swift
+++ b/Vibrdrome/App/AppState.swift
@@ -164,18 +164,27 @@ final class AppState {
         return true
     }
 
-    func saveCredentials(url: String, username: String, password: String) {
+    func saveCredentials(url: String, username: String, password: String, name: String? = nil) {
         configure(url: url, username: username, password: password)
         guard isConfigured else { return }
+
+        let trimmedName = name?.trimmingCharacters(in: .whitespaces)
+        let resolvedName: String = {
+            if let trimmedName, !trimmedName.isEmpty { return trimmedName }
+            return extractServerName(from: serverURL)
+        }()
 
         // Update or create server config
         if let activeId = activeServerId,
            let index = servers.firstIndex(where: { $0.id == activeId }) {
             servers[index].url = serverURL
             servers[index].username = username
+            if let trimmedName, !trimmedName.isEmpty {
+                servers[index].name = trimmedName
+            }
             keychain["server_\(activeId)"] = password
         } else {
-            let config = SavedServer(name: extractServerName(from: serverURL), url: serverURL, username: username)
+            let config = SavedServer(name: resolvedName, url: serverURL, username: username)
             servers.append(config)
             activeServerId = config.id
             keychain["server_\(config.id)"] = password

--- a/Vibrdrome/CarPlay/CarPlayManager.swift
+++ b/Vibrdrome/CarPlay/CarPlayManager.swift
@@ -1,6 +1,7 @@
 #if os(iOS) && CARPLAY_ENABLED
 import CarPlay
 import os.log
+import SwiftData
 
 @MainActor
 final class CarPlayManager: NSObject {
@@ -248,12 +249,28 @@ final class CarPlayManager: NSObject {
             let client = AppState.shared.subsonicClient
             let genres = try await client.getGenres()
             let sorted = genres.sorted { ($0.songCount ?? 0) > ($1.songCount ?? 0) }
-            let items = sorted.prefix(30).map { genre in
+            let context = PersistenceController.shared.container.mainContext
+            let cached = (try? context.fetch(FetchDescriptor<GenreArtwork>())) ?? []
+            let coverArtByGenre = Dictionary(uniqueKeysWithValues: cached.map { ($0.genre, $0.coverArtId) })
+
+            let items = sorted.prefix(30).map { genre -> CPListItem in
                 let detail = genre.songCount.map { "\($0) songs" }
-                let item = CPListItem(text: genre.value, detailText: detail)
+                let fallback = GenreIconView.uiImage(for: genre.value)
+                let item = CPListItem(text: genre.value, detailText: detail, image: fallback)
                 item.handler = { [weak self] _, completion in
                     self?.playGenre(genre.value)
                     completion()
+                }
+                // Swap in real album art once it loads; keeps the template
+                // responsive while images fetch in the background.
+                if let coverArtId = coverArtByGenre[genre.value] {
+                    let url = client.coverArtURL(id: coverArtId, size: 200)
+                    Task {
+                        if let (data, _) = try? await URLSession.shared.data(from: url),
+                           let image = UIImage(data: data) {
+                            item.setImage(image)
+                        }
+                    }
                 }
                 return item
             }

--- a/Vibrdrome/Core/Audio/AudioSession.swift
+++ b/Vibrdrome/Core/Audio/AudioSession.swift
@@ -1,9 +1,18 @@
 import AVFoundation
 import Foundation
+import os.log
+
+private let sessionLog = Logger(subsystem: "com.vibrdrome.app", category: "AudioSession")
 
 final class AudioSessionManager: @unchecked Sendable {
     static let shared = AudioSessionManager()
     private var isConfigured = false
+
+    /// Playback state captured at interruption `.began` so `.ended` can resume
+    /// even when iOS omits `AVAudioSessionInterruptionOptions.shouldResume`.
+    /// Siri / Messages announcements on CarPlay often drop that flag, which
+    /// leaves the user stuck paused after returning to CarPlay.
+    @MainActor private static var wasPlayingBeforeInterruption = false
 
     func configure() {
         guard !isConfigured else { return }
@@ -53,17 +62,21 @@ final class AudioSessionManager: @unchecked Sendable {
         Task { @MainActor in
             switch type {
             case .began:
+                wasPlayingBeforeInterruption = AudioEngine.shared.isPlaying
+                sessionLog.info("Interruption began: wasPlaying=\(wasPlayingBeforeInterruption)")
                 AudioEngine.shared.pause()
             case .ended:
-                // Reactivate audio session — iOS deactivates it during interruptions
+                let shouldRestore = shouldResume || wasPlayingBeforeInterruption
+                sessionLog.info("Interruption ended: shouldResume=\(shouldResume) wasPlaying=\(wasPlayingBeforeInterruption) -> restore=\(shouldRestore)")
                 do {
                     try AVAudioSession.sharedInstance().setActive(true)
                 } catch {
-                    print("Failed to reactivate audio session: \(error)")
+                    sessionLog.error("Failed to reactivate audio session: \(error.localizedDescription)")
                 }
-                if shouldResume {
+                if shouldRestore {
                     AudioEngine.shared.resume()
                 }
+                wasPlayingBeforeInterruption = false
             @unknown default:
                 break
             }
@@ -75,10 +88,33 @@ final class AudioSessionManager: @unchecked Sendable {
               let reasonValue = info[AVAudioSessionRouteChangeReasonKey] as? UInt,
               let reason = AVAudioSession.RouteChangeReason(rawValue: reasonValue) else { return }
 
-        if reason == .oldDeviceUnavailable {
+        let session = AVAudioSession.sharedInstance()
+        let currentOutputs = session.currentRoute.outputs.map(\.portType.rawValue).joined(separator: ",")
+        sessionLog.info("RouteChange: reason=\(reasonString(reason)) currentOutputs=[\(currentOutputs, privacy: .public)]")
+
+        // Only pause when the route change actually leaves us with no audio outputs.
+        // CarPlay and Bluetooth connections can fire `.oldDeviceUnavailable` during
+        // transient hiccups even though a valid output remains — pausing in that
+        // case is what produces the "random pause" users see on CarPlay.
+        if reason == .oldDeviceUnavailable && session.currentRoute.outputs.isEmpty {
+            sessionLog.info("Pausing: old device unavailable with no remaining outputs")
             Task { @MainActor in
                 AudioEngine.shared.pause()
             }
+        }
+    }
+
+    private static func reasonString(_ reason: AVAudioSession.RouteChangeReason) -> String {
+        switch reason {
+        case .unknown: return "unknown"
+        case .newDeviceAvailable: return "newDeviceAvailable"
+        case .oldDeviceUnavailable: return "oldDeviceUnavailable"
+        case .categoryChange: return "categoryChange"
+        case .override: return "override"
+        case .wakeFromSleep: return "wakeFromSleep"
+        case .noSuitableRouteForCategory: return "noSuitableRouteForCategory"
+        case .routeConfigurationChange: return "routeConfigurationChange"
+        @unknown default: return "other(\(reason.rawValue))"
         }
     }
     #endif

--- a/Vibrdrome/Core/Constants/UserDefaultsKeys.swift
+++ b/Vibrdrome/Core/Constants/UserDefaultsKeys.swift
@@ -124,6 +124,7 @@ enum UserDefaultsKeys {
     static let showSongsTab = "showSongsTab"
     static let showGenresTab = "showGenresTab"
     static let showFavoritesTab = "showFavoritesTab"
+    static let showLibraryHomeTab = "showLibraryHomeTab"
     static let tabBarOrder = "tabBarOrder"
 
     // MARK: - Library Layout

--- a/Vibrdrome/Core/Persistence/Models/GenreArtwork.swift
+++ b/Vibrdrome/Core/Persistence/Models/GenreArtwork.swift
@@ -1,0 +1,17 @@
+import Foundation
+import SwiftData
+
+/// Caches the cover art ID of a representative album for a given genre so the
+/// Genres screen can show real album artwork instead of generated icons.
+@Model
+final class GenreArtwork {
+    @Attribute(.unique) var genre: String = ""
+    var coverArtId: String = ""
+    var updatedAt: Date = Date()
+
+    init(genre: String, coverArtId: String) {
+        self.genre = genre
+        self.coverArtId = coverArtId
+        self.updatedAt = Date()
+    }
+}

--- a/Vibrdrome/Core/Persistence/PersistenceController.swift
+++ b/Vibrdrome/Core/Persistence/PersistenceController.swift
@@ -30,6 +30,7 @@ final class PersistenceController {
             PendingAction.self,
             SavedQueue.self,
             AlbumCollection.self,
+            GenreArtwork.self,
         ])
 
         let config = ModelConfiguration(

--- a/Vibrdrome/Features/Library/AlbumDetailView.swift
+++ b/Vibrdrome/Features/Library/AlbumDetailView.swift
@@ -14,6 +14,7 @@ struct AlbumDetailView: View {
     @State private var selectedSongs = Set<String>()
     @State private var isSelecting = false
     @State private var showAddToPlaylist = false
+    @State private var isStarred = false
 
     var body: some View {
         ScrollView {
@@ -81,6 +82,16 @@ struct AlbumDetailView: View {
         .navigationBarTitleDisplayMode(.inline)
         #endif
         .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    toggleAlbumStar()
+                } label: {
+                    Image(systemName: isStarred ? "heart.fill" : "heart")
+                        .foregroundStyle(isStarred ? Color.pink : Color.accentColor)
+                }
+                .accessibilityLabel(isStarred ? "Unfavorite Album" : "Favorite Album")
+                .accessibilityIdentifier("albumFavoriteButton")
+            }
             ToolbarItem(placement: .primaryAction) {
                 Button {
                     withAnimation(.easeInOut(duration: 0.2)) {
@@ -597,6 +608,7 @@ struct AlbumDetailView: View {
         defer { isLoading = false }
         do {
             album = try await appState.subsonicClient.getAlbum(id: albumId)
+            isStarred = album?.starred != nil
             // Load album notes (info2) in background — non-fatal if it fails
             if let info = try? await appState.subsonicClient.getAlbumInfo(id: albumId) {
                 albumNotes = info.notes
@@ -619,6 +631,25 @@ struct AlbumDetailView: View {
             }
         } catch {
             self.error = ErrorPresenter.userMessage(for: error)
+        }
+    }
+
+    private func toggleAlbumStar() {
+        let wasStarred = isStarred
+        isStarred.toggle()
+        #if os(iOS)
+        Haptics.light()
+        #endif
+        Task {
+            do {
+                if wasStarred {
+                    try await OfflineActionQueue.shared.unstar(albumId: albumId)
+                } else {
+                    try await OfflineActionQueue.shared.star(albumId: albumId)
+                }
+            } catch {
+                isStarred = wasStarred
+            }
         }
     }
 }

--- a/Vibrdrome/Features/Library/AlbumsView.swift
+++ b/Vibrdrome/Features/Library/AlbumsView.swift
@@ -26,7 +26,38 @@ struct AlbumsView: View {
     @State private var activeGenre: String?
     @State private var searchResults: [Album] = []
     @State private var searchTask: Task<Void, Never>?
+    @State private var favoritedAlbumIds: Set<String> = []
+    @SceneStorage("albumsFilter") private var filterRaw: String = AlbumFilter.all.rawValue
+    @Query(filter: #Predicate<DownloadedSong> { $0.isComplete == true })
+    private var downloadedSongs: [DownloadedSong]
     private let pageSize = 40
+
+    enum AlbumFilter: String, CaseIterable, Identifiable {
+        case all, favorites, downloaded
+        var id: String { rawValue }
+        var label: String {
+            switch self {
+            case .all: "All"
+            case .favorites: "Favorites"
+            case .downloaded: "Downloaded"
+            }
+        }
+        var icon: String {
+            switch self {
+            case .all: "line.3.horizontal.decrease.circle"
+            case .favorites: "heart.fill"
+            case .downloaded: "arrow.down.circle.fill"
+            }
+        }
+    }
+
+    private var activeFilter: AlbumFilter {
+        AlbumFilter(rawValue: filterRaw) ?? .all
+    }
+
+    private var downloadedAlbumNames: Set<String> {
+        Set(downloadedSongs.compactMap { $0.albumName?.lowercased() })
+    }
 
     enum AlbumSortOption: String, CaseIterable {
         case name, artist, year, recentlyAdded
@@ -66,6 +97,15 @@ struct AlbumsView: View {
                 $0.genre?.caseInsensitiveCompare(activeGenre) == .orderedSame
             }
         }
+        switch activeFilter {
+        case .all:
+            break
+        case .favorites:
+            result = result.filter { favoritedAlbumIds.contains($0.id) }
+        case .downloaded:
+            let downloaded = downloadedAlbumNames
+            result = result.filter { downloaded.contains($0.name.lowercased()) }
+        }
         if clientSideSort == .year {
             result.sort { ($0.year ?? 0) > ($1.year ?? 0) }
         }
@@ -86,6 +126,7 @@ struct AlbumsView: View {
         .navigationTitle(title)
         #if os(iOS)
         .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .automatic), prompt: "Search in Albums")
+        .navigationBarTitleDisplayMode(.large)
         #else
         .searchable(text: $searchText, prompt: "Search in Albums")
         #endif
@@ -105,9 +146,6 @@ struct AlbumsView: View {
                 searchResults = results?.album ?? []
             }
         }
-        #if os(iOS)
-        .navigationBarTitleDisplayMode(.inline)
-        #endif
         .overlay {
             if isLoading && albums.isEmpty {
                 ProgressView("Loading albums...")
@@ -200,6 +238,12 @@ struct AlbumsView: View {
                         Label(effectiveGenre?.cleanedGenreDisplay ?? "Genre", systemImage: "guitars")
                     }
                     Divider()
+                    Picker("Filter", selection: $filterRaw) {
+                        ForEach(AlbumFilter.allCases) { option in
+                            Label(option.label, systemImage: option.icon).tag(option.rawValue)
+                        }
+                    }
+                    Divider()
                     Button {
                         albums = []
                         hasMore = true
@@ -243,11 +287,20 @@ struct AlbumsView: View {
                 availableGenres = (try? await appState.subsonicClient.getGenres()
                     .map(\.value).sorted()) ?? []
             }
+            await loadFavoritedAlbumIds()
         }
         .refreshable {
             albums = []
             hasMore = true
             await loadAlbums()
+        }
+    }
+
+    private func loadFavoritedAlbumIds() async {
+        guard favoritedAlbumIds.isEmpty else { return }
+        if let starred = try? await appState.subsonicClient.getStarred(),
+           let albums = starred.album {
+            favoritedAlbumIds = Set(albums.map(\.id))
         }
     }
 

--- a/Vibrdrome/Features/Library/ArtistDetailView.swift
+++ b/Vibrdrome/Features/Library/ArtistDetailView.swift
@@ -11,6 +11,7 @@ struct ArtistDetailView: View {
     @State private var isLoading = true
     @State private var error: String?
     @State private var showFullBio = false
+    @State private var isStarred = false
 
     var body: some View {
         List {
@@ -135,6 +136,18 @@ struct ArtistDetailView: View {
             }
         }
         .toolbar {
+            if artist != nil {
+                ToolbarItem(placement: .primaryAction) {
+                    Button {
+                        toggleArtistStar()
+                    } label: {
+                        Image(systemName: isStarred ? "heart.fill" : "heart")
+                            .foregroundStyle(isStarred ? Color.pink : Color.accentColor)
+                    }
+                    .accessibilityLabel(isStarred ? "Unfavorite Artist" : "Favorite Artist")
+                    .accessibilityIdentifier("artistFavoriteButton")
+                }
+            }
             if let artist {
                 ToolbarItem(placement: .primaryAction) {
                     Button {
@@ -157,6 +170,7 @@ struct ArtistDetailView: View {
         do {
             let loadedArtist = try await appState.subsonicClient.getArtist(id: artistId)
             artist = loadedArtist
+            isStarred = loadedArtist.starred != nil
             // Load top songs and similar artists in parallel
             async let topSongsResult = appState.subsonicClient.getTopSongs(
                 artist: loadedArtist.name, count: 10
@@ -175,5 +189,24 @@ struct ArtistDetailView: View {
     private func cleanBiography(_ text: String) -> String {
         text.replacingOccurrences(of: "<[^>]+>", with: "", options: .regularExpression)
             .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func toggleArtistStar() {
+        let wasStarred = isStarred
+        isStarred.toggle()
+        #if os(iOS)
+        Haptics.light()
+        #endif
+        Task {
+            do {
+                if wasStarred {
+                    try await OfflineActionQueue.shared.unstar(artistId: artistId)
+                } else {
+                    try await OfflineActionQueue.shared.star(artistId: artistId)
+                }
+            } catch {
+                isStarred = wasStarred
+            }
+        }
     }
 }

--- a/Vibrdrome/Features/Library/ArtistsView.swift
+++ b/Vibrdrome/Features/Library/ArtistsView.swift
@@ -1,3 +1,4 @@
+import SwiftData
 import SwiftUI
 
 struct ArtistsView: View {
@@ -7,8 +8,39 @@ struct ArtistsView: View {
     @State private var error: String?
     @State private var searchText = ""
     @State private var sortReversed = false
+    @State private var favoritedArtistIds: Set<String> = []
     @AppStorage("artistsViewStyle") private var showAsList = true
     @AppStorage(UserDefaultsKeys.gridColumnsPerRow) private var gridColumns = 2
+    @SceneStorage("artistsFilter") private var filterRaw: String = ArtistFilter.all.rawValue
+    @Query(filter: #Predicate<DownloadedSong> { $0.isComplete == true })
+    private var downloadedSongs: [DownloadedSong]
+
+    enum ArtistFilter: String, CaseIterable, Identifiable {
+        case all, favorites, downloaded
+        var id: String { rawValue }
+        var label: String {
+            switch self {
+            case .all: "All"
+            case .favorites: "Favorites"
+            case .downloaded: "Downloaded"
+            }
+        }
+        var icon: String {
+            switch self {
+            case .all: "line.3.horizontal.decrease.circle"
+            case .favorites: "heart.fill"
+            case .downloaded: "arrow.down.circle.fill"
+            }
+        }
+    }
+
+    private var activeFilter: ArtistFilter {
+        ArtistFilter(rawValue: filterRaw) ?? .all
+    }
+
+    private var downloadedArtistNames: Set<String> {
+        Set(downloadedSongs.compactMap { $0.artistName?.lowercased() })
+    }
 
     enum ArtistSortOption: String, CaseIterable {
         case nameAZ, nameZA
@@ -22,12 +54,25 @@ struct ArtistsView: View {
 
     private var filteredIndexes: [(id: String, name: String, artists: [Artist])] {
         var raw: [(id: String, name: String, artists: [Artist])]
+        let downloaded = downloadedArtistNames
+        let favorited = favoritedArtistIds
+        func passesFilter(_ artist: Artist) -> Bool {
+            switch activeFilter {
+            case .all: return true
+            case .favorites: return favorited.contains(artist.id)
+            case .downloaded: return downloaded.contains(artist.name.lowercased())
+            }
+        }
         if searchText.isEmpty {
-            raw = indexes.map { (id: $0.id, name: $0.name, artists: $0.artist ?? []) }
+            raw = indexes.compactMap { index in
+                let artists = (index.artist ?? []).filter(passesFilter)
+                guard !artists.isEmpty else { return nil }
+                return (id: index.id, name: index.name, artists: artists)
+            }
         } else {
             raw = indexes.compactMap { index in
                 let filtered = (index.artist ?? []).filter {
-                    $0.name.localizedCaseInsensitiveContains(searchText)
+                    $0.name.localizedCaseInsensitiveContains(searchText) && passesFilter($0)
                 }
                 guard !filtered.isEmpty else { return nil }
                 return (id: index.id, name: index.name, artists: filtered)
@@ -73,11 +118,9 @@ struct ArtistsView: View {
         .navigationTitle("Artists")
         #if os(iOS)
         .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .automatic), prompt: "Search Artists")
+        .navigationBarTitleDisplayMode(.large)
         #else
         .searchable(text: $searchText, prompt: "Search Artists")
-        #endif
-        #if os(iOS)
-        .navigationBarTitleDisplayMode(.inline)
         #endif
         .overlay {
             if isLoading && indexes.isEmpty {
@@ -107,6 +150,12 @@ struct ArtistsView: View {
             }
             ToolbarItem(placement: .primaryAction) {
                 Menu {
+                    Picker("Filter", selection: $filterRaw) {
+                        ForEach(ArtistFilter.allCases) { option in
+                            Label(option.label, systemImage: option.icon).tag(option.rawValue)
+                        }
+                    }
+                    Divider()
                     Button {
                         sortReversed = false
                     } label: {
@@ -134,12 +183,21 @@ struct ArtistsView: View {
                         Label("Refresh", systemImage: "arrow.clockwise")
                     }
                 } label: {
-                    Image(systemName: "arrow.up.arrow.down")
+                    Image(systemName: activeFilter == .all ? "arrow.up.arrow.down" : "line.3.horizontal.decrease.circle.fill")
                 }
             }
         }
         .task { await loadArtists() }
+        .task { await loadFavorites() }
         .refreshable { await loadArtists() }
+    }
+
+    private func loadFavorites() async {
+        guard favoritedArtistIds.isEmpty else { return }
+        if let starred = try? await appState.subsonicClient.getStarred(),
+           let artists = starred.artist {
+            favoritedArtistIds = Set(artists.map(\.id))
+        }
     }
 
     // MARK: - List view

--- a/Vibrdrome/Features/Library/ContentView.swift
+++ b/Vibrdrome/Features/Library/ContentView.swift
@@ -10,15 +10,16 @@ struct ContentView: View {
     @State private var isOffline = false
     @AppStorage(UserDefaultsKeys.tabBarOrder) private var tabBarOrderJSON = "[]"
     @AppStorage(UserDefaultsKeys.showSearchTab) private var showSearchTab = true
-    @AppStorage(UserDefaultsKeys.showPlaylistsTab) private var showPlaylistsTab = true
+    @AppStorage(UserDefaultsKeys.showPlaylistsTab) private var showPlaylistsTab = false
     @AppStorage(UserDefaultsKeys.showRadioTab) private var showRadioTab = true
+    @AppStorage(UserDefaultsKeys.showLibraryHomeTab) private var showLibraryHomeTab = true
     @AppStorage(UserDefaultsKeys.settingsInNavBar) private var settingsInNavBar = false
     @AppStorage(UserDefaultsKeys.showDownloadsTab) private var showDownloadsTab = false
     @AppStorage(UserDefaultsKeys.showArtistsTab) private var showArtistsTab = false
     @AppStorage(UserDefaultsKeys.showAlbumsTab) private var showAlbumsTab = false
     @AppStorage(UserDefaultsKeys.showSongsTab) private var showSongsTab = false
     @AppStorage(UserDefaultsKeys.showGenresTab) private var showGenresTab = false
-    @AppStorage(UserDefaultsKeys.showFavoritesTab) private var showFavoritesTab = false
+    @AppStorage(UserDefaultsKeys.showFavoritesTab) private var showFavoritesTab = true
 
     private var engine: AudioEngine { AudioEngine.shared }
 
@@ -122,25 +123,26 @@ struct ContentView: View {
     }
 
     private var orderedTabIds: [String] {
+        let allIds = ["library", "favorites", "library-home", "search", "radio",
+                      "artists", "albums", "songs", "genres",
+                      "playlists", "downloads", "settings"]
         if let data = tabBarOrderJSON.data(using: .utf8),
            let saved = try? JSONDecoder().decode([String].self, from: data),
            !saved.isEmpty {
             // Ensure all known tabs are in the list (append missing ones)
-            let allIds = ["library", "artists", "albums", "songs", "genres",
-                          "favorites", "search", "playlists", "radio", "downloads", "settings"]
             var result = saved.filter { allIds.contains($0) }
             for id in allIds where !result.contains(id) {
                 result.append(id)
             }
             return result
         }
-        return ["library", "artists", "albums", "songs", "genres",
-                "favorites", "search", "playlists", "radio", "downloads", "settings"]
+        return allIds
     }
 
     private func isTabVisible(_ id: String) -> Bool {
         switch id {
         case "library": return true
+        case "library-home": return showLibraryHomeTab
         case "artists": return showArtistsTab
         case "albums": return showAlbumsTab
         case "songs": return showSongsTab
@@ -188,6 +190,7 @@ struct ContentView: View {
 
     private func tabLabel(_ id: String) -> String {
         switch id {
+        case "library-home": return "Library"
         case "artists": return "Artists"
         case "albums": return "Albums"
         case "songs": return "Songs"
@@ -204,6 +207,7 @@ struct ContentView: View {
 
     private func tabIcon(_ id: String) -> String {
         switch id {
+        case "library-home": return "music.note.house.fill"
         case "artists": return "music.mic"
         case "albums": return "square.stack.fill"
         case "songs": return "music.note"
@@ -221,6 +225,7 @@ struct ContentView: View {
     @ViewBuilder
     private func tabView(for id: String) -> some View {
         switch id {
+        case "library-home": NavigationStack { LibraryHomeView() }
         case "artists": NavigationStack { ArtistsView() }
         case "albums": NavigationStack { AlbumsView(listType: .alphabeticalByName, title: "Albums") }
         case "songs": NavigationStack { SongsView() }
@@ -240,6 +245,11 @@ struct ContentView: View {
             LibraryView(navPath: $libraryNavPath)
                 .tabItem { Label("Home", systemImage: "house") }
                 .tag("library")
+            if showLibraryHomeTab {
+                NavigationStack { LibraryHomeView() }
+                    .tabItem { Label("Library", systemImage: "music.note.house.fill") }
+                    .tag("library-home")
+            }
             if showArtistsTab {
                 NavigationStack { ArtistsView() }
                     .tabItem { Label("Artists", systemImage: "music.mic") }

--- a/Vibrdrome/Features/Library/FavoritesView.swift
+++ b/Vibrdrome/Features/Library/FavoritesView.swift
@@ -9,6 +9,28 @@ struct FavoritesView: View {
     @State private var selectedSongs = Set<String>()
     @State private var isSelecting = false
     @State private var showBatchAddToPlaylist = false
+    @State private var selectedCategory: FavoriteCategory = .songs
+    @AppStorage("favoritesViewAsList") private var showAsList = true
+    @AppStorage(UserDefaultsKeys.gridColumnsPerRow) private var gridColumns = 2
+
+    enum FavoriteCategory: String, CaseIterable, Identifiable {
+        case songs, albums, artists
+        var id: String { rawValue }
+        var label: String {
+            switch self {
+            case .songs: "Songs"
+            case .albums: "Albums"
+            case .artists: "Artists"
+            }
+        }
+        var icon: String {
+            switch self {
+            case .songs: "music.note"
+            case .albums: "square.stack"
+            case .artists: "music.mic"
+            }
+        }
+    }
 
     private var filteredArtists: [Artist] {
         guard let artists = starred?.artist else { return [] }
@@ -32,117 +54,26 @@ struct FavoritesView: View {
     }
 
     var body: some View {
-        List {
-            if starred != nil {
-                // Starred Artists
-                if !filteredArtists.isEmpty {
-                    Section("Artists") {
-                        ForEach(filteredArtists) { artist in
-                            NavigationLink {
-                                ArtistDetailView(artistId: artist.id)
-                            } label: {
-                                ArtistRow(artist: artist)
-                            }
-                            .accessibilityIdentifier("favArtistRow_\(artist.id)")
-                        }
-                    }
-                }
-
-                // Starred Albums
-                if !filteredAlbums.isEmpty {
-                    Section("Albums") {
-                        ForEach(filteredAlbums) { album in
-                            NavigationLink {
-                                AlbumDetailView(albumId: album.id)
-                            } label: {
-                                AlbumCard(album: album)
-                            }
-                            .accessibilityIdentifier("favAlbumRow_\(album.id)")
-                        }
-                    }
-                }
-
-                // Starred Songs
-                if !filteredSongs.isEmpty {
-                    Section("Songs") {
-                        HStack(spacing: 12) {
-                            Button {
-                                AudioEngine.shared.play(song: filteredSongs[0], from: filteredSongs, at: 0)
-                            } label: {
-                                Label("Play All", systemImage: "play.fill")
-                                    .font(.subheadline)
-                                    .fontWeight(.semibold)
-                                    .frame(maxWidth: .infinity)
-                            }
-                            .buttonStyle(.bordered)
-                            .tint(.accentColor)
-                            .accessibilityIdentifier("favPlayAllButton")
-
-                            Button {
-                                let shuffled = filteredSongs.shuffled()
-                                AudioEngine.shared.play(song: shuffled[0], from: shuffled, at: 0)
-                            } label: {
-                                Label("Shuffle", systemImage: "shuffle")
-                                    .font(.subheadline)
-                                    .fontWeight(.semibold)
-                                    .frame(maxWidth: .infinity)
-                            }
-                            .buttonStyle(.bordered)
-                            .tint(.accentColor)
-                            .accessibilityIdentifier("favShuffleButton")
-                        }
-                        .listRowSeparator(.hidden)
-
-                        ForEach(Array(filteredSongs.enumerated()), id: \.element.id) { index, song in
-                            HStack(spacing: 0) {
-                                if isSelecting {
-                                    Button {
-                                        toggleSelection(song.id)
-                                    } label: {
-                                        Image(systemName: selectedSongs.contains(song.id)
-                                              ? "checkmark.circle.fill" : "circle")
-                                            .foregroundStyle(selectedSongs.contains(song.id)
-                                                             ? Color.accentColor : .secondary)
-                                            .font(.title3)
-                                    }
-                                    .buttonStyle(.plain)
-                                    .padding(.trailing, 8)
-                                }
-
-                                TrackRow(song: song, showTrackNumber: false)
-                                    .trackContextMenu(song: song, queue: filteredSongs, index: index)
-                                    .accessibilityIdentifier("favSongRow_\(song.id)")
-                                    .onTapGesture {
-                                        if isSelecting {
-                                            toggleSelection(song.id)
-                                        } else {
-                                            AudioEngine.shared.play(song: song, from: filteredSongs, at: index)
-                                        }
-                                    }
-                            }
-                        }
-
-                        // Batch action bar
-                        if isSelecting && !selectedSongs.isEmpty {
-                            favoritesBatchActionBar(songs: filteredSongs)
-                                .listRowSeparator(.hidden)
-                        }
-                    }
-                }
+        Group {
+            switch selectedCategory {
+            case .songs:   songsContent
+            case .albums:  albumsContent
+            case .artists: artistsContent
             }
         }
-        .listStyle(.plain)
+        .safeAreaInset(edge: .top) {
+            categoryPicker
+                .background(.bar)
+        }
         #if os(iOS)
         .contentMargins(.bottom, 80)
         #endif
         .navigationTitle("Favorites")
         #if os(iOS)
         .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .automatic), prompt: "Search Favorites")
+        .navigationBarTitleDisplayMode(.large)
         #else
         .searchable(text: $searchText, prompt: "Search Favorites")
-        #endif
-        #if os(iOS)
-        .navigationBarTitleDisplayMode(.inline)
         #endif
         .overlay {
             if isLoading && starred == nil {
@@ -165,17 +96,29 @@ struct FavoritesView: View {
             }
         }
         .toolbar {
-            ToolbarItem(placement: .primaryAction) {
-                Button {
-                    withAnimation(.easeInOut(duration: 0.2)) {
-                        isSelecting.toggle()
-                        if !isSelecting { selectedSongs.removeAll() }
+            if selectedCategory != .songs {
+                ToolbarItem(placement: .automatic) {
+                    Button {
+                        withAnimation(.easeInOut(duration: 0.2)) { showAsList.toggle() }
+                    } label: {
+                        Image(systemName: showAsList ? "square.grid.2x2" : "list.bullet")
                     }
-                } label: {
-                    Image(systemName: isSelecting ? "checkmark.circle.fill" : "checkmark.circle")
+                    .accessibilityLabel(showAsList ? "Grid View" : "List View")
                 }
-                .accessibilityLabel(isSelecting ? "Done Selecting" : "Select Songs")
-                .accessibilityIdentifier("favSelectButton")
+            }
+            ToolbarItem(placement: .primaryAction) {
+                if selectedCategory == .songs {
+                    Button {
+                        withAnimation(.easeInOut(duration: 0.2)) {
+                            isSelecting.toggle()
+                            if !isSelecting { selectedSongs.removeAll() }
+                        }
+                    } label: {
+                        Image(systemName: isSelecting ? "checkmark.circle.fill" : "checkmark.circle")
+                    }
+                    .accessibilityLabel(isSelecting ? "Done Selecting" : "Select Songs")
+                    .accessibilityIdentifier("favSelectButton")
+                }
             }
             #if os(macOS)
             ToolbarItem {
@@ -193,21 +136,208 @@ struct FavoritesView: View {
         .refreshable { await loadStarred() }
     }
 
+    // MARK: - Category picker
+
+    private var categoryPicker: some View {
+        Picker("Category", selection: $selectedCategory) {
+            ForEach(FavoriteCategory.allCases) { cat in
+                Text(cat.label).tag(cat)
+            }
+        }
+        .pickerStyle(.segmented)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 8)
+        .accessibilityIdentifier("favoritesCategoryPicker")
+    }
+
+    // MARK: - Songs
+
+    @ViewBuilder
+    private var songsContent: some View {
+        let songs = filteredSongs
+        if songs.isEmpty {
+            emptyCategory("No Favorited Songs")
+        } else {
+            List {
+                HStack(spacing: 12) {
+                    Button {
+                        AudioEngine.shared.play(song: songs[0], from: songs, at: 0)
+                    } label: {
+                        Label("Play All", systemImage: "play.fill")
+                            .font(.subheadline)
+                            .fontWeight(.semibold)
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.bordered)
+                    .tint(.accentColor)
+                    .accessibilityIdentifier("favPlayAllButton")
+
+                    Button {
+                        let shuffled = songs.shuffled()
+                        AudioEngine.shared.play(song: shuffled[0], from: shuffled, at: 0)
+                    } label: {
+                        Label("Shuffle", systemImage: "shuffle")
+                            .font(.subheadline)
+                            .fontWeight(.semibold)
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.bordered)
+                    .tint(.accentColor)
+                    .accessibilityIdentifier("favShuffleButton")
+                }
+                .listRowSeparator(.hidden)
+
+                ForEach(Array(songs.enumerated()), id: \.element.id) { index, song in
+                    HStack(spacing: 0) {
+                        if isSelecting {
+                            Button {
+                                toggleSelection(song.id)
+                            } label: {
+                                Image(systemName: selectedSongs.contains(song.id)
+                                      ? "checkmark.circle.fill" : "circle")
+                                    .foregroundStyle(selectedSongs.contains(song.id)
+                                                     ? Color.accentColor : .secondary)
+                                    .font(.title3)
+                            }
+                            .buttonStyle(.plain)
+                            .padding(.trailing, 8)
+                        }
+
+                        TrackRow(song: song, showTrackNumber: false)
+                            .trackContextMenu(song: song, queue: songs, index: index)
+                            .accessibilityIdentifier("favSongRow_\(song.id)")
+                            .onTapGesture {
+                                if isSelecting {
+                                    toggleSelection(song.id)
+                                } else {
+                                    AudioEngine.shared.play(song: song, from: songs, at: index)
+                                }
+                            }
+                    }
+                }
+
+                if isSelecting && !selectedSongs.isEmpty {
+                    BatchActionBar(
+                        selectedSongIds: selectedSongs,
+                        songs: songs,
+                        onAddToPlaylist: { showBatchAddToPlaylist = true }
+                    )
+                    .listRowSeparator(.hidden)
+                }
+            }
+            .listStyle(.plain)
+        }
+    }
+
+    // MARK: - Albums
+
+    @ViewBuilder
+    private var albumsContent: some View {
+        let albums = filteredAlbums
+        if albums.isEmpty {
+            emptyCategory("No Favorited Albums")
+        } else if showAsList {
+            List(albums) { album in
+                NavigationLink {
+                    AlbumDetailView(albumId: album.id)
+                } label: {
+                    AlbumCard(album: album)
+                }
+                .accessibilityIdentifier("favAlbumRow_\(album.id)")
+            }
+            .listStyle(.plain)
+        } else {
+            ScrollView {
+                LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 16),
+                                         count: max(2, min(10, gridColumns))), spacing: 20) {
+                    ForEach(albums) { album in
+                        NavigationLink {
+                            AlbumDetailView(albumId: album.id)
+                        } label: {
+                            VStack(alignment: .leading, spacing: 6) {
+                                AlbumArtView(coverArtId: album.coverArt, size: 140, cornerRadius: 10)
+                                    .shadow(color: .black.opacity(0.15), radius: 6, y: 3)
+                                Text(album.name)
+                                    .font(.subheadline)
+                                    .fontWeight(.medium)
+                                    .foregroundColor(.primary)
+                                    .lineLimit(1)
+                                if let artist = album.artist {
+                                    Text(artist)
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                        .lineLimit(1)
+                                }
+                            }
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityIdentifier("favAlbumCard_\(album.id)")
+                    }
+                }
+                .padding(16)
+            }
+        }
+    }
+
+    // MARK: - Artists
+
+    @ViewBuilder
+    private var artistsContent: some View {
+        let artists = filteredArtists
+        if artists.isEmpty {
+            emptyCategory("No Favorited Artists")
+        } else if showAsList {
+            List(artists) { artist in
+                NavigationLink {
+                    ArtistDetailView(artistId: artist.id)
+                } label: {
+                    ArtistRow(artist: artist)
+                }
+                .accessibilityIdentifier("favArtistRow_\(artist.id)")
+            }
+            .listStyle(.plain)
+        } else {
+            ScrollView {
+                LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 16),
+                                         count: max(2, min(10, gridColumns))), spacing: 20) {
+                    ForEach(artists) { artist in
+                        NavigationLink {
+                            ArtistDetailView(artistId: artist.id)
+                        } label: {
+                            VStack(spacing: 8) {
+                                AlbumArtView(coverArtId: artist.coverArt, size: 140, cornerRadius: 70)
+                                    .shadow(color: .black.opacity(0.15), radius: 6, y: 3)
+                                Text(artist.name)
+                                    .font(.subheadline)
+                                    .fontWeight(.medium)
+                                    .foregroundColor(.primary)
+                                    .multilineTextAlignment(.center)
+                                    .lineLimit(2)
+                            }
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityIdentifier("favArtistCard_\(artist.id)")
+                    }
+                }
+                .padding(16)
+            }
+        }
+    }
+
+    private func emptyCategory(_ message: String) -> some View {
+        ContentUnavailableView {
+            Label(message, systemImage: "heart")
+        } description: {
+            Text("Star items to see them here")
+        }
+    }
+
     private func toggleSelection(_ songId: String) {
         if selectedSongs.contains(songId) {
             selectedSongs.remove(songId)
         } else {
             selectedSongs.insert(songId)
         }
-    }
-
-    @ViewBuilder
-    private func favoritesBatchActionBar(songs: [Song]) -> some View {
-        BatchActionBar(
-            selectedSongIds: selectedSongs,
-            songs: songs,
-            onAddToPlaylist: { showBatchAddToPlaylist = true }
-        )
     }
 
     private var isEmpty: Bool {

--- a/Vibrdrome/Features/Library/GenerationsView.swift
+++ b/Vibrdrome/Features/Library/GenerationsView.swift
@@ -43,7 +43,7 @@ struct GenerationsView: View {
         }
         .navigationTitle("Generations")
         #if os(iOS)
-        .navigationBarTitleDisplayMode(.inline)
+        .navigationBarTitleDisplayMode(.large)
         .contentMargins(.bottom, 80)
         #endif
         .task { await loadDecadeArt() }

--- a/Vibrdrome/Features/Library/GenresView.swift
+++ b/Vibrdrome/Features/Library/GenresView.swift
@@ -1,11 +1,17 @@
+import SwiftData
 import SwiftUI
 
 struct GenresView: View {
     @Environment(AppState.self) private var appState
+    @Environment(\.modelContext) private var modelContext
+    @Query private var genreArtworks: [GenreArtwork]
     @State private var genres: [Genre] = []
     @State private var isLoading = true
     @State private var error: String?
-    @State private var genreArt: [String: String] = [:] // genre → coverArtId
+
+    private var genreArtworkMap: [String: String] {
+        Dictionary(uniqueKeysWithValues: genreArtworks.map { ($0.genre, $0.coverArtId) })
+    }
     @State private var searchText = ""
     @State private var sortBy: GenreSortOption = .name
     @AppStorage("genresViewStyle") private var showAsList = true
@@ -56,7 +62,7 @@ struct GenresView: View {
         .searchable(text: $searchText, prompt: "Search Genres")
         #endif
         #if os(iOS)
-        .navigationBarTitleDisplayMode(.inline)
+        .navigationBarTitleDisplayMode(.large)
         #endif
         .overlay {
             if isLoading && genres.isEmpty {
@@ -127,7 +133,7 @@ struct GenresView: View {
                 AlbumsView(listType: .byGenre, title: genre.value.cleanedGenreDisplay, genre: genre.value)
             } label: {
                 HStack(spacing: 12) {
-                    GenreIconView(genre: genre.value)
+                    GenreIconView(genre: genre.value, coverArtId: genreArtworkMap[genre.value])
                         .frame(width: 48, height: 48)
                         .clipShape(RoundedRectangle(cornerRadius: 8))
 
@@ -168,7 +174,7 @@ struct GenresView: View {
 
     private func genreCard(_ genre: Genre) -> some View {
         VStack(alignment: .leading, spacing: 8) {
-            GenreIconView(genre: genre.value)
+            GenreIconView(genre: genre.value, coverArtId: genreArtworkMap[genre.value])
                 .aspectRatio(1, contentMode: .fit)
                 .clipShape(RoundedRectangle(cornerRadius: 10))
                 .shadow(color: .black.opacity(0.15), radius: 6, y: 3)
@@ -209,11 +215,12 @@ struct GenresView: View {
     }
 
     private func loadGenreArt(client: SubsonicClient) async {
-        for genre in genres.prefix(30) where genreArt[genre.value] == nil {
-            if let albums = try? await client.getAlbumList(type: .byGenre, size: 1, genre: genre.value),
-               let coverArt = albums.first?.coverArt {
-                genreArt[genre.value] = coverArt
-            }
+        let existing = Set(genreArtworks.map(\.genre))
+        for genre in genres where !existing.contains(genre.value) {
+            guard let albums = try? await client.getAlbumList(type: .byGenre, size: 1, genre: genre.value),
+                  let coverArt = albums.first?.coverArt else { continue }
+            modelContext.insert(GenreArtwork(genre: genre.value, coverArtId: coverArt))
         }
+        try? modelContext.save()
     }
 }

--- a/Vibrdrome/Features/Library/LibraryCustomizeView.swift
+++ b/Vibrdrome/Features/Library/LibraryCustomizeView.swift
@@ -161,11 +161,13 @@ struct LibraryCustomizeView: View {
     private func carouselIcon(_ carousel: LibraryCarousel) -> String {
         switch carousel {
         case .recentlyAdded: "clock"
+        case .favoriteAlbums: "heart.square.fill"
         case .mostPlayed: "star"
         case .rediscover: "heart"
         case .randomPicks: "shuffle"
         case .recentlyPlayed: "play.circle"
         case .topArtists: "person.2"
+        case .featuredGenre: "guitars.fill"
         }
     }
 

--- a/Vibrdrome/Features/Library/LibraryHomeView.swift
+++ b/Vibrdrome/Features/Library/LibraryHomeView.swift
@@ -1,0 +1,96 @@
+import SwiftUI
+
+/// Apple Music-style Library tab — a single entry point to Playlists, Artists,
+/// Albums, Songs, Genres, and Downloaded, with a Recently Added carousel below.
+struct LibraryHomeView: View {
+    @Environment(AppState.self) private var appState
+    @State private var recentlyAdded: [Album] = []
+    @State private var isLoadingRecent = false
+
+    var body: some View {
+        List {
+            Section {
+                categoryRow("Playlists", systemImage: "music.note.list", destination: AnyView(PlaylistsView()))
+                categoryRow("Artists", systemImage: "music.mic", destination: AnyView(ArtistsView()))
+                categoryRow("Albums", systemImage: "square.stack", destination: AnyView(AlbumsView(listType: .alphabeticalByName, title: "Albums")))
+                categoryRow("Songs", systemImage: "music.note", destination: AnyView(SongsView()))
+                categoryRow("Genres", systemImage: "guitars", destination: AnyView(GenresView()))
+                categoryRow("Downloaded", systemImage: "arrow.down.circle", destination: AnyView(DownloadsView()))
+            }
+            .listRowSeparator(.visible)
+
+            if !recentlyAdded.isEmpty {
+                Section("Recently Added") {
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        LazyHStack(spacing: 16) {
+                            ForEach(recentlyAdded.prefix(20)) { album in
+                                NavigationLink(value: AlbumNavItem(id: album.id)) {
+                                    recentlyAddedCard(album)
+                                }
+                                .buttonStyle(.plain)
+                            }
+                        }
+                        .padding(.horizontal, 4)
+                        .padding(.vertical, 8)
+                    }
+                    .listRowInsets(EdgeInsets())
+                }
+            }
+        }
+        .listStyle(.plain)
+        .navigationTitle("Library")
+        #if os(iOS)
+        .navigationBarTitleDisplayMode(.large)
+        .contentMargins(.bottom, 80)
+        #endif
+        .navigationDestination(for: AlbumNavItem.self) { item in
+            AlbumDetailView(albumId: item.id)
+        }
+        .task { await loadRecentlyAdded() }
+    }
+
+    @ViewBuilder
+    private func categoryRow(_ title: String, systemImage: String, destination: AnyView) -> some View {
+        NavigationLink {
+            destination
+        } label: {
+            Label(title, systemImage: systemImage)
+                .font(.title3)
+                .foregroundStyle(.tint)
+                .padding(.vertical, 6)
+        }
+        .accessibilityIdentifier("libraryHomeRow_\(title)")
+    }
+
+    @ViewBuilder
+    private func recentlyAddedCard(_ album: Album) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            AlbumArtView(coverArtId: album.coverArt, size: 140, cornerRadius: 10)
+                .shadow(color: .black.opacity(0.15), radius: 6, y: 3)
+            Text(album.name)
+                .font(.subheadline)
+                .fontWeight(.medium)
+                .lineLimit(1)
+            if let artist = album.artist {
+                Text(artist)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+        }
+        .frame(width: 140)
+    }
+
+    private func loadRecentlyAdded() async {
+        guard recentlyAdded.isEmpty, !isLoadingRecent else { return }
+        isLoadingRecent = true
+        defer { isLoadingRecent = false }
+        let client = appState.subsonicClient
+        if let cached = await client.cachedResponse(for: .getAlbumList2(type: .newest, size: 20), ttl: 3600) {
+            recentlyAdded = cached.albumList2?.album ?? []
+        }
+        if let result = try? await client.getAlbumList(type: .newest, size: 20) {
+            recentlyAdded = result
+        }
+    }
+}

--- a/Vibrdrome/Features/Library/LibraryLayoutConfig.swift
+++ b/Vibrdrome/Features/Library/LibraryLayoutConfig.swift
@@ -94,22 +94,26 @@ enum LibraryPill: String, CaseIterable, Codable, Identifiable {
 
 enum LibraryCarousel: String, CaseIterable, Codable, Identifiable {
     case recentlyAdded
+    case favoriteAlbums
     case mostPlayed
     case rediscover
     case randomPicks
     case recentlyPlayed
     case topArtists
+    case featuredGenre
 
     var id: String { rawValue }
 
     var title: String {
         switch self {
         case .recentlyAdded: "Recently Added"
+        case .favoriteAlbums: "Favorite Albums"
         case .mostPlayed: "Most Played"
         case .rediscover: "Rediscover"
         case .randomPicks: "Random Picks"
         case .recentlyPlayed: "Recently Played"
         case .topArtists: "Your Top Artists"
+        case .featuredGenre: "Featured Genre"
         }
     }
 }

--- a/Vibrdrome/Features/Library/LibraryView.swift
+++ b/Vibrdrome/Features/Library/LibraryView.swift
@@ -10,6 +10,9 @@ struct LibraryView: View {
     @State private var randomAlbums: [Album] = []
     @State private var recentlyPlayedAlbums: [Album] = []
     @State private var starredSongs: [Song] = []
+    @State private var favoriteAlbums: [Album] = []
+    @State private var featuredGenreAlbums: [Album] = []
+    @State private var featuredGenreName: String = ""
     @State private var topArtistNames: [(name: String, count: Int, coverArtId: String?)] = []
     @State private var isLoaded = false
     @State private var isLoadingRandomMix = false
@@ -50,7 +53,7 @@ struct LibraryView: View {
             }
             .navigationTitle(activeServerName)
             #if os(iOS)
-            .navigationBarTitleDisplayMode(.inline)
+            .navigationBarTitleDisplayMode(.large)
             #endif
             .toolbar {
                 #if os(iOS)
@@ -73,18 +76,18 @@ struct LibraryView: View {
                     .accessibilityIdentifier("createPlaylistButton")
                 }
                 ToolbarItem(placement: .topBarTrailing) {
-                    if settingsInNavBar {
-                        NavigationLink {
-                            SettingsView()
-                        } label: {
-                            Image(systemName: "gear")
+                    HStack(spacing: 14) {
+                        if settingsInNavBar {
+                            NavigationLink {
+                                SettingsView()
+                            } label: {
+                                Image(systemName: "gear")
+                            }
+                            .accessibilityLabel("Settings")
+                            .accessibilityIdentifier("settingsNavBarButton")
                         }
-                        .accessibilityLabel("Settings")
-                        .accessibilityIdentifier("settingsNavBarButton")
+                        profileMenu
                     }
-                }
-                ToolbarItem(placement: .topBarTrailing) {
-                    profileMenu
                 }
                 #else
                 ToolbarItem(placement: .automatic) {
@@ -166,6 +169,7 @@ struct LibraryView: View {
     // MARK: - Dynamic Carousel
 
     @ViewBuilder
+    // swiftlint:disable:next cyclomatic_complexity
     private func carouselView(for carousel: LibraryCarousel) -> some View {
         switch carousel {
         case .recentlyAdded:
@@ -199,6 +203,18 @@ struct LibraryView: View {
         case .topArtists:
             if !topArtistNames.isEmpty {
                 topArtistsCarousel
+            }
+        case .favoriteAlbums:
+            if !favoriteAlbums.isEmpty {
+                albumSection("Favorite Albums", albums: favoriteAlbums) {
+                    FavoritesView()
+                }
+            }
+        case .featuredGenre:
+            if !featuredGenreAlbums.isEmpty && !featuredGenreName.isEmpty {
+                albumSection("Featured: \(featuredGenreName)", albums: featuredGenreAlbums) {
+                    AlbumsView(listType: .byGenre, title: featuredGenreName, genre: featuredGenreName)
+                }
             }
         }
     }
@@ -653,13 +669,37 @@ struct LibraryView: View {
         randomAlbums = (try? await random) ?? randomAlbums
         recentlyPlayedAlbums = (try? await recentlyPlayed) ?? recentlyPlayedAlbums
 
-        if let result = try? await starred, var songs = result.song, !songs.isEmpty {
-            songs.shuffle()
-            starredSongs = Array(songs.prefix(15))
+        if let result = try? await starred {
+            if var songs = result.song, !songs.isEmpty {
+                songs.shuffle()
+                starredSongs = Array(songs.prefix(15))
+            }
+            if let albums = result.album {
+                favoriteAlbums = Array(albums.prefix(15))
+            }
         }
+
+        // Featured genre: pick a random genre with enough albums and load 10
+        await loadFeaturedGenre(client: client, folder: folder)
 
         // Load top artists from local play history
         loadTopArtists()
+    }
+
+    private func loadFeaturedGenre(client: SubsonicClient, folder: String?) async {
+        guard featuredGenreAlbums.isEmpty else { return }
+        guard let genres = try? await client.getGenres() else { return }
+        // Rotate daily: pick a genre using day-of-year seed so the featured
+        // carousel feels fresh without hitting the server every launch.
+        let seeded = genres.filter { ($0.albumCount ?? 0) >= 5 }
+        guard !seeded.isEmpty else { return }
+        let dayOfYear = Calendar.current.ordinality(of: .day, in: .year, for: Date()) ?? 0
+        let pick = seeded[dayOfYear % seeded.count]
+        featuredGenreName = pick.value.cleanedGenreDisplay
+        if let albums = try? await client.getAlbumList(
+            type: .byGenre, size: 10, genre: pick.value, musicFolderId: folder) {
+            featuredGenreAlbums = albums
+        }
     }
 
     private func loadTopArtists() {

--- a/Vibrdrome/Features/Library/SongsView.swift
+++ b/Vibrdrome/Features/Library/SongsView.swift
@@ -84,7 +84,7 @@ struct SongsView: View {
         }
         .navigationTitle(songs.isEmpty ? "Songs" : "Songs (\(songs.count))")
         #if os(iOS)
-        .navigationBarTitleDisplayMode(.inline)
+        .navigationBarTitleDisplayMode(.large)
         #endif
         #if os(iOS)
         .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .automatic), prompt: "Search songs")

--- a/Vibrdrome/Features/Player/MiniPlayerView.swift
+++ b/Vibrdrome/Features/Player/MiniPlayerView.swift
@@ -112,6 +112,7 @@ struct MiniPlayerView: View {
         #if os(iOS)
         .modifier(ConditionalGlassModifier(enabled: enableLiquidGlass))
         #endif
+        .frame(maxWidth: 560)
         .padding(.horizontal, 20)
         .accessibilityIdentifier("MiniPlayer")
         #if os(iOS)

--- a/Vibrdrome/Features/Settings/ServerConfigView.swift
+++ b/Vibrdrome/Features/Settings/ServerConfigView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct ServerConfigView: View {
     @Environment(AppState.self) private var appState
+    @State private var name = ""
     @State private var url = ""
     @State private var username = ""
     @State private var password = ""
@@ -70,6 +71,10 @@ struct ServerConfigView: View {
 
                 // Fields
                 VStack(spacing: 12) {
+                    TextField("Server Name", text: $name, prompt: Text("My Navidrome"))
+                        .textFieldStyle(.roundedBorder)
+                        .autocorrectionDisabled()
+
                     TextField("Server URL", text: $url, prompt: Text("https://music.example.com"))
                         .textFieldStyle(.roundedBorder)
                         .textContentType(.URL)
@@ -97,7 +102,7 @@ struct ServerConfigView: View {
                 // Buttons
                 VStack(spacing: 10) {
                     Button {
-                        appState.saveCredentials(url: url, username: username, password: password)
+                        appState.saveCredentials(url: url, username: username, password: password, name: name)
                         if !appState.isConfigured {
                             testResult = "Invalid server URL. Please enter a valid URL."
                         }
@@ -183,6 +188,10 @@ struct ServerConfigView: View {
                 }
 
                 Section("Server Details") {
+                    TextField("Name", text: $name, prompt: Text("My Navidrome"))
+                        .autocorrectionDisabled()
+                        .accessibilityIdentifier("serverNameField")
+
                     TextField("URL", text: $url, prompt: Text("https://..."))
                         .textContentType(.URL)
                         #if os(iOS)
@@ -214,7 +223,7 @@ struct ServerConfigView: View {
 
                 Section {
                     Button {
-                        appState.saveCredentials(url: url, username: username, password: password)
+                        appState.saveCredentials(url: url, username: username, password: password, name: name)
                         if appState.isConfigured {
                             dismiss()
                         } else {

--- a/Vibrdrome/Features/Settings/SettingsView.swift
+++ b/Vibrdrome/Features/Settings/SettingsView.swift
@@ -77,6 +77,15 @@ struct SettingsView: View {
             }
             .accessibilityIdentifier("appearanceSettingsLink")
 
+            #if os(iOS)
+            NavigationLink {
+                TabBarSettingsView()
+            } label: {
+                Label("Tab Bar", systemImage: "dock.rectangle")
+            }
+            .accessibilityIdentifier("tabBarSettingsLink")
+            #endif
+
             #if os(macOS)
             NavigationLink {
                 LayoutSettingsView()
@@ -89,13 +98,6 @@ struct SettingsView: View {
             downloadsSection
 
             #if os(iOS)
-            NavigationLink {
-                TabBarSettingsView()
-            } label: {
-                Label("Tab Bar", systemImage: "dock.rectangle")
-            }
-            .accessibilityIdentifier("tabBarSettingsLink")
-
             carPlaySection
             #endif
 

--- a/Vibrdrome/Features/Settings/TabBarSettingsView.swift
+++ b/Vibrdrome/Features/Settings/TabBarSettingsView.swift
@@ -32,9 +32,29 @@ struct TabBarSettingsView: View {
     private var defaultTabItems: [TabItemConfig] {
         var items = [
             TabItemConfig(
-                id: "library", name: "Library", icon: "music.note.house.fill",
-                description: "Browse your music library",
+                id: "library", name: "Home", icon: "house.fill",
+                description: "Carousels and quick access",
                 isAlwaysShown: true, defaultsKey: nil, defaultValue: true
+            ),
+            TabItemConfig(
+                id: "favorites", name: "Favorites", icon: "heart.fill",
+                description: "Your favorited songs, albums, and artists",
+                isAlwaysShown: false, defaultsKey: UserDefaultsKeys.showFavoritesTab, defaultValue: true
+            ),
+            TabItemConfig(
+                id: "library-home", name: "Library", icon: "music.note.house.fill",
+                description: "Playlists, artists, albums, songs, genres, downloads",
+                isAlwaysShown: false, defaultsKey: UserDefaultsKeys.showLibraryHomeTab, defaultValue: true
+            ),
+            TabItemConfig(
+                id: "search", name: "Search", icon: "magnifyingglass",
+                description: "Search songs, albums, and artists",
+                isAlwaysShown: false, defaultsKey: UserDefaultsKeys.showSearchTab, defaultValue: true
+            ),
+            TabItemConfig(
+                id: "radio", name: "Radio", icon: "antenna.radiowaves.left.and.right",
+                description: "Internet radio stations",
+                isAlwaysShown: false, defaultsKey: UserDefaultsKeys.showRadioTab, defaultValue: true
             ),
             TabItemConfig(
                 id: "artists", name: "Artists", icon: "music.mic",
@@ -57,24 +77,9 @@ struct TabBarSettingsView: View {
                 isAlwaysShown: false, defaultsKey: UserDefaultsKeys.showGenresTab, defaultValue: false
             ),
             TabItemConfig(
-                id: "favorites", name: "Favorites", icon: "heart.fill",
-                description: "Your favorited songs and albums",
-                isAlwaysShown: false, defaultsKey: UserDefaultsKeys.showFavoritesTab, defaultValue: false
-            ),
-            TabItemConfig(
-                id: "search", name: "Search", icon: "magnifyingglass",
-                description: "Search songs, albums, and artists",
-                isAlwaysShown: false, defaultsKey: UserDefaultsKeys.showSearchTab, defaultValue: true
-            ),
-            TabItemConfig(
                 id: "playlists", name: "Playlists", icon: "music.note.list",
                 description: "Your playlists",
-                isAlwaysShown: false, defaultsKey: UserDefaultsKeys.showPlaylistsTab, defaultValue: true
-            ),
-            TabItemConfig(
-                id: "radio", name: "Radio", icon: "antenna.radiowaves.left.and.right",
-                description: "Internet radio stations",
-                isAlwaysShown: false, defaultsKey: UserDefaultsKeys.showRadioTab, defaultValue: true
+                isAlwaysShown: false, defaultsKey: UserDefaultsKeys.showPlaylistsTab, defaultValue: false
             ),
             TabItemConfig(
                 id: "downloads", name: "Downloads", icon: "arrow.down.circle.fill",
@@ -126,7 +131,7 @@ struct TabBarSettingsView: View {
         } header: {
             settingSectionHeader("Settings Location", icon: "location.fill", color: .blue)
         } footer: {
-            Text("Settings will appear as a gear icon in the top-right of Library.")
+            Text("Settings will appear as a gear icon in the top-right of Home.")
         }
     }
 

--- a/Vibrdrome/Shared/Components/GenreIconView.swift
+++ b/Vibrdrome/Shared/Components/GenreIconView.swift
@@ -1,7 +1,15 @@
 import SwiftUI
+import NukeUI
 
 struct GenreIconView: View {
     let genre: String
+    let coverArtId: String?
+    @Environment(AppState.self) private var appState
+
+    init(genre: String, coverArtId: String? = nil) {
+        self.genre = genre
+        self.coverArtId = coverArtId
+    }
 
     private var style: (icon: String, colors: [Color]) {
         let key = genre.lowercased()
@@ -218,33 +226,49 @@ struct GenreIconView: View {
                                .init(red: 0.2, green: 0.2, blue: 0.3)])
     }
 
-    private var assetName: String {
-        "genre_" + genre.replacingOccurrences(of: " ", with: "_")
-            .replacingOccurrences(of: "/", with: "-")
-            .replacingOccurrences(of: "-", with: "_")
-    }
-
-    private var hasAsset: Bool {
-        #if os(iOS)
-        UIImage(named: assetName) != nil
-        #else
-        NSImage(named: assetName) != nil
-        #endif
-    }
-
     var body: some View {
-        if hasAsset {
-            Image(assetName)
-                .resizable()
-                .aspectRatio(contentMode: .fill)
-        } else {
-            let s = style
-            ZStack {
-                LinearGradient(colors: s.colors, startPoint: .topLeading, endPoint: .bottomTrailing)
-                Image(systemName: s.icon)
-                    .font(.system(size: 30, weight: .medium))
-                    .foregroundStyle(.white.opacity(0.9))
+        if let coverArtId {
+            LazyImage(url: appState.subsonicClient.coverArtURL(id: coverArtId, size: 300)) { state in
+                if let image = state.image {
+                    image.resizable().aspectRatio(contentMode: .fill)
+                } else {
+                    fallbackIcon
+                }
             }
+        } else {
+            fallbackIcon
+        }
+    }
+
+    private var fallbackIcon: some View {
+        let s = style
+        return ZStack {
+            LinearGradient(colors: s.colors, startPoint: .topLeading, endPoint: .bottomTrailing)
+            Image(systemName: s.icon)
+                .font(.system(size: 30, weight: .medium))
+                .foregroundStyle(.white.opacity(0.9))
         }
     }
 }
+
+#if os(iOS)
+import UIKit
+
+extension GenreIconView {
+    /// Rasterized icon for surfaces that can't host SwiftUI (e.g. CarPlay CPListItem).
+    /// Uses the gradient + SF Symbol fallback — the album-art path is only
+    /// visible in SwiftUI contexts because ImageRenderer here doesn't get the
+    /// model container. Callers wanting real album art (CarPlay) should fetch
+    /// the cover art URL via SubsonicClient.coverArtURL(id:) and load the image
+    /// themselves, falling back to this method if no artwork is cached yet.
+    @MainActor
+    static func uiImage(for genre: String, size: CGSize = CGSize(width: 80, height: 80)) -> UIImage? {
+        let view = GenreIconView(genre: genre)
+            .frame(width: size.width, height: size.height)
+            .clipShape(RoundedRectangle(cornerRadius: size.width * 0.15))
+        let renderer = ImageRenderer(content: view)
+        renderer.scale = UIScreen.main.scale
+        return renderer.uiImage
+    }
+}
+#endif

--- a/Vibrdrome/Vibrdrome.swift
+++ b/Vibrdrome/Vibrdrome.swift
@@ -142,6 +142,7 @@ struct VibrdromeApp: App {
         }
         #if os(macOS)
         .defaultSize(width: 1100, height: 750)
+        .windowStyle(.hiddenTitleBar)
         .commands {
             CommandMenu("Playback") {
                 PlaybackCommands()

--- a/VibrdromeTests/Features/LibraryPillTests.swift
+++ b/VibrdromeTests/Features/LibraryPillTests.swift
@@ -16,7 +16,7 @@ struct LibraryPillTests {
     }
 
     @Test func allCarouselsCount() {
-        #expect(LibraryCarousel.allCases.count == 6)
+        #expect(LibraryCarousel.allCases.count == 8)
     }
 
     @Test func defaultConfigIncludesAllPills() {

--- a/VibrdromeUITests/TestHelpers.swift
+++ b/VibrdromeUITests/TestHelpers.swift
@@ -259,11 +259,18 @@ extension XCUIApplication {
     }
 
     /// Tap the Playlists tab (iPhone) or Playlists sidebar item (iPad).
+    /// On iPhone, Playlists moved out of the default tab bar in Build 47 —
+    /// reach it through the Library tab (tap the "Library" tab first, then
+    /// the Playlists row). Falls back to the Playlists tab if still visible.
     func goToPlaylists() {
         if isSidebarLayout {
             tapSidebarItem("Playlists")
-        } else {
+        } else if tabBars.buttons["Playlists"].waitForExistence(timeout: 1) {
             tabBars.buttons["Playlists"].tap()
+        } else {
+            tabBars.buttons["Library"].tap()
+            let row = buttons["libraryHomeRow_Playlists"]
+            if row.waitForExistence(timeout: 2) { row.tap() }
         }
     }
 
@@ -272,16 +279,23 @@ extension XCUIApplication {
         if isSidebarLayout {
             tapSidebarItem("Stations")
         } else {
-            tabBars.buttons["Radio"].tap()
+            let radio = tabBars.buttons["Radio"]
+            if radio.waitForExistence(timeout: 2) { radio.tap() }
         }
     }
 
     /// Tap the Settings tab (iPhone) or Settings sidebar item (iPad).
+    /// Build 47 default hides the Settings tab (it's reachable via the gear
+    /// icon in the Home toolbar). Fall back to that when the tab is absent.
     func goToSettings() {
         if isSidebarLayout {
             tapSidebarItem("Settings")
-        } else {
+        } else if tabBars.buttons["Settings"].waitForExistence(timeout: 1) {
             tabBars.buttons["Settings"].tap()
+        } else {
+            tabBars.buttons["Home"].tap()
+            let gear = buttons["settingsNavBarButton"]
+            if gear.waitForExistence(timeout: 2) { gear.tap() }
         }
     }
 

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -347,6 +347,30 @@
 
         <div class="timeline">
 
+            <!-- Build 47 -->
+            <div class="timeline-item" data-animate>
+                <div class="build-card">
+                    <div class="build-header">
+                        <span class="build-badge">Build 47</span>
+                        <span class="build-date">April 18, 2026</span>
+                    </div>
+                    <ul>
+                        <li>New Apple Music-style Library tab with Playlists / Artists / Albums / Songs / Genres / Downloaded + Recently Added</li>
+                        <li>Default tab bar: Home, Favorites, Library, Search, Radio</li>
+                        <li>Favorites tab reworked with Songs / Albums / Artists segments and grid-list toggle</li>
+                        <li>New home carousels: Favorite Albums and Featured Genre (daily rotation)</li>
+                        <li>Heart button on Album Detail and Artist Detail to favorite/unfavorite</li>
+                        <li>Filter menu on Artists and Albums (All / Favorites / Downloaded)</li>
+                        <li>Genre list now uses real album artwork</li>
+                        <li>CarPlay: genre list shows album art + audio resumes after Siri/call/message interruptions</li>
+                        <li>macOS window title hidden next to traffic lights</li>
+                        <li>Larger section headings across library views</li>
+                        <li>iPad landscape mini player no longer stretches full-width</li>
+                        <li>536 unit tests in 40 suites</li>
+                    </ul>
+                </div>
+            </div>
+
             <!-- Build 46 -->
             <div class="timeline-item" data-animate>
                 <div class="build-card">

--- a/project.yml
+++ b/project.yml
@@ -89,7 +89,7 @@ targets:
         DEVELOPMENT_TEAM: 85JD2B827Q
         PRODUCT_BUNDLE_IDENTIFIER: com.vibrdrome.app
         MARKETING_VERSION: "1.0.0"
-        CURRENT_PROJECT_VERSION: "46"
+        CURRENT_PROJECT_VERSION: "47"
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS: "YES"
         SWIFT_ACTIVE_COMPILATION_CONDITIONS: "$(inherited) CARPLAY_ENABLED"
@@ -123,7 +123,7 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.vibrdrome.app.widget
         CODE_SIGN_ENTITLEMENTS: VibrdromeWidget/VibrdromeWidget.entitlements
         MARKETING_VERSION: "1.0.0"
-        CURRENT_PROJECT_VERSION: "46"
+        CURRENT_PROJECT_VERSION: "47"
     entitlements:
       path: VibrdromeWidget/VibrdromeWidget.entitlements
 
@@ -140,7 +140,7 @@ targets:
         DEVELOPMENT_TEAM: 85JD2B827Q
         PRODUCT_BUNDLE_IDENTIFIER: com.vibrdrome.app.watchkitapp
         MARKETING_VERSION: "1.0.0"
-        CURRENT_PROJECT_VERSION: "46"
+        CURRENT_PROJECT_VERSION: "47"
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         SWIFT_VERSION: "6.0"
 


### PR DESCRIPTION
## Summary

Community-feedback-driven UX overhaul plus CarPlay audio fix.

### Structure
- **New Library tab** (Apple Music-style): single entry point with Playlists / Artists / Albums / Songs / Genres / Downloaded + Recently Added carousel
- **Default tab bar**: Home, Favorites, Library, Search, Radio (new installs only)
- **Favorites tab**: Songs / Albums / Artists segmented picker, grid-list toggle
- **Heart button on Album Detail and Artist Detail** toolbars -- albums and artists can finally be favorited
- **New Home carousels**: Favorite Albums, Featured Genre (daily rotation)
- **Filter menus** on Artists and Albums (All / Favorites / Downloaded)

### Visual
- **Genre list uses real album art** via new `GenreArtwork` SwiftData cache; CarPlay genres list picks up the same artwork async
- Large-title nav across Home / Genres / Artists / Albums / Songs / Favorites / Generations
- macOS: window title hidden next to traffic lights
- iPad landscape mini player capped at 560pt maxWidth
- Home header spacing between gear + profile icon tightened

### CarPlay
- **Resume after interruptions fix**: audio now resumes after calls / Siri / Messages even when iOS omits `shouldResume`
- Route-change only pauses when `currentRoute.outputs.isEmpty` -- no more false-positive pauses on transient route flaps
- `os.log` diagnostics on interruption and route-change paths

### Settings
- Tab Bar settings moved to same level as Player / Appearance
- Tab bar settings label: "Library" -> "Home" for the Home tab entry
- Initial onboarding server setup gains the Server Name field

### Test infra
- UI test helpers updated for the new tab layout (Playlists reached via Library tab, Settings reached via Home gear when not in the bar)
- Carousel count test updated to 8 (added favoriteAlbums + featuredGenre)

## Test plan
- [x] SwiftLint -- 0 violations across 117 files
- [x] Unit tests -- 536/536 passing
- [x] UI tests (RotationTests) -- 12/12 passing
- [x] Security audit -- no concerns
- [x] Build iOS / macOS / watchOS -- 0 warnings
- [x] Device regression (iPhone) -- full smoke test passed
- [x] iPad + macOS sim testing -- all items confirmed
- [x] docs/ updates (CHANGELOG, changelog.html, TESTING.md)
- [x] Version bump + xcodegen + entitlements restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)