### PR TITLE
Build 50: Get Info, search shortcuts, toolbar polish, Radio Mix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to Vibrdrome (iOS/macOS) are documented here.
 
 ## v1.0.0
 
+### Build 50 -- April 21, 2026
+- Get Info window (from PR #13): long-press songs/albums/artists -> "Get Info" for a detail sheet with Overview and Raw metadata tabs. macOS opens in a separate window; iOS/iPad uses a sheet.
+- Search keyboard shortcuts on macOS (from PR #14): `CMD+K` jumps to the Search tab and focuses the field, `CMD+F` focuses the search bar in the current view. Discoverable via the new Navigate menu.
+- NowPlaying toolbar: hide the entire row when all items are disabled (previously left an empty rounded pill).
+- New Settings -> Player -> Toolbar Background toggle. Off for plain icons directly on the artwork; on keeps the pill + glass effect.
+- New Radio Mix toolbar item -- plays a mix of songs similar to the current track via Subsonic getSimilarSongs. Off by default, enable in Settings -> Player -> Controls.
+- Radio: grid cards now support long-press -> Delete Station (previously only list view).
+- Add Station form clarified with three labeled sections: Name, Stream URL, and Homepage (optional) each with explainer text.
+- Settings -> Appearance: subtitle under Liquid Glass toggle explains what it does.
+- iPad: mini player stays pinned at the bottom when the floating keyboard appears instead of riding up.
+- 536 unit tests in 40 suites; 12 UI rotation tests.
+
+**TestFlight Notes:**
+> Get Info window, CMD+K/CMD+F shortcuts on macOS, Now Playing toolbar
+> polish, Radio Mix button, Radio grid Delete Station, Add Station
+> clarity, Liquid Glass hint, iPad mini player keyboard fix.
+
 ### Build 49 -- April 20, 2026 (Hotfix)
 - Fix: CarPlay Genres crash on tap. Crash log showed `ImageRenderer._uiImage.getter` triggering `EnvironmentValues.subscript.getter` assertion — SwiftUI was eagerly evaluating `GenreIconView`'s `@Environment(AppState.self)` during rasterization and asserting because the CarPlay-side ImageRenderer had no environment chain. Replaced the per-row rasterized fallback with a plain SF Symbol. Album art still loads async and replaces the symbol when available.
 - Removed the now-unused `GenreIconView.uiImage(for:)` rasterization helper.

--- a/TESTING.md
+++ b/TESTING.md
@@ -25,6 +25,15 @@ Run through this checklist before every TestFlight build. Each item should be ve
 - [ ] Recently Played in Queue shows only songs actually listened to (not unplayed queue entries)
 - [ ] Spam-tap play/pause rapidly — no audio glitching or dropouts
 - [ ] Spam-tap different track rows rapidly — audio settles on the last-tapped track without churn
+- [ ] Now Playing: disable all toolbar items in Settings -> Player -> Controls; bottom row hides entirely (no empty pill)
+- [ ] Settings -> Player -> Toolbar Background toggle: off = no pill behind bottom icons; on = pill visible
+- [ ] Settings -> Player -> Controls -> Radio Mix toggle on; Now Playing shows the radio tower icon; tapping plays similar songs to current track
+- [ ] iPad Radio tab (landscape grid view): long-press any station card -> "Delete Station" menu appears
+- [ ] Radio -> Add URL: three labeled sections (Name, Stream URL, Homepage) with explainer footers
+- [ ] Settings -> Appearance: Liquid Glass toggle shows subtitle "Tinted pill backgrounds and translucent tab bar..."
+- [ ] iPad: with mini player visible, switch keyboard to floating mode; mini player stays pinned at screen bottom
+- [ ] macOS: menu bar shows Navigate menu with "Go to Search ⌘K" and "Focus Search ⌘F"; both shortcuts fire without beeping
+- [ ] Long-press any song/album/artist -> "Get Info" item; opens sheet (iOS) or window (macOS) with Overview and Raw metadata tabs
 
 ## Library & Navigation
 

--- a/Vibrdrome/Core/Audio/AudioEngine+Radio.swift
+++ b/Vibrdrome/Core/Audio/AudioEngine+Radio.swift
@@ -79,33 +79,43 @@ extension AudioEngine {
         })
     }
 
-    /// Start radio seeded from a specific song
+    /// Start radio seeded from a specific song. When the song has an artist
+    /// tag this falls into artist radio (artist + related artists); otherwise
+    /// it uses song-level similarity. Use `startSongSimilarityMix(_:)` when
+    /// the caller specifically wants "songs like this one" regardless of
+    /// whether the artist tag is present.
     func startRadioFromSong(_ song: Song) {
         if let artistName = song.artist {
             startRadio(artistName: artistName)
         } else {
-            stopRadioMode()
-            isRadioMode = true
-            radioSeedArtistName = nil
-            clearRadioSkippedIds()
-            setRadioRefillTask(Task { [weak self] in
-                guard let self else { return }
-                let client = AppState.shared.subsonicClient
-                var songs = (try? await client.getSimilarSongs(
-                    id: song.id, count: 30
-                )) ?? []
-                if songs.isEmpty {
-                    songs = (try? await client.getRandomSongs(size: 20)) ?? []
-                }
-                guard !Task.isCancelled else { return }
-                let unique = self.deduplicateRadioSongs(songs, against: [])
-                guard let first = unique.first else {
-                    self.isRadioMode = false
-                    return
-                }
-                self.play(song: first, from: unique)
-            })
+            startSongSimilarityMix(song)
         }
+    }
+
+    /// Play a mix of songs similar to the given track, independent of the
+    /// artist-radio path. Uses `getSimilarSongs` directly so the result is a
+    /// song-level similarity queue, matching what "Instant Mix" / "Radio Mix"
+    /// means in Apple Music / Spotify.
+    func startSongSimilarityMix(_ song: Song) {
+        stopRadioMode()
+        isRadioMode = true
+        radioSeedArtistName = nil
+        clearRadioSkippedIds()
+        setRadioRefillTask(Task { [weak self] in
+            guard let self else { return }
+            let client = AppState.shared.subsonicClient
+            var songs = (try? await client.getSimilarSongs(id: song.id, count: 30)) ?? []
+            if songs.isEmpty {
+                songs = (try? await client.getRandomSongs(size: 20)) ?? []
+            }
+            guard !Task.isCancelled else { return }
+            let unique = self.deduplicateRadioSongs(songs, against: [])
+            guard let first = unique.first else {
+                self.isRadioMode = false
+                return
+            }
+            self.play(song: first, from: unique)
+        })
     }
 
     /// Skip current track and block it from future radio results

--- a/Vibrdrome/Core/Constants/UserDefaultsKeys.swift
+++ b/Vibrdrome/Core/Constants/UserDefaultsKeys.swift
@@ -1,5 +1,14 @@
 import Foundation
 
+// MARK: - Notification Names
+
+extension Notification.Name {
+    /// Posted to navigate to the Search view and focus its search bar.
+    static let navigateToSearch = Notification.Name("com.vibrdrome.navigateToSearch")
+    /// Posted to focus the search bar in the currently visible view.
+    static let focusSearchBar = Notification.Name("com.vibrdrome.focusSearchBar")
+}
+
 /// Centralized UserDefaults key constants.
 /// Use with both `UserDefaults.standard` and `@AppStorage`.
 enum UserDefaultsKeys {

--- a/Vibrdrome/Core/Constants/UserDefaultsKeys.swift
+++ b/Vibrdrome/Core/Constants/UserDefaultsKeys.swift
@@ -68,6 +68,8 @@ enum UserDefaultsKeys {
     static let showAirPlayInToolbar = "showAirPlayInToolbar"
     static let showLyricsInToolbar = "showLyricsInToolbar"
     static let showSettingsInToolbar = "showSettingsInToolbar"
+    static let showRadioMixInToolbar = "showRadioMixInToolbar"
+    static let nowPlayingToolbarBackground = "nowPlayingToolbarBackground"
     static let nowPlayingToolbarOrder = "nowPlayingToolbarOrder"
 
     // MARK: - Discord

--- a/Vibrdrome/Core/Networking/SubsonicClient.swift
+++ b/Vibrdrome/Core/Networking/SubsonicClient.swift
@@ -191,6 +191,90 @@ final class SubsonicClient {
         return buildURL(path: "/rest/getCoverArt", extra: extra)
     }
 
+    // MARK: - Raw JSON Metadata
+
+    /// Returns the raw decoded JSON object under `subsonic-response` for an endpoint.
+    /// Useful for diagnostics and exposing metadata fields not modeled in typed structs.
+    func rawSubsonicResponse(for endpoint: SubsonicEndpoint) async throws -> [String: Any] {
+        guard var components = URLComponents(
+            url: baseURL.appendingPathComponent(endpoint.path),
+            resolvingAgainstBaseURL: false
+        ) else {
+            throw SubsonicError.invalidURL
+        }
+        components.queryItems = auth.authParameters() + endpoint.queryItems
+
+        guard let url = components.url else {
+            throw SubsonicError.invalidURL
+        }
+
+        let (data, response) = try await session.data(from: url)
+
+        guard let httpResponse = response as? HTTPURLResponse,
+              (200...299).contains(httpResponse.statusCode) else {
+            let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
+            throw SubsonicError.httpError(statusCode)
+        }
+
+        let json = try JSONSerialization.jsonObject(with: data)
+        guard let root = json as? [String: Any],
+              let subsonic = root["subsonic-response"] as? [String: Any] else {
+            let error = NSError(
+                domain: "SubsonicClient",
+                code: -1,
+                userInfo: [NSLocalizedDescriptionKey: "Unexpected JSON format"]
+            )
+            throw SubsonicError.decodingError(error)
+        }
+
+        if let status = subsonic["status"] as? String, status != "ok" {
+            if let error = subsonic["error"] as? [String: Any] {
+                let code = error["code"] as? Int ?? 0
+                let message = error["message"] as? String ?? "Unknown API error"
+                throw SubsonicError.apiError(code: code, message: message)
+            }
+            throw SubsonicError.apiError(code: 0, message: "Server returned status: \(status)")
+        }
+
+        return subsonic
+    }
+
+    /// Returns Navidrome inspect metadata for a media item ID when available.
+    /// This endpoint includes `rawTags` with full file tag key/value arrays.
+    func inspectMetadata(id: String) async throws -> [String: Any] {
+        guard var components = URLComponents(
+            url: baseURL.appendingPathComponent("api/inspect"),
+            resolvingAgainstBaseURL: false
+        ) else {
+            throw SubsonicError.invalidURL
+        }
+        components.queryItems = [URLQueryItem(name: "id", value: id)] + auth.authParameters()
+
+        guard let url = components.url else {
+            throw SubsonicError.invalidURL
+        }
+
+        let (data, response) = try await session.data(from: url)
+
+        guard let httpResponse = response as? HTTPURLResponse,
+              (200...299).contains(httpResponse.statusCode) else {
+            let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
+            throw SubsonicError.httpError(statusCode)
+        }
+
+        let json = try JSONSerialization.jsonObject(with: data)
+        guard let payload = json as? [String: Any] else {
+            let error = NSError(
+                domain: "SubsonicClient",
+                code: -1,
+                userInfo: [NSLocalizedDescriptionKey: "Unexpected inspect JSON format"]
+            )
+            throw SubsonicError.decodingError(error)
+        }
+
+        return payload
+    }
+
     func downloadURL(id: String) -> URL {
         buildURL(path: "/rest/download", extra: [URLQueryItem(name: "id", value: id)])
     }

--- a/Vibrdrome/Features/Library/AlbumDetailView.swift
+++ b/Vibrdrome/Features/Library/AlbumDetailView.swift
@@ -575,6 +575,7 @@ struct AlbumDetailView: View {
                                 .frame(width: Theme.albumCardSize)
                             }
                             .buttonStyle(.plain)
+                            .albumGetInfoContextMenu(album: similar)
                         }
                     }
                     .padding(.horizontal, 16)

--- a/Vibrdrome/Features/Library/AlbumsView.swift
+++ b/Vibrdrome/Features/Library/AlbumsView.swift
@@ -10,6 +10,7 @@ struct AlbumsView: View {
     var toYear: Int?
 
     @Environment(AppState.self) private var appState
+    @Environment(\.openWindow) private var openWindow
     @State private var albums: [Album] = []
     @State private var isLoading = true
     @State private var error: String?
@@ -17,6 +18,7 @@ struct AlbumsView: View {
     @State private var searchText = ""
     @State private var activeListType: AlbumListType?
     @State private var clientSideSort: AlbumSortOption?
+    @State private var getInfoTarget: GetInfoTarget?
     @AppStorage("albumsViewStyle") private var showAsList = false
     @AppStorage(UserDefaultsKeys.gridColumnsPerRow) private var gridColumns = 2
     @Environment(\.modelContext) private var modelContext
@@ -294,6 +296,19 @@ struct AlbumsView: View {
             hasMore = true
             await loadAlbums()
         }
+        #if os(iOS)
+        .sheet(item: $getInfoTarget) { target in
+            NavigationStack {
+                GetInfoView(target: target)
+                    .toolbar {
+                        ToolbarItem(placement: .confirmationAction) {
+                            Button("Done") { getInfoTarget = nil }
+                        }
+                    }
+            }
+            .environment(appState)
+        }
+        #endif
     }
 
     private func loadFavoritedAlbumIds() async {
@@ -412,6 +427,16 @@ struct AlbumsView: View {
                     DownloadManager.shared.downloadAlbum(songs: songs, client: appState.subsonicClient)
                 }
             } label: { Label("Download", systemImage: "arrow.down.circle") }
+
+            Divider()
+
+            Button {
+                #if os(macOS)
+                openWindow(id: "get-info", value: GetInfoTarget(type: .album, id: album.id))
+                #else
+                getInfoTarget = GetInfoTarget(type: .album, id: album.id)
+                #endif
+            } label: { Label("Get Info", systemImage: "doc.text.magnifyingglass") }
         }
     }
 

--- a/Vibrdrome/Features/Library/AlbumsView.swift
+++ b/Vibrdrome/Features/Library/AlbumsView.swift
@@ -16,6 +16,7 @@ struct AlbumsView: View {
     @State private var error: String?
     @State private var hasMore = true
     @State private var searchText = ""
+    @State private var searchIsActive = false
     @State private var activeListType: AlbumListType?
     @State private var clientSideSort: AlbumSortOption?
     @State private var getInfoTarget: GetInfoTarget?
@@ -130,7 +131,7 @@ struct AlbumsView: View {
         .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .automatic), prompt: "Search in Albums")
         .navigationBarTitleDisplayMode(.large)
         #else
-        .searchable(text: $searchText, prompt: "Search in Albums")
+        .searchable(text: $searchText, isPresented: $searchIsActive, prompt: "Search in Albums")
         #endif
         .onChange(of: searchText) { _, newValue in
             searchTask?.cancel()
@@ -147,6 +148,10 @@ struct AlbumsView: View {
                 guard !Task.isCancelled else { return }
                 searchResults = results?.album ?? []
             }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .focusSearchBar)) { _ in
+            searchIsActive = false
+            DispatchQueue.main.async { searchIsActive = true }
         }
         .overlay {
             if isLoading && albums.isEmpty {

--- a/Vibrdrome/Features/Library/ArtistDetailView.swift
+++ b/Vibrdrome/Features/Library/ArtistDetailView.swift
@@ -65,6 +65,7 @@ struct ArtistDetailView: View {
                             AlbumCard(album: album)
                         }
                         .accessibilityIdentifier("artistAlbumRow_\(album.id)")
+                        .albumGetInfoContextMenu(album: album)
                     }
                 } header: {
                     Text("Albums (\(albums.count))")
@@ -96,6 +97,7 @@ struct ArtistDetailView: View {
                                 }
                                 .buttonStyle(.plain)
                                 .accessibilityIdentifier("similarArtist_\(similar.id)")
+                                .artistGetInfoContextMenu(artist: similar)
                             }
                         }
                         .padding(.horizontal, 16)

--- a/Vibrdrome/Features/Library/ArtistsView.swift
+++ b/Vibrdrome/Features/Library/ArtistsView.swift
@@ -214,6 +214,7 @@ struct ArtistsView: View {
                                 ArtistRow(artist: artist)
                             }
                             .accessibilityIdentifier("artistRow_\(artist.id)")
+                            .artistGetInfoContextMenu(artist: artist)
                         }
                     }
                 }
@@ -266,6 +267,7 @@ struct ArtistsView: View {
                                 }
                                 .buttonStyle(.plain)
                                 .accessibilityIdentifier("artistCard_\(artist.id)")
+                                .artistGetInfoContextMenu(artist: artist)
                             }
                         }
                         .padding(.horizontal, 16)

--- a/Vibrdrome/Features/Library/ArtistsView.swift
+++ b/Vibrdrome/Features/Library/ArtistsView.swift
@@ -7,6 +7,7 @@ struct ArtistsView: View {
     @State private var isLoading = true
     @State private var error: String?
     @State private var searchText = ""
+    @State private var searchIsActive = false
     @State private var sortReversed = false
     @State private var favoritedArtistIds: Set<String> = []
     @AppStorage("artistsViewStyle") private var showAsList = true
@@ -120,8 +121,12 @@ struct ArtistsView: View {
         .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .automatic), prompt: "Search Artists")
         .navigationBarTitleDisplayMode(.large)
         #else
-        .searchable(text: $searchText, prompt: "Search Artists")
+        .searchable(text: $searchText, isPresented: $searchIsActive, prompt: "Search Artists")
         #endif
+        .onReceive(NotificationCenter.default.publisher(for: .focusSearchBar)) { _ in
+            searchIsActive = false
+            DispatchQueue.main.async { searchIsActive = true }
+        }
         .overlay {
             if isLoading && indexes.isEmpty {
                 ProgressView("Loading artists...")

--- a/Vibrdrome/Features/Library/ContentView.swift
+++ b/Vibrdrome/Features/Library/ContentView.swift
@@ -184,6 +184,10 @@ struct ContentView: View {
             if engine.currentSong != nil || engine.currentRadioStation != nil {
                 MiniPlayerView()
                     .padding(.bottom, 54)
+                    // Pin to the screen bottom regardless of keyboard presence.
+                    // Without this, iPad floating keyboards drag the mini
+                    // player up to where a docked keyboard would sit.
+                    .ignoresSafeArea(.keyboard, edges: .bottom)
             }
         }
     }
@@ -311,6 +315,10 @@ struct ContentView: View {
             if engine.currentSong != nil || engine.currentRadioStation != nil {
                 MiniPlayerView()
                     .padding(.bottom, 54)
+                    // Pin to the screen bottom regardless of keyboard presence.
+                    // Without this, iPad floating keyboards drag the mini
+                    // player up to where a docked keyboard would sit.
+                    .ignoresSafeArea(.keyboard, edges: .bottom)
             }
         }
     }

--- a/Vibrdrome/Features/Library/FavoritesView.swift
+++ b/Vibrdrome/Features/Library/FavoritesView.swift
@@ -6,6 +6,7 @@ struct FavoritesView: View {
     @State private var isLoading = true
     @State private var error: String?
     @State private var searchText = ""
+    @State private var searchIsActive = false
     @State private var selectedSongs = Set<String>()
     @State private var isSelecting = false
     @State private var showBatchAddToPlaylist = false
@@ -73,8 +74,12 @@ struct FavoritesView: View {
         .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .automatic), prompt: "Search Favorites")
         .navigationBarTitleDisplayMode(.large)
         #else
-        .searchable(text: $searchText, prompt: "Search Favorites")
+        .searchable(text: $searchText, isPresented: $searchIsActive, prompt: "Search Favorites")
         #endif
+        .onReceive(NotificationCenter.default.publisher(for: .focusSearchBar)) { _ in
+            searchIsActive = false
+            DispatchQueue.main.async { searchIsActive = true }
+        }
         .overlay {
             if isLoading && starred == nil {
                 ProgressView("Loading favorites...")

--- a/Vibrdrome/Features/Library/FavoritesView.swift
+++ b/Vibrdrome/Features/Library/FavoritesView.swift
@@ -244,6 +244,7 @@ struct FavoritesView: View {
                     AlbumCard(album: album)
                 }
                 .accessibilityIdentifier("favAlbumRow_\(album.id)")
+                .albumGetInfoContextMenu(album: album)
             }
             .listStyle(.plain)
         } else {
@@ -272,6 +273,7 @@ struct FavoritesView: View {
                         }
                         .buttonStyle(.plain)
                         .accessibilityIdentifier("favAlbumCard_\(album.id)")
+                        .albumGetInfoContextMenu(album: album)
                     }
                 }
                 .padding(16)
@@ -294,6 +296,7 @@ struct FavoritesView: View {
                     ArtistRow(artist: artist)
                 }
                 .accessibilityIdentifier("favArtistRow_\(artist.id)")
+                .artistGetInfoContextMenu(artist: artist)
             }
             .listStyle(.plain)
         } else {
@@ -317,6 +320,7 @@ struct FavoritesView: View {
                         }
                         .buttonStyle(.plain)
                         .accessibilityIdentifier("favArtistCard_\(artist.id)")
+                        .artistGetInfoContextMenu(artist: artist)
                     }
                 }
                 .padding(16)

--- a/Vibrdrome/Features/Library/GenresView.swift
+++ b/Vibrdrome/Features/Library/GenresView.swift
@@ -21,6 +21,7 @@ struct GenresView: View {
         )
     }
     @State private var searchText = ""
+    @State private var searchIsActive = false
     @State private var sortBy: GenreSortOption = .name
     @AppStorage("genresViewStyle") private var showAsList = true
     @AppStorage(UserDefaultsKeys.gridColumnsPerRow) private var gridColumns = 2
@@ -67,8 +68,12 @@ struct GenresView: View {
         #if os(iOS)
         .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .automatic), prompt: "Search Genres")
         #else
-        .searchable(text: $searchText, prompt: "Search Genres")
+        .searchable(text: $searchText, isPresented: $searchIsActive, prompt: "Search Genres")
         #endif
+        .onReceive(NotificationCenter.default.publisher(for: .focusSearchBar)) { _ in
+            searchIsActive = false
+            DispatchQueue.main.async { searchIsActive = true }
+        }
         #if os(iOS)
         .navigationBarTitleDisplayMode(.large)
         #endif

--- a/Vibrdrome/Features/Library/GetInfoView.swift
+++ b/Vibrdrome/Features/Library/GetInfoView.swift
@@ -1,0 +1,708 @@
+import SwiftUI
+import os.log
+
+// MARK: - GetInfoTarget
+
+/// Identifies which item to show info for. Codable so it can be used with openWindow(id:value:).
+struct GetInfoTarget: Codable, Hashable, Identifiable {
+    enum ItemType: String, Codable { case song, album, artist }
+    let type: ItemType
+    let id: String
+}
+
+// MARK: - GetInfoViewModel
+
+@Observable
+@MainActor
+final class GetInfoViewModel {
+    // Song
+    var song: Song?
+    // Album
+    var album: Album?
+    var albumInfo: AlbumInfo2?
+    // Artist
+    var artist: Artist?
+    var artistInfo: ArtistInfo2?
+    // Raw API metadata payloads, including fields not modeled in typed structs
+    var rawMetadataPayloads: [String: Any] = [:]
+    // Common state
+    var isLoading = false
+    var errorMessage: String?
+
+    func load(target: GetInfoTarget, client: SubsonicClient) async {
+        isLoading = true
+        errorMessage = nil
+        rawMetadataPayloads = [:]
+        defer { isLoading = false }
+        do {
+            switch target.type {
+            case .song:
+                async let songResult = client.getSong(id: target.id)
+                let s = try await songResult
+                song = s
+                if let rawSong = try? await client.rawSubsonicResponse(for: .getSong(id: target.id)) {
+                    rawMetadataPayloads["getSong"] = rawSong
+                }
+                if let inspect = try? await client.inspectMetadata(id: target.id) {
+                    rawMetadataPayloads["inspect"] = inspect
+                }
+                // Also fetch album info if available
+                if let albumId = s.albumId {
+                    albumInfo = try? await client.getAlbumInfo(id: albumId)
+                    if let rawAlbumInfo = try? await client.rawSubsonicResponse(for: .getAlbumInfo2(id: albumId)) {
+                        rawMetadataPayloads["getAlbumInfo2"] = rawAlbumInfo
+                    }
+                }
+            case .album:
+                async let albumResult = client.getAlbum(id: target.id)
+                async let infoResult = client.getAlbumInfo(id: target.id)
+                album = try await albumResult
+                albumInfo = try? await infoResult
+                if let rawAlbum = try? await client.rawSubsonicResponse(for: .getAlbum(id: target.id)) {
+                    rawMetadataPayloads["getAlbum"] = rawAlbum
+                }
+                if let rawAlbumInfo = try? await client.rawSubsonicResponse(for: .getAlbumInfo2(id: target.id)) {
+                    rawMetadataPayloads["getAlbumInfo2"] = rawAlbumInfo
+                }
+            case .artist:
+                async let artistResult = client.getArtist(id: target.id)
+                async let infoResult = client.getArtistInfo(id: target.id)
+                artist = try await artistResult
+                artistInfo = try? await infoResult
+                if let rawArtist = try? await client.rawSubsonicResponse(for: .getArtist(id: target.id)) {
+                    rawMetadataPayloads["getArtist"] = rawArtist
+                }
+                if let rawArtistInfo = try? await client.rawSubsonicResponse(for: .getArtistInfo2(id: target.id)) {
+                    rawMetadataPayloads["getArtistInfo2"] = rawArtistInfo
+                }
+            }
+        } catch {
+            errorMessage = ErrorPresenter.userMessage(for: error)
+        }
+    }
+}
+
+// MARK: - GetInfoView
+
+struct GetInfoView: View {
+    let target: GetInfoTarget
+
+    @Environment(AppState.self) private var appState
+    @State private var vm = GetInfoViewModel()
+
+    var body: some View {
+        Group {
+            if vm.isLoading && !hasContent {
+                ProgressView()
+                    .frame(maxWidth: .infinity, minHeight: 200)
+            } else if let err = vm.errorMessage, !hasContent {
+                ContentUnavailableView {
+                    Label("Error", systemImage: "exclamationmark.triangle")
+                } description: {
+                    Text(err)
+                } actions: {
+                    Button("Retry") { Task { await vm.load(target: target, client: appState.subsonicClient) } }
+                        .buttonStyle(.bordered)
+                }
+            } else {
+                TabView {
+                    overviewTab
+                        .tabItem { Text("Overview") }
+                        .accessibilityLabel("Overview tab")
+                    rawMetadataTab
+                        .tabItem { Text("Raw metadata") }
+                        .accessibilityLabel("Raw metadata tab")
+                }
+            }
+        }
+        .navigationTitle(navigationTitle)
+        #if os(iOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+        .task { await vm.load(target: target, client: appState.subsonicClient) }
+    }
+
+    @ViewBuilder
+    private var overviewTab: some View {
+        ScrollView {
+            VStack(spacing: 24) {
+                switch target.type {
+                case .song:
+                    if let song = vm.song {
+                        songContent(song)
+                    }
+                case .album:
+                    if let album = vm.album {
+                        albumContent(album)
+                    }
+                case .artist:
+                    if let artist = vm.artist {
+                        artistContent(artist)
+                    }
+                }
+            }
+            .padding(.horizontal, 24)
+            .padding(.vertical, 20)
+            .frame(maxWidth: 700)
+            .frame(maxWidth: .infinity)
+        }
+    }
+
+    @ViewBuilder
+    private var rawMetadataTab: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 12) {
+                if rawMetadataRows.isEmpty {
+                    ContentUnavailableView {
+                        Label("No Metadata", systemImage: "doc.text")
+                    } description: {
+                        Text("No raw metadata is available for this item.")
+                    }
+                } else {
+                    HStack {
+                        Text("Raw metadata")
+                            .font(.headline)
+                        Spacer()
+                        Button {
+                            let text = rawMetadataRows.map { "\($0.key)\t\($0.value)" }.joined(separator: "\n")
+                            #if os(macOS)
+                            NSPasteboard.general.clearContents()
+                            NSPasteboard.general.setString(text, forType: .string)
+                            #else
+                            UIPasteboard.general.string = text
+                            #endif
+                        } label: {
+                            Label("Copy All", systemImage: "doc.on.doc")
+                                .font(.callout)
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                    }
+
+                    rawMetadataTable
+                }
+            }
+            .padding(.horizontal, 20)
+            .padding(.vertical, 16)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private var hasContent: Bool {
+        vm.song != nil || vm.album != nil || vm.artist != nil
+    }
+
+    private var navigationTitle: String {
+        if let s = vm.song { return s.title }
+        if let a = vm.album { return a.name }
+        if let a = vm.artist { return a.name }
+        return "Get Info"
+    }
+
+    // MARK: - Song Content
+
+    // swiftlint:disable cyclomatic_complexity
+    @ViewBuilder
+    private func songContent(_ song: Song) -> some View {
+        // Art + title header
+        VStack(spacing: 16) {
+            AlbumArtView(coverArtId: song.coverArt, size: 220, cornerRadius: 12)
+                .shadow(color: .black.opacity(0.25), radius: 14, y: 6)
+
+            VStack(spacing: 4) {
+                Text(song.title)
+                    .font(.title2).bold()
+                    .multilineTextAlignment(.center)
+                if let artist = song.artist {
+                    Text(artist).font(.body).foregroundStyle(.secondary)
+                }
+                if let album = song.album {
+                    Text(album).font(.caption).foregroundStyle(.tertiary)
+                }
+            }
+        }
+
+        sectionHeader("Track Details")
+        infoGrid {
+            if let track = song.track { infoCell("Track", "\(track)") }
+            if let disc = song.discNumber { infoCell("Disc", "\(disc)") }
+            if let year = song.year { infoCell("Year", "\(year)") }
+            if let genre = song.genre { infoCell("Genre", genre) }
+            if let duration = song.duration { infoCell("Duration", formatDuration(duration)) }
+            if let bpm = song.bpm, bpm > 0 { infoCell("BPM", "\(bpm)") }
+        }
+
+        sectionHeader("Audio")
+        infoGrid {
+            if let suffix = song.suffix { infoCell("Format", suffix.uppercased()) }
+            if let bitRate = song.bitRate { infoCell("Bitrate", "\(bitRate) kbps") }
+            if let size = song.size { infoCell("File Size", formatBytes(size)) }
+            if let contentType = song.contentType { infoCell("MIME Type", contentType) }
+            if let rg = song.replayGain {
+                if let tg = rg.trackGain { infoCell("Track Gain", String(format: "%.2f dB", tg)) }
+                if let ag = rg.albumGain { infoCell("Album Gain", String(format: "%.2f dB", ag)) }
+                if let tp = rg.trackPeak { infoCell("Track Peak", String(format: "%.4f", tp)) }
+            }
+        }
+
+        sectionHeader("Identifiers")
+        infoGrid {
+            infoCell("Song ID", song.id)
+            if let albumId = song.albumId { infoCell("Album ID", albumId) }
+            if let artistId = song.artistId { infoCell("Artist ID", artistId) }
+            if let parent = song.parent { infoCell("Parent ID", parent) }
+            if let mbid = song.musicBrainzId { infoCell("MusicBrainz ID", mbid) }
+            if let path = song.path { infoCell("Path", path) }
+            if let created = song.created { infoCell("Added", created) }
+        }
+
+        if let notes = vm.albumInfo?.notes, !notes.isEmpty {
+            sectionHeader("Album Notes")
+            Text(stripHtml(notes))
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(14)
+                .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 10))
+        }
+
+        externalLinksSection(mbid: song.musicBrainzId, lastFmUrl: vm.albumInfo?.lastFmUrl)
+    }
+    // swiftlint:enable cyclomatic_complexity
+
+    // MARK: - Album Content
+
+    // swiftlint:disable cyclomatic_complexity function_body_length
+    @ViewBuilder
+    private func albumContent(_ album: Album) -> some View {
+        VStack(spacing: 16) {
+            AlbumArtView(coverArtId: album.coverArt, size: 220, cornerRadius: 12)
+                .shadow(color: .black.opacity(0.25), radius: 14, y: 6)
+
+            VStack(spacing: 4) {
+                Text(album.name)
+                    .font(.title2).bold()
+                    .multilineTextAlignment(.center)
+                if let artist = album.artist {
+                    Text(artist).font(.body).foregroundStyle(.secondary)
+                }
+            }
+        }
+
+        sectionHeader("Album Details")
+        infoGrid {
+            if let year = album.year { infoCell("Year", "\(year)") }
+            if let genre = album.genre { infoCell("Genre", genre) }
+            if let count = album.songCount { infoCell("Tracks", "\(count)") }
+            if let dur = album.duration { infoCell("Duration", formatDuration(dur)) }
+            if let created = album.created { infoCell("Added", created) }
+        }
+
+        sectionHeader("Identifiers")
+        infoGrid {
+            infoCell("Album ID", album.id)
+            if let artistId = album.artistId { infoCell("Artist ID", artistId) }
+            if let mbid = vm.albumInfo?.musicBrainzId { infoCell("MusicBrainz ID", mbid) }
+        }
+
+        if let rg = album.replayGain {
+            sectionHeader("Replay Gain")
+            infoGrid {
+                if let ag = rg.albumGain { infoCell("Album Gain", String(format: "%.2f dB", ag)) }
+                if let tg = rg.trackGain { infoCell("Track Gain", String(format: "%.2f dB", tg)) }
+                if let ap = rg.albumPeak { infoCell("Album Peak", String(format: "%.4f", ap)) }
+                if let tp = rg.trackPeak { infoCell("Track Peak", String(format: "%.4f", tp)) }
+            }
+        }
+
+        if let notes = vm.albumInfo?.notes, !notes.isEmpty {
+            sectionHeader("Notes")
+            Text(stripHtml(notes))
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(14)
+                .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 10))
+        }
+
+        externalLinksSection(mbid: vm.albumInfo?.musicBrainzId, lastFmUrl: vm.albumInfo?.lastFmUrl)
+    }
+    // swiftlint:enable cyclomatic_complexity function_body_length
+
+    // MARK: - Artist Content
+
+    @ViewBuilder
+    private func artistContent(_ artist: Artist) -> some View {
+        VStack(spacing: 16) {
+            AlbumArtView(coverArtId: artist.coverArt, size: 180, cornerRadius: 90)
+                .shadow(color: .black.opacity(0.25), radius: 14, y: 6)
+
+            VStack(spacing: 4) {
+                Text(artist.name)
+                    .font(.title2).bold()
+                if let count = artist.albumCount {
+                    Text("\(count) album\(count == 1 ? "" : "s")")
+                        .font(.body).foregroundStyle(.secondary)
+                }
+            }
+        }
+
+        sectionHeader("Identifiers")
+        infoGrid {
+            infoCell("Artist ID", artist.id)
+            if let mbid = vm.artistInfo?.musicBrainzId { infoCell("MusicBrainz ID", mbid) }
+        }
+
+        if let bio = vm.artistInfo?.biography, !bio.isEmpty {
+            sectionHeader("Biography")
+            Text(stripHtml(bio))
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(14)
+                .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 10))
+        }
+
+        externalLinksSection(mbid: vm.artistInfo?.musicBrainzId, lastFmUrl: vm.artistInfo?.lastFmUrl)
+
+        if let similar = vm.artistInfo?.similarArtist, !similar.isEmpty {
+            sectionHeader("Similar Artists")
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 120), spacing: 8)], spacing: 8) {
+                ForEach(similar) { a in
+                    HStack {
+                        AlbumArtView(coverArtId: a.coverArt, size: 36, cornerRadius: 18)
+                        Text(a.name).font(.caption).lineLimit(1)
+                        Spacer()
+                    }
+                    .padding(8)
+                    .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 8))
+                }
+            }
+        }
+    }
+
+    // MARK: - Shared Helpers
+
+    @ViewBuilder
+    private func sectionHeader(_ title: String) -> some View {
+        Text(title)
+            .font(.headline)
+            .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    @ViewBuilder
+    private func infoGrid<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {
+        let columns = [GridItem(.adaptive(minimum: 150), spacing: 10)]
+        LazyVGrid(columns: columns, alignment: .leading, spacing: 10, content: content)
+    }
+
+    private func infoCell(_ label: String, _ value: String) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(label)
+                .font(.caption2)
+                .fontWeight(.semibold)
+                .foregroundStyle(.tertiary)
+                .textCase(.uppercase)
+            Text(value)
+                .font(.subheadline)
+                .lineLimit(2)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(10)
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 10))
+    }
+
+    @ViewBuilder
+    private func externalLinksSection(mbid: String?, lastFmUrl: String?) -> some View {
+        let hasMbid = mbid != nil
+        let hasLastFm = lastFmUrl != nil
+        if hasMbid || hasLastFm {
+            sectionHeader("External Links")
+            HStack(spacing: 10) {
+                if let mbid, let url = URL(string: "https://musicbrainz.org/recording/\(mbid)") {
+                    Link(destination: url) {
+                        Label("MusicBrainz", systemImage: "globe")
+                            .font(.callout)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 8)
+                    }
+                    .buttonStyle(.bordered)
+                }
+                if let lfm = lastFmUrl, let url = URL(string: lfm) {
+                    Link(destination: url) {
+                        Label("Last.fm", systemImage: "globe")
+                            .font(.callout)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 8)
+                    }
+                    .buttonStyle(.bordered)
+                }
+            }
+        }
+    }
+
+    private func stripHtml(_ html: String) -> String {
+        // Simple regex-free strip: remove tags
+        var result = html
+        while let start = result.range(of: "<"), let end = result.range(of: ">", range: start.upperBound..<result.endIndex) {
+            result.removeSubrange(start.lowerBound...end.lowerBound)
+        }
+        return result
+            .replacingOccurrences(of: "&amp;", with: "&")
+            .replacingOccurrences(of: "&lt;", with: "<")
+            .replacingOccurrences(of: "&gt;", with: ">")
+            .replacingOccurrences(of: "&quot;", with: "\"")
+            .replacingOccurrences(of: "&#39;", with: "'")
+            .replacingOccurrences(of: "&nbsp;", with: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func formatBytes(_ bytes: Int) -> String {
+        let formatter = ByteCountFormatter()
+        formatter.allowedUnits = [.useMB, .useKB, .useGB]
+        formatter.countStyle = .file
+        return formatter.string(fromByteCount: Int64(bytes))
+    }
+
+    // MARK: - Raw Metadata
+
+    private struct RawMetadataRow: Identifiable {
+        let key: String
+        let value: String
+        var id: String { "\(key)=\(value)" }
+    }
+
+    /// Keys that hold nested child-entity arrays — excluded to keep raw metadata focused on the entity itself.
+    private static let childArrayKeyPrefixes = [
+        "album.song[", "artist.album[",
+        "artistInfo.similarArtist[",
+        "rawApi.getAlbum.album.song[", "rawApi.getArtist.artist.album[",
+        "rawApi.getArtistInfo2.artistInfo2.similarArtist["
+    ]
+
+    private var rawMetadataRows: [RawMetadataRow] {
+        var rows: [RawMetadataRow] = []
+
+        if !vm.rawMetadataPayloads.isEmpty {
+            flattenMetadata(value: vm.rawMetadataPayloads, keyPath: "rawApi", rows: &rows)
+        }
+
+        switch target.type {
+        case .song:
+            if let song = vm.song {
+                flattenMetadata(value: song, keyPath: "song", rows: &rows)
+            }
+            if let albumInfo = vm.albumInfo {
+                flattenMetadata(value: albumInfo, keyPath: "albumInfo", rows: &rows)
+            }
+        case .album:
+            if let album = vm.album {
+                flattenMetadata(value: album, keyPath: "album", rows: &rows)
+            }
+            if let albumInfo = vm.albumInfo {
+                flattenMetadata(value: albumInfo, keyPath: "albumInfo", rows: &rows)
+            }
+        case .artist:
+            if let artist = vm.artist {
+                flattenMetadata(value: artist, keyPath: "artist", rows: &rows)
+            }
+            if let artistInfo = vm.artistInfo {
+                flattenMetadata(value: artistInfo, keyPath: "artistInfo", rows: &rows)
+            }
+        }
+
+        return rows
+            .filter { row in !Self.childArrayKeyPrefixes.contains(where: { row.key.hasPrefix($0) }) }
+            .sorted { $0.key.localizedCaseInsensitiveCompare($1.key) == .orderedAscending }
+    }
+
+    @ViewBuilder
+    private var rawMetadataTable: some View {
+        VStack(spacing: 0) {
+            HStack(alignment: .top, spacing: 12) {
+                Text("Key")
+                    .font(.caption)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(.secondary)
+                    .frame(width: 220, alignment: .leading)
+                Text("Value")
+                    .font(.caption)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+
+            Divider()
+
+            ForEach(rawMetadataRows) { row in
+                HStack(alignment: .top, spacing: 12) {
+                    Text(row.key)
+                        .font(.system(.caption, design: .monospaced))
+                        .foregroundStyle(.secondary)
+                        .frame(width: 220, alignment: .leading)
+                        .textSelection(.enabled)
+                    Text(row.value)
+                        .font(.system(.caption, design: .monospaced))
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .textSelection(.enabled)
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+                .accessibilityLabel("\(row.key): \(row.value)")
+
+                if row.id != rawMetadataRows.last?.id {
+                    Divider()
+                }
+            }
+        }
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 10))
+    }
+
+    // swiftlint:disable cyclomatic_complexity
+    private func flattenMetadata(value: Any, keyPath: String, rows: inout [RawMetadataRow]) {
+        let mirror = Mirror(reflecting: value)
+
+        if mirror.displayStyle == .optional {
+            if let child = mirror.children.first {
+                flattenMetadata(value: child.value, keyPath: keyPath, rows: &rows)
+            } else {
+                rows.append(RawMetadataRow(key: keyPath, value: "nil"))
+            }
+            return
+        }
+
+        if mirror.children.isEmpty {
+            rows.append(RawMetadataRow(key: keyPath, value: scalarDescription(value)))
+            return
+        }
+
+        switch mirror.displayStyle {
+        case .collection, .set:
+            if mirror.children.isEmpty {
+                rows.append(RawMetadataRow(key: keyPath, value: "[]"))
+            } else {
+                let values = Array(mirror.children.map(\.value))
+                if let scalarValues = scalarCollectionValues(values) {
+                    rows.append(RawMetadataRow(key: keyPath, value: scalarValues.joined(separator: ", ")))
+                } else {
+                    for (index, child) in mirror.children.enumerated() {
+                        flattenMetadata(value: child.value, keyPath: "\(keyPath)[\(index)]", rows: &rows)
+                    }
+                }
+            }
+        case .dictionary:
+            if mirror.children.isEmpty {
+                rows.append(RawMetadataRow(key: keyPath, value: "[:]"))
+            } else {
+                for child in mirror.children {
+                    let tuple = Mirror(reflecting: child.value)
+                    let tupleChildren = Array(tuple.children)
+                    if tupleChildren.count == 2 {
+                        let key = scalarDescription(tupleChildren[0].value)
+                        let childPath = appendDictionaryKey(base: keyPath, key: key)
+                        flattenMetadata(value: tupleChildren[1].value, keyPath: childPath, rows: &rows)
+                    }
+                }
+            }
+        case .struct, .class, .tuple:
+            for child in mirror.children {
+                let childLabel = sanitizeLabel(child.label)
+                let childPath = keyPath.isEmpty ? childLabel : "\(keyPath).\(childLabel)"
+                flattenMetadata(value: child.value, keyPath: childPath, rows: &rows)
+            }
+        case .enum:
+            rows.append(RawMetadataRow(key: keyPath, value: scalarDescription(value)))
+        case .none:
+            rows.append(RawMetadataRow(key: keyPath, value: scalarDescription(value)))
+        @unknown default:
+            rows.append(RawMetadataRow(key: keyPath, value: scalarDescription(value)))
+        }
+    }
+    // swiftlint:enable cyclomatic_complexity
+
+    private func scalarDescription(_ value: Any) -> String {
+        if value is NSNull { return "null" }
+        if let value = value as? String { return value }
+        if let value = value as? Int { return String(value) }
+        if let value = value as? Int64 { return String(value) }
+        if let value = value as? Double { return String(value) }
+        if let value = value as? Float { return String(value) }
+        if let value = value as? Bool { return value ? "true" : "false" }
+        if let value = value as? URL { return value.absoluteString }
+        if let value = value as? Date {
+            let formatter = ISO8601DateFormatter()
+            return formatter.string(from: value)
+        }
+        return String(describing: value)
+    }
+
+    private func sanitizeLabel(_ label: String?) -> String {
+        guard let label, !label.isEmpty else { return "value" }
+        if label.hasPrefix(".") {
+            return "item\(label)"
+        }
+        return label
+    }
+
+    private func appendDictionaryKey(base: String, key: String) -> String {
+        let keyIsIdentifier = key.range(of: "^[A-Za-z_][A-Za-z0-9_]*$", options: .regularExpression) != nil
+        if keyIsIdentifier {
+            return base.isEmpty ? key : "\(base).\(key)"
+        }
+
+        let escaped = key.replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+        return "\(base)[\"\(escaped)\"]"
+    }
+
+    private func scalarCollectionValues(_ values: [Any]) -> [String]? {
+        var rendered: [String] = []
+        rendered.reserveCapacity(values.count)
+
+        for value in values {
+            guard let scalar = scalarValueIfSimple(value) else {
+                return nil
+            }
+            rendered.append(scalar)
+        }
+
+        return rendered
+    }
+
+    private func scalarValueIfSimple(_ value: Any) -> String? {
+        let mirror = Mirror(reflecting: value)
+
+        if mirror.displayStyle == .optional {
+            if let child = mirror.children.first {
+                return scalarValueIfSimple(child.value)
+            }
+            return "nil"
+        }
+
+        if mirror.children.isEmpty {
+            return scalarDescription(value)
+        }
+
+        switch mirror.displayStyle {
+        case .dictionary:
+            // Treat dictionaries with exactly one scalar value as simple.
+            let entries = Array(mirror.children)
+            guard entries.count == 1 else { return nil }
+            let tuple = Mirror(reflecting: entries[0].value)
+            let tupleChildren = Array(tuple.children)
+            guard tupleChildren.count == 2 else { return nil }
+            return scalarValueIfSimple(tupleChildren[1].value)
+
+        case .struct, .class, .tuple:
+            // Treat single-field objects as simple values (e.g. {"name": "Electronic"}).
+            let children = Array(mirror.children)
+            guard children.count == 1 else { return nil }
+            return scalarValueIfSimple(children[0].value)
+
+        default:
+            return nil
+        }
+    }
+}

--- a/Vibrdrome/Features/Library/GetInfoView.swift
+++ b/Vibrdrome/Features/Library/GetInfoView.swift
@@ -272,7 +272,6 @@ struct GetInfoView: View {
 
     // MARK: - Album Content
 
-    // swiftlint:disable cyclomatic_complexity function_body_length
     @ViewBuilder
     private func albumContent(_ album: Album) -> some View {
         VStack(spacing: 16) {
@@ -327,7 +326,6 @@ struct GetInfoView: View {
 
         externalLinksSection(mbid: vm.albumInfo?.musicBrainzId, lastFmUrl: vm.albumInfo?.lastFmUrl)
     }
-    // swiftlint:enable cyclomatic_complexity function_body_length
 
     // MARK: - Artist Content
 

--- a/Vibrdrome/Features/Library/LibraryView.swift
+++ b/Vibrdrome/Features/Library/LibraryView.swift
@@ -422,6 +422,7 @@ struct LibraryView: View {
                             albumCard(album)
                         }
                         .buttonStyle(.plain)
+                        .albumGetInfoContextMenu(album: album)
                     }
                 }
                 .padding(.horizontal, 16)
@@ -471,8 +472,9 @@ struct LibraryView: View {
 
             ScrollView(.horizontal, showsIndicators: false) {
                 LazyHStack(spacing: 14) {
-                    ForEach(starredSongs) { song in
+                    ForEach(Array(starredSongs.enumerated()), id: \.element.id) { index, song in
                         songCard(song)
+                            .trackContextMenu(song: song, queue: starredSongs, index: index)
                             .onTapGesture {
                                 AudioEngine.shared.play(song: song, from: starredSongs, at: starredSongs.firstIndex(where: { $0.id == song.id }) ?? 0)
                             }

--- a/Vibrdrome/Features/Library/SidebarContentView.swift
+++ b/Vibrdrome/Features/Library/SidebarContentView.swift
@@ -210,6 +210,9 @@ struct SidebarContentView: View {
                 break
             }
         }
+        .onReceive(NotificationCenter.default.publisher(for: .navigateToSearch)) { _ in
+            selectionRaw = SidebarItem.search.rawValue
+        }
     }
 
     var body: some View {

--- a/Vibrdrome/Features/Library/SidebarContentView.swift
+++ b/Vibrdrome/Features/Library/SidebarContentView.swift
@@ -227,6 +227,7 @@ struct SidebarContentView: View {
             .safeAreaInset(edge: .bottom) {
                 if engine.currentSong != nil || engine.currentRadioStation != nil {
                     MiniPlayerView()
+                        .ignoresSafeArea(.keyboard, edges: .bottom)
                 }
             }
         #endif

--- a/Vibrdrome/Features/Library/SongsView.swift
+++ b/Vibrdrome/Features/Library/SongsView.swift
@@ -7,6 +7,7 @@ struct SongsView: View {
     @State private var isLoading = true
     @State private var hasMore = false
     @State private var searchText = ""
+    @State private var searchIsActive = false
     @State private var searchResults: [Song] = []
     @State private var isSearching = false
     @State private var availableGenres: [String] = []
@@ -89,8 +90,12 @@ struct SongsView: View {
         #if os(iOS)
         .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .automatic), prompt: "Search songs")
         #else
-        .searchable(text: $searchText, prompt: "Search songs")
+        .searchable(text: $searchText, isPresented: $searchIsActive, prompt: "Search songs")
         #endif
+        .onReceive(NotificationCenter.default.publisher(for: .focusSearchBar)) { _ in
+            searchIsActive = false
+            DispatchQueue.main.async { searchIsActive = true }
+        }
         .onChange(of: searchText) { _, query in
             guard query.count >= 2 else {
                 searchResults = []

--- a/Vibrdrome/Features/Player/NowPlayingView+iOS.swift
+++ b/Vibrdrome/Features/Player/NowPlayingView+iOS.swift
@@ -298,6 +298,7 @@ extension NowPlayingView {
 
     // MARK: - Bottom Toolbar (6 icons)
 
+    @ViewBuilder
     var bottomToolbar: some View {
         let orderedItems = NowPlayingToolbarItem.decodeOrder(from: toolbarOrderJSON)
         let visibleItems = orderedItems.filter { item in
@@ -307,24 +308,42 @@ extension NowPlayingView {
             case .airplay: return showAirPlayInToolbar
             case .lyrics: return showLyricsInToolbar
             case .settings: return showSettingsInToolbar
+            case .radioMix: return showRadioMixInToolbar
             }
         }
-        return HStack(spacing: 0) {
-            ForEach(Array(visibleItems.enumerated()), id: \.element.id) { index, item in
-                toolbarButton(for: item)
-                if index < visibleItems.count - 1 {
-                    Spacer()
+        // Hide the entire row when the user has disabled every item --
+        // previously the empty pill still rendered.
+        if !visibleItems.isEmpty {
+            HStack(spacing: 0) {
+                ForEach(Array(visibleItems.enumerated()), id: \.element.id) { index, item in
+                    toolbarButton(for: item)
+                    if index < visibleItems.count - 1 {
+                        Spacer()
+                    }
                 }
             }
+            .font(.title3)
+            .fontWeight(.semibold)
+            .buttonStyle(.plain)
+            .foregroundColor(.white)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 8)
+            .modifier(ToolbarBackgroundModifier(enabled: nowPlayingToolbarBackground))
         }
-        .font(.title3)
-        .fontWeight(.semibold)
-        .buttonStyle(.plain)
-        .foregroundColor(.white)
-        .padding(.horizontal, 16)
-        .padding(.vertical, 8)
-        .background(.white.opacity(0.08), in: RoundedRectangle(cornerRadius: 16))
-        .modifier(GlassEffectToolbarModifier())
+    }
+
+    /// Toggles the pill background + glass effect on the bottom toolbar.
+    private struct ToolbarBackgroundModifier: ViewModifier {
+        let enabled: Bool
+        func body(content: Content) -> some View {
+            if enabled {
+                content
+                    .background(.white.opacity(0.08), in: RoundedRectangle(cornerRadius: 16))
+                    .modifier(GlassEffectToolbarModifier())
+            } else {
+                content
+            }
+        }
     }
 
     @ViewBuilder
@@ -374,6 +393,19 @@ extension NowPlayingView {
             }
             .accessibilityLabel("Quick Settings")
             .accessibilityIdentifier("quickSettingsButton")
+
+        case .radioMix:
+            Button {
+                guard let song = engine.currentSong else { return }
+                Haptics.light()
+                AudioEngine.shared.startSongSimilarityMix(song)
+            } label: {
+                Image(systemName: "dot.radiowaves.left.and.right")
+                    .frame(minWidth: 44, minHeight: 44)
+            }
+            .disabled(engine.currentSong == nil)
+            .accessibilityLabel("Start Radio Mix")
+            .accessibilityIdentifier("radioMixButton")
         }
     }
 

--- a/Vibrdrome/Features/Player/NowPlayingView.swift
+++ b/Vibrdrome/Features/Player/NowPlayingView.swift
@@ -24,6 +24,8 @@ struct NowPlayingView: View {
     @AppStorage(UserDefaultsKeys.showVisualizerInToolbar) var showVisualizerInToolbar: Bool = true
     @AppStorage(UserDefaultsKeys.showEQInToolbar) var showEQInToolbar: Bool = true
     @AppStorage(UserDefaultsKeys.showAirPlayInToolbar) var showAirPlayInToolbar: Bool = true
+    @AppStorage(UserDefaultsKeys.showRadioMixInToolbar) var showRadioMixInToolbar: Bool = false
+    @AppStorage(UserDefaultsKeys.nowPlayingToolbarBackground) var nowPlayingToolbarBackground: Bool = true
     @AppStorage(UserDefaultsKeys.showLyricsInToolbar) var showLyricsInToolbar: Bool = true
     @AppStorage(UserDefaultsKeys.showSettingsInToolbar) var showSettingsInToolbar: Bool = true
     @AppStorage(UserDefaultsKeys.nowPlayingToolbarOrder) var toolbarOrderJSON: String = "[]"
@@ -852,10 +854,11 @@ enum NowPlayingToolbarItem: String, CaseIterable, Identifiable {
     case airplay
     case lyrics
     case settings
+    case radioMix
 
     var id: String { rawValue }
 
-    static let defaultOrder: [NowPlayingToolbarItem] = [.visualizer, .eq, .airplay, .lyrics, .settings]
+    static let defaultOrder: [NowPlayingToolbarItem] = [.visualizer, .eq, .airplay, .lyrics, .settings, .radioMix]
 
     static func decodeOrder(from json: String) -> [NowPlayingToolbarItem] {
         guard let data = json.data(using: .utf8),

--- a/Vibrdrome/Features/Playlists/PlaylistsView.swift
+++ b/Vibrdrome/Features/Playlists/PlaylistsView.swift
@@ -11,6 +11,7 @@ struct PlaylistsView: View {
     @AppStorage("playlistViewStyle") private var showAsList = false
     @AppStorage(UserDefaultsKeys.gridColumnsPerRow) private var gridColumns = 2
     @State private var searchText = ""
+    @State private var searchIsActive = false
     @State private var sortBy: PlaylistSortOption = .name
 
     enum PlaylistSortOption: String, CaseIterable {
@@ -70,8 +71,12 @@ struct PlaylistsView: View {
         #if os(iOS)
         .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .always), prompt: "Search Playlists")
         #else
-        .searchable(text: $searchText, prompt: "Search Playlists")
+        .searchable(text: $searchText, isPresented: $searchIsActive, prompt: "Search Playlists")
         #endif
+        .onReceive(NotificationCenter.default.publisher(for: .focusSearchBar)) { _ in
+            searchIsActive = false
+            DispatchQueue.main.async { searchIsActive = true }
+        }
         #if os(iOS)
         .navigationBarTitleDisplayMode(.inline)
         #endif

--- a/Vibrdrome/Features/Radio/RadioView.swift
+++ b/Vibrdrome/Features/Radio/RadioView.swift
@@ -439,20 +439,36 @@ struct AddStationView: View {
     var body: some View {
         NavigationStack {
             Form {
-                Section("Station Details") {
+                Section("Name") {
                     TextField("Station Name", text: $name, prompt: Text("My Radio Station"))
+                }
+
+                Section {
                     TextField("Stream URL", text: $streamUrl, prompt: Text("https://stream.example.com/live"))
                         .autocorrectionDisabled()
                         #if os(iOS)
                         .textInputAutocapitalization(.never)
                         .keyboardType(.URL)
                         #endif
-                    TextField("Homepage (optional)", text: $homepageUrl, prompt: Text("https://example.com"))
+                } header: {
+                    Text("Stream URL")
+                } footer: {
+                    Text("Direct audio stream URL (MP3, AAC, or OGG). This is what actually plays.")
+                        .font(.caption)
+                }
+
+                Section {
+                    TextField("Homepage URL", text: $homepageUrl, prompt: Text("https://example.com"))
                         .autocorrectionDisabled()
                         #if os(iOS)
                         .textInputAutocapitalization(.never)
                         .keyboardType(.URL)
                         #endif
+                } header: {
+                    Text("Homepage (optional)")
+                } footer: {
+                    Text("Optional website for the station. Used to fetch a favicon as the station's icon. Leave blank to skip.")
+                        .font(.caption)
                 }
 
                 if let error {
@@ -461,12 +477,6 @@ struct AddStationView: View {
                             .foregroundStyle(.red)
                             .font(.caption)
                     }
-                }
-
-                Section {
-                    Text("Enter a direct stream URL (MP3, AAC, OGG). The station will be saved to your Navidrome server.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
                 }
             }
             .navigationTitle("Add Station")

--- a/Vibrdrome/Features/Radio/RadioView.swift
+++ b/Vibrdrome/Features/Radio/RadioView.swift
@@ -292,6 +292,13 @@ struct RadioView: View {
             )
         }
         .buttonStyle(.plain)
+        .contextMenu {
+            Button(role: .destructive) {
+                deleteStation(station)
+            } label: {
+                Label("Delete Station", systemImage: "trash")
+            }
+        }
     }
 
     private func stationIcon(_ station: InternetRadioStation, color: Color, isPlaying: Bool, size: CGFloat = 48) -> some View {

--- a/Vibrdrome/Features/Radio/RadioView.swift
+++ b/Vibrdrome/Features/Radio/RadioView.swift
@@ -7,6 +7,7 @@ struct RadioView: View {
     @State private var isLoading = true
     @State private var error: String?
     @State private var searchText = ""
+    @State private var searchIsActive = false
     @State private var showAddSheet = false
     @State private var showSearchSheet = false
     @AppStorage("radioViewStyle") private var showAsList = false
@@ -98,7 +99,15 @@ struct RadioView: View {
             #endif
         }
         .navigationTitle("Radio")
+        #if os(macOS)
+        .searchable(text: $searchText, isPresented: $searchIsActive, prompt: "Filter stations...")
+        #else
         .searchable(text: $searchText, prompt: "Filter stations...")
+        #endif
+        .onReceive(NotificationCenter.default.publisher(for: .focusSearchBar)) { _ in
+            searchIsActive = false
+            DispatchQueue.main.async { searchIsActive = true }
+        }
         #if os(iOS)
         .toolbar {
             ToolbarItem(placement: .automatic) {

--- a/Vibrdrome/Features/Search/SearchView.swift
+++ b/Vibrdrome/Features/Search/SearchView.swift
@@ -114,6 +114,7 @@ struct SearchView: View {
                             artistBubble(artist)
                         }
                         .buttonStyle(.plain)
+                        .artistGetInfoContextMenu(artist: artist)
                     }
                 }
                 .padding(.horizontal, 16)
@@ -137,6 +138,7 @@ struct SearchView: View {
                             albumTile(album)
                         }
                         .buttonStyle(.plain)
+                        .albumGetInfoContextMenu(album: album)
                     }
                 }
                 .padding(.horizontal, 16)

--- a/Vibrdrome/Features/Search/SearchView.swift
+++ b/Vibrdrome/Features/Search/SearchView.swift
@@ -54,6 +54,10 @@ struct SearchView: View {
                 searchIsActive = true
             }
         }
+        .onReceive(NotificationCenter.default.publisher(for: .focusSearchBar)) { _ in
+            searchIsActive = false
+            DispatchQueue.main.async { searchIsActive = true }
+        }
         .onSubmit(of: .search) {
             saveRecentSearch(query)
         }

--- a/Vibrdrome/Features/Settings/AppearanceSettingsView.swift
+++ b/Vibrdrome/Features/Settings/AppearanceSettingsView.swift
@@ -49,11 +49,16 @@ struct AppearanceSettingsView: View {
             }
             .accessibilityIdentifier("themePicker")
 
-            Toggle(isOn: $enableLiquidGlass) {
-                Label("Liquid Glass", systemImage: "drop.fill")
-                    .foregroundColor(.primary)
+            VStack(alignment: .leading, spacing: 4) {
+                Toggle(isOn: $enableLiquidGlass) {
+                    Label("Liquid Glass", systemImage: "drop.fill")
+                        .foregroundColor(.primary)
+                }
+                .accessibilityIdentifier("enableLiquidGlassToggle")
+                Text("Tinted pill backgrounds and translucent tab bar. Turn off for plain icons.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
-            .accessibilityIdentifier("enableLiquidGlassToggle")
 
             // Accent color picker
             VStack(alignment: .leading, spacing: 10) {

--- a/Vibrdrome/Features/Settings/PlayerSettingsView.swift
+++ b/Vibrdrome/Features/Settings/PlayerSettingsView.swift
@@ -67,6 +67,8 @@ struct PlayerSettingsView: View {
     @AppStorage(UserDefaultsKeys.showAirPlayInToolbar) private var showAirPlayInToolbar: Bool = true
     @AppStorage(UserDefaultsKeys.showLyricsInToolbar) private var showLyricsInToolbar: Bool = true
     @AppStorage(UserDefaultsKeys.showSettingsInToolbar) private var showSettingsInToolbar: Bool = true
+    @AppStorage(UserDefaultsKeys.showRadioMixInToolbar) private var showRadioMixInToolbar: Bool = false
+    @AppStorage(UserDefaultsKeys.nowPlayingToolbarBackground) private var nowPlayingToolbarBackground: Bool = true
     @AppStorage(UserDefaultsKeys.nowPlayingToolbarOrder) private var toolbarOrderJSON: String = "[]"
 
     // Song Display
@@ -410,6 +412,17 @@ struct PlayerSettingsView: View {
             }
             .accessibilityIdentifier("showLosslessBadgeToggle")
 
+            VStack(alignment: .leading, spacing: 4) {
+                Toggle(isOn: $nowPlayingToolbarBackground) {
+                    Label("Toolbar Background", systemImage: "rectangle.fill")
+                        .foregroundColor(.primary)
+                }
+                .accessibilityIdentifier("nowPlayingToolbarBackgroundToggle")
+                Text("Rounded pill + translucent backdrop behind the bottom icon row. Turn off for a cleaner look.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
             nowPlayingToolbarSubsection
         } header: {
             settingSectionHeader("Controls", icon: "slider.horizontal.3", color: .blue)
@@ -443,6 +456,7 @@ struct PlayerSettingsView: View {
         case .airplay: return $showAirPlayInToolbar
         case .lyrics: return $showLyricsInToolbar
         case .settings: return $showSettingsInToolbar
+        case .radioMix: return $showRadioMixInToolbar
         }
     }
 
@@ -453,6 +467,7 @@ struct PlayerSettingsView: View {
         case .airplay: return "AirPlay"
         case .lyrics: return "Lyrics"
         case .settings: return "Quick Settings"
+        case .radioMix: return "Radio Mix"
         }
     }
 
@@ -463,6 +478,7 @@ struct PlayerSettingsView: View {
         case .airplay: return "airplayaudio"
         case .lyrics: return "quote.bubble"
         case .settings: return "gearshape"
+        case .radioMix: return "dot.radiowaves.left.and.right"
         }
     }
 

--- a/Vibrdrome/Shared/Components/GetInfoContextMenus.swift
+++ b/Vibrdrome/Shared/Components/GetInfoContextMenus.swift
@@ -1,0 +1,87 @@
+import SwiftUI
+
+struct ArtistGetInfoContextMenuModifier: ViewModifier {
+    let artist: Artist
+
+    @Environment(\.openWindow) private var openWindow
+    #if os(iOS)
+    @Environment(AppState.self) private var appState
+    @State private var showGetInfo = false
+    #endif
+
+    func body(content: Content) -> some View {
+        content
+            .contextMenu {
+                Button {
+                    #if os(macOS)
+                    openWindow(id: "get-info", value: GetInfoTarget(type: .artist, id: artist.id))
+                    #else
+                    showGetInfo = true
+                    #endif
+                } label: {
+                    Label("Get Info", systemImage: "doc.text.magnifyingglass")
+                }
+            }
+            #if os(iOS)
+            .sheet(isPresented: $showGetInfo) {
+                NavigationStack {
+                    GetInfoView(target: GetInfoTarget(type: .artist, id: artist.id))
+                        .toolbar {
+                            ToolbarItem(placement: .confirmationAction) {
+                                Button("Done") { showGetInfo = false }
+                            }
+                        }
+                }
+                .environment(appState)
+            }
+            #endif
+    }
+}
+
+struct AlbumGetInfoContextMenuModifier: ViewModifier {
+    let album: Album
+
+    @Environment(\.openWindow) private var openWindow
+    #if os(iOS)
+    @Environment(AppState.self) private var appState
+    @State private var showGetInfo = false
+    #endif
+
+    func body(content: Content) -> some View {
+        content
+            .contextMenu {
+                Button {
+                    #if os(macOS)
+                    openWindow(id: "get-info", value: GetInfoTarget(type: .album, id: album.id))
+                    #else
+                    showGetInfo = true
+                    #endif
+                } label: {
+                    Label("Get Info", systemImage: "doc.text.magnifyingglass")
+                }
+            }
+            #if os(iOS)
+            .sheet(isPresented: $showGetInfo) {
+                NavigationStack {
+                    GetInfoView(target: GetInfoTarget(type: .album, id: album.id))
+                        .toolbar {
+                            ToolbarItem(placement: .confirmationAction) {
+                                Button("Done") { showGetInfo = false }
+                            }
+                        }
+                }
+                .environment(appState)
+            }
+            #endif
+    }
+}
+
+extension View {
+    func artistGetInfoContextMenu(artist: Artist) -> some View {
+        modifier(ArtistGetInfoContextMenuModifier(artist: artist))
+    }
+
+    func albumGetInfoContextMenu(album: Album) -> some View {
+        modifier(AlbumGetInfoContextMenuModifier(album: album))
+    }
+}

--- a/Vibrdrome/Shared/Components/TrackContextMenu.swift
+++ b/Vibrdrome/Shared/Components/TrackContextMenu.swift
@@ -8,7 +8,9 @@ struct TrackContextMenuModifier: ViewModifier {
     var onRemove: (() -> Void)?
 
     @Environment(AppState.self) private var appState
+    @Environment(\.openWindow) private var openWindow
     @State private var showAddToPlaylist = false
+    @State private var showGetInfo = false
 
     func body(content: Content) -> some View {
         content
@@ -17,6 +19,19 @@ struct TrackContextMenuModifier: ViewModifier {
                 AddToPlaylistView(songIds: [song.id])
                     .environment(appState)
             }
+            #if os(iOS)
+            .sheet(isPresented: $showGetInfo) {
+                NavigationStack {
+                    GetInfoView(target: GetInfoTarget(type: .song, id: song.id))
+                        .toolbar {
+                            ToolbarItem(placement: .confirmationAction) {
+                                Button("Done") { showGetInfo = false }
+                            }
+                        }
+                }
+                .environment(appState)
+            }
+            #endif
     }
 
     @ViewBuilder
@@ -130,6 +145,16 @@ struct TrackContextMenuModifier: ViewModifier {
             appState.pendingNavigation = .song(id: song.id)
         } label: {
             Label("Song Info", systemImage: "info.circle")
+        }
+
+        Button {
+            #if os(macOS)
+            openWindow(id: "get-info", value: GetInfoTarget(type: .song, id: song.id))
+            #else
+            showGetInfo = true
+            #endif
+        } label: {
+            Label("Get Info", systemImage: "doc.text.magnifyingglass")
         }
 
         if let albumId = song.albumId {

--- a/Vibrdrome/Vibrdrome.swift
+++ b/Vibrdrome/Vibrdrome.swift
@@ -168,6 +168,19 @@ struct VibrdromeApp: App {
         }
         .defaultSize(width: 700, height: 500)
 
+        WindowGroup("Get Info", id: "get-info", for: GetInfoTarget.self) { $target in
+            if let target {
+                NavigationStack {
+                    GetInfoView(target: target)
+                }
+                .environment(appState)
+                .modelContainer(persistenceController.container)
+                .preferredColorScheme(colorScheme)
+                .tint(accentColor)
+            }
+        }
+        .defaultSize(width: 560, height: 700)
+
         Window("Mini Player", id: "mini-player") {
             PopOutPlayerView()
                 .environment(appState)

--- a/Vibrdrome/Vibrdrome.swift
+++ b/Vibrdrome/Vibrdrome.swift
@@ -19,6 +19,8 @@ class VibrdromeAppDelegate: NSObject, UIApplicationDelegate {
 }
 #elseif os(macOS)
 class VibrdromeMacDelegate: NSObject, NSApplicationDelegate {
+    private var eventMonitor: Any?
+
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
         true
     }
@@ -36,6 +38,22 @@ class VibrdromeMacDelegate: NSObject, NSApplicationDelegate {
                 app.activate()
             }
             NSApp.terminate(nil)
+        }
+
+        // Intercept CMD+F before AppKit's responder chain (performFindPanelAction:) claims it
+        eventMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+            guard event.modifierFlags.intersection(.deviceIndependentFlagsMask) == .command,
+                  event.charactersIgnoringModifiers == "f" else {
+                return event
+            }
+            NotificationCenter.default.post(name: .focusSearchBar, object: nil)
+            return nil
+        }
+    }
+
+    func applicationWillTerminate(_ notification: Notification) {
+        if let monitor = eventMonitor {
+            NSEvent.removeMonitor(monitor)
         }
     }
 }
@@ -146,6 +164,17 @@ struct VibrdromeApp: App {
         .commands {
             CommandMenu("Playback") {
                 PlaybackCommands()
+            }
+            CommandMenu("Navigate") {
+                Button("Go to Search") {
+                    NotificationCenter.default.post(name: .navigateToSearch, object: nil)
+                }
+                .keyboardShortcut("k", modifiers: .command)
+
+                Button("Focus Search") {
+                    NotificationCenter.default.post(name: .focusSearchBar, object: nil)
+                }
+                .keyboardShortcut("f", modifiers: .command)
             }
         }
         #endif

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -347,6 +347,26 @@
 
         <div class="timeline">
 
+            <!-- Build 50 -->
+            <div class="timeline-item" data-animate>
+                <div class="build-card">
+                    <div class="build-header">
+                        <span class="build-badge">Build 50</span>
+                        <span class="build-date">April 21, 2026</span>
+                    </div>
+                    <ul>
+                        <li>Get Info window with Overview and Raw metadata tabs</li>
+                        <li>CMD+K / CMD+F search keyboard shortcuts on macOS</li>
+                        <li>Now Playing toolbar: hides when empty, new Toolbar Background toggle</li>
+                        <li>New Radio Mix toolbar item (song-similarity mix)</li>
+                        <li>Radio grid cards: long-press to Delete Station</li>
+                        <li>Add Station form: labeled sections for Name / Stream URL / Homepage</li>
+                        <li>Liquid Glass toggle subtitle explains what it does</li>
+                        <li>iPad floating keyboard no longer drags the mini player up</li>
+                    </ul>
+                </div>
+            </div>
+
             <!-- Build 49 -->
             <div class="timeline-item" data-animate>
                 <div class="build-card">

--- a/project.yml
+++ b/project.yml
@@ -89,7 +89,7 @@ targets:
         DEVELOPMENT_TEAM: 85JD2B827Q
         PRODUCT_BUNDLE_IDENTIFIER: com.vibrdrome.app
         MARKETING_VERSION: "1.0.0"
-        CURRENT_PROJECT_VERSION: "49"
+        CURRENT_PROJECT_VERSION: "50"
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS: "YES"
         SWIFT_ACTIVE_COMPILATION_CONDITIONS: "$(inherited) CARPLAY_ENABLED"
@@ -123,7 +123,7 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.vibrdrome.app.widget
         CODE_SIGN_ENTITLEMENTS: VibrdromeWidget/VibrdromeWidget.entitlements
         MARKETING_VERSION: "1.0.0"
-        CURRENT_PROJECT_VERSION: "49"
+        CURRENT_PROJECT_VERSION: "50"
     entitlements:
       path: VibrdromeWidget/VibrdromeWidget.entitlements
 
@@ -140,7 +140,7 @@ targets:
         DEVELOPMENT_TEAM: 85JD2B827Q
         PRODUCT_BUNDLE_IDENTIFIER: com.vibrdrome.app.watchkitapp
         MARKETING_VERSION: "1.0.0"
-        CURRENT_PROJECT_VERSION: "49"
+        CURRENT_PROJECT_VERSION: "50"
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         SWIFT_VERSION: "6.0"
 


### PR DESCRIPTION
## Summary
- Get Info window (iOS sheet / macOS window) with Overview + Raw metadata tabs, accessible from song/album/artist context menus
- macOS CMD+K (Go to Search) and CMD+F (Focus Search) shortcuts via Navigate menu + NSEvent local monitor
- Now Playing toolbar polish: empty pill fix, Radio Mix button (always uses getSimilarSongs), optional background pill, added as reorderable item
- Radio grid: Delete Station context menu on cards (fixes iPad landscape delete gap)
- Add Station form split into labeled sections (Name / Stream URL / Homepage) with explainer footers
- Liquid Glass toggle gets descriptive subtitle
- Mini player pinned to bottom ignoring keyboard safe area (iPad floating keyboard fix)

## Test plan
- [x] SwiftLint: 0 violations, 0 serious in 119 files
- [x] Unit tests: 536 passed in 40 suites
- [x] UI RotationTests: 10 passed, 0 failures
- [x] iOS build clean
- [x] macOS build clean
- [x] watchOS build clean
- [x] Device smoke test items 1-9 verified (CMD+K/CMD+F confirmed after xcodegen regen)
- [ ] TestFlight regression per TESTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)