### PR TITLE
Docs refresh for Build 50 + pre-commit doc-gate hook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,23 +55,28 @@ xcodegen generate
 
 ## Pre-TestFlight Checklist
 
-Run in order before every TestFlight build:
+Run in order before every TestFlight build. Every step is mandatory -- no "if applicable", no "if new features", no skipping.
 
-1. `swiftlint` — 0 violations
-2. Unit tests: `xcodebuild test -only-testing:VibrdromeTests` — all pass
-3. UI tests: `xcodebuild test -only-testing:VibrdromeUITests/RotationTests` — all pass
+1. `swiftlint` -- 0 violations
+2. Unit tests: `xcodebuild test -only-testing:VibrdromeTests` -- all pass
+3. UI tests: `xcodebuild test -only-testing:VibrdromeUITests/RotationTests` -- all pass
 4. Security audit on recent changes
 5. Build iOS with 0 warnings
 6. Build macOS with 0 warnings
 7. Build watchOS with 0 warnings
 8. Device test on phone (see TESTING.md for full regression checklist)
-9. Update CHANGELOG.md with build number and TestFlight notes
-10. Update docs/changelog.html with new build entry
-11. Update docs/features.html if new features were added
-12. Update docs/index.html feature grid if new features were added
-13. Update TESTING.md with test items for new features
-14. Increment CURRENT_PROJECT_VERSION in project.yml (all 3 targets)
-13. Regenerate xcodegen and restore entitlements
+9. Update `CHANGELOG.md` -- new build entry, no exceptions
+10. Update `docs/changelog.html` -- matching HTML entry, no exceptions
+11. Update `docs/features.html` -- add or refresh any feature text that changed; if nothing changed, verify by re-reading
+12. Update `docs/index.html` feature grid -- same rule as features.html
+13. Update `docs/User-Guide.md` -- add or refresh any user-facing behavior that changed
+14. Update `docs/TESTING-CHECKLIST.md` -- add test items for every user-visible change
+15. Update `docs/APPSTORE-METADATA.md` "What's New" block for the new build, and refresh any description lines the build affects
+16. Update `TESTING.md` -- test items for every new feature and regression area
+17. Increment `CURRENT_PROJECT_VERSION` in `project.yml` (all 3 targets)
+18. Regenerate xcodegen and restore entitlements
+
+The pre-commit hook (`scripts/hooks/pre-commit`) enforces steps 9-16: if `project.yml`'s `CURRENT_PROJECT_VERSION` bumps in a commit, the required doc files must be touched in the same commit. Do not bypass with `--no-verify`; the hook is the safety net.
 
 ## Post-XcodeGen Entitlements Restore
 

--- a/docs/APPSTORE-METADATA.md
+++ b/docs/APPSTORE-METADATA.md
@@ -1,4 +1,4 @@
-# App Store Metadata — Vibrdrome
+# App Store Metadata -- Vibrdrome
 
 ## App Information
 
@@ -11,7 +11,7 @@
 
 ## Description
 
-Vibrdrome is a native music player for your Navidrome server. Stream your entire library, download for offline, and enjoy audiophile-grade playback — all from a fast, beautiful interface built for iOS.
+Vibrdrome is a native music player for your Navidrome server. Stream your entire library, download for offline, and enjoy audiophile-grade playback -- all from a fast, beautiful interface built for iOS and macOS.
 
 **Your Music, Your Server**
 Connect to any Navidrome or Subsonic-compatible server. Browse by artist, album, genre, folder, or decade. Search your entire collection instantly. Smart caching means screens load instantly after your first visit.
@@ -20,33 +20,59 @@ Connect to any Navidrome or Subsonic-compatible server. Browse by artist, album,
 - Gapless playback for seamless album listening
 - Crossfade between tracks with adjustable duration
 - 10-band parametric equalizer with custom presets
-- ReplayGain for consistent volume across albums
-- Adjustable playback speed (0.5x–2.0x)
+- ReplayGain with pre-gain and fallback for consistent volume across albums
+- Adjustable playback speed (0.5x-2.0x)
+- Adaptive bitrate streaming that reacts to your connection
 
 **Smart Playlists & Radio**
-Generate mixes by artist, genre, or mood — Random Mix, B-Sides & Obscure, and Curated Weekly built in. Browse thousands of internet radio stations or add your own stream URLs.
+- Artist radio and Random Mix built in
+- Radio Mix: queue songs similar to the one currently playing
+- B-Sides & Obscure, Curated Weekly, decade and genre mixes
+- Browse thousands of internet radio stations or add your own stream URLs
+- Long-press to delete any custom station
 
 **Offline & Downloads**
 Download albums, playlists, and individual tracks. Auto-download favorites. Resume interrupted downloads. Manage storage with configurable cache limits.
 
+**Get Info**
+Long-press any song, album, or artist to open a Get Info view with two tabs:
+- Overview: cover art, year, duration, bitrate/format, ReplayGain, and links to MusicBrainz and Last.fm
+- Raw Metadata: full Subsonic API payload plus Navidrome file tags (rawTags) for deep metadata diving
+
+**Built for Mac**
+- Get Info opens as its own window, not a modal
+- Navigate menu with Go to Search (Command+K) and Focus Search (Command+F)
+- Standalone Mini Player window and dedicated Settings window
+- Native menu bar commands for Playback and Navigation
+
 **And More**
-- Metal-powered audio visualizer with 6 reactive presets
+- Metal-powered audio visualizer with 18 reactive presets
 - Synced lyrics with tap-to-seek
 - Sleep timer with volume fade-out
-- CarPlay support for hands-free listening
+- CarPlay support for hands-free listening, with genre and radio browsing
+- Apple Watch companion for playback control from your wrist
+- Home Screen widget and Siri shortcuts
+- AirPlay 2 streaming with multi-room support
 - Background audio with lock screen and Control Center controls
-- Dark mode with 10 customizable accent colors
-- AirPlay streaming
+- Dark mode with customizable accent colors, Liquid Glass toolbar on iOS 26
+- ListenBrainz and Last.fm scrobbling with offline queue
+- Discord Rich Presence (macOS)
 
 Vibrdrome is free, open source, and contains no ads or tracking.
 
 ## Keywords
 
-navidrome,subsonic,music,player,streaming,self-hosted,gapless,offline,equalizer,carplay
+navidrome,subsonic,music,player,streaming,self-hosted,gapless,offline,equalizer,carplay,watch,lyrics,radio,metadata
 
-## What's New (Version 1.0)
+## What's New (v1.0.0 Beta Build 50)
 
-Initial release.
+- Get Info window (long-press any song, album, or artist). Overview and Raw Metadata tabs. iOS sheet, macOS window.
+- macOS keyboard shortcuts: Command+K jumps to Search, Command+F focuses the search bar, both in a new Navigate menu.
+- Now Playing toolbar polish: empty pill fix, optional background pill, new Radio Mix button that plays songs similar to the current track.
+- Radio grid: long-press any station card to delete (fixes iPad landscape gap).
+- Add Station form now split into labeled Name / Stream URL / Homepage sections.
+- iPad mini player stays pinned to the bottom even when the floating keyboard is up.
+- Liquid Glass toggle gets a descriptive subtitle so its effect is obvious.
 
 ## Support URL
 
@@ -67,13 +93,15 @@ https://vibrdrome.io
 | iPhone 6.7" (15/16 Pro Max) | 1290 x 2796 | Yes |
 | iPhone 6.1" (15/16 Pro) | 1179 x 2556 | Yes |
 | iPad Pro 12.9" | 2048 x 2732 | If submitting for iPad |
+| Mac | 2880 x 1800 or 1280 x 800 | If submitting for Mac |
 
 **Suggested screenshots (in order):**
-1. Library — home screen with quick access pills and album carousels
-2. Now Playing — full player with album art, controls, progress
-3. Equalizer — 10-band EQ with preset selector
-4. Playlists — smart mix or playlist detail
-5. Radio — internet radio stations
-6. Visualizer — full-screen audio visualizer
-7. Lyrics — synced lyrics during playback
-8. Search — search results with artists, albums, songs
+1. Library -- home screen with quick access pills and album carousels
+2. Now Playing -- full player with album art, controls, progress, Radio Mix in toolbar
+3. Get Info -- Overview tab with MusicBrainz/Last.fm links
+4. Equalizer -- 10-band EQ with preset selector
+5. Playlists -- smart mix or playlist detail
+6. Radio -- internet radio stations grid
+7. Visualizer -- full-screen audio visualizer
+8. Lyrics -- synced lyrics during playback
+9. Search -- search results with artists, albums, songs

--- a/docs/TESTING-CHECKLIST.md
+++ b/docs/TESTING-CHECKLIST.md
@@ -1,18 +1,21 @@
 # Vibrdrome Device Testing Checklist
 
+A lightweight smoke list. For the full build-by-build regression list, see [TESTING.md](../TESTING.md) in the repo root.
+
 ## Core Playback
 - [ ] Play a song, skip forward/back, scrub the progress bar
-- [ ] Let an album play through — verify gapless transitions
+- [ ] Let an album play through -- verify gapless transitions
 - [ ] Enable crossfade in settings, play through a transition
-- [ ] Try the EQ — toggle presets, adjust bands
-- [ ] Lock the phone — verify lock screen controls work
-- [ ] Play music, open another app — confirm background audio continues
+- [ ] Try the EQ -- toggle presets, adjust bands
+- [ ] Lock the phone -- verify lock screen controls work
+- [ ] Play music, open another app -- confirm background audio continues
 
 ## Library Browsing
 - [ ] Browse by artist, album, genre, folder
 - [ ] Search for a song, album, and artist
 - [ ] Check that album art loads correctly
 - [ ] Star/favorite a song, verify it syncs to Navidrome
+- [ ] Long-press any song / album / artist and open **Get Info**; Overview tab shows art, title, year, bitrate, ReplayGain, MusicBrainz + Last.fm links; Raw Metadata tab shows full Subsonic response and Navidrome rawTags
 
 ## Offline & Downloads
 - [ ] Download an album for offline
@@ -26,7 +29,21 @@
 ## Radio
 - [ ] Search for a station in Find Stations
 - [ ] Play a radio stream
-- [ ] Add a custom stream URL
+- [ ] Add a custom stream URL -- verify the Add Station form shows three labeled sections (Name / Stream URL / Homepage)
+- [ ] Long-press a radio station card and choose **Delete Station**; verify it works in portrait and landscape on both iPhone and iPad
+
+## Now Playing Toolbar
+- [ ] Open Settings > Player > Now Playing Toolbar and toggle items off; the toolbar pill disappears entirely when all items are off (no empty pill)
+- [ ] Enable the **Radio Mix** item; while a song plays, tap Radio Mix and verify it queues songs similar to the current track (not the full artist radio)
+- [ ] Toggle the optional toolbar background and verify the pill gets a frosted background
+
+## macOS
+- [ ] Menu bar shows a **Navigate** menu with **Go to Search (⌘K)** and **Focus Search (⌘F)**; both shortcuts fire without a system beep
+- [ ] Long-press an item and open **Get Info**; it opens as its own window (not a sheet) and multiple can be open at once
+- [ ] Enable Liquid Glass in Appearance and confirm the toolbar/mini player get a frosted background
+
+## iPad
+- [ ] On iPad, bring up the floating keyboard; the mini player stays pinned to the bottom and is not pushed off-screen
 
 ## Extras
 - [ ] Try lyrics on a song that has them
@@ -35,13 +52,6 @@
 - [ ] Try different themes/accent colors
 
 ## Edge Cases
-- [ ] Kill the app mid-song, reopen — does it remember state?
+- [ ] Kill the app mid-song, reopen -- does it remember state?
 - [ ] Poor Wi-Fi / switch between Wi-Fi and cellular
 - [ ] Incoming phone call during playback
-
-## Once Apple Verifies (1-2 days)
-- [ ] Switch to paid team signing in Xcode
-- [ ] Archive and upload to TestFlight
-- [ ] Apply for CarPlay entitlement
-- [ ] Take App Store screenshots on device
-- [ ] Submit for review

--- a/docs/User-Guide.md
+++ b/docs/User-Guide.md
@@ -32,11 +32,28 @@ Use the **Playlists** tab to view and manage your server-side playlists.
 ## Playback
 
 - **Play a song**: Tap any song to start playback. The remaining songs in the list are added to your queue.
-- **Mini player**: Appears at the bottom of the screen during playback. Tap it to open the full-screen player.
+- **Mini player**: Appears at the bottom of the screen during playback. Tap it to open the full-screen player. On iPad it stays pinned to the bottom even when the floating keyboard is up.
 - **Full-screen player**: Shows album art, playback progress, and controls. Swipe down to dismiss.
 - **Queue**: Tap the queue icon in the player to view and reorder upcoming tracks.
 - **Shuffle**: Tap the shuffle icon to randomize your queue.
 - **Repeat**: Tap the repeat icon to cycle through off, repeat all, and repeat one.
+- **Radio Mix**: Open the player toolbar and tap the Radio Mix button to queue up songs similar to the one currently playing. Rearrange or hide toolbar items in **Settings > Player > Now Playing Toolbar**.
+
+## Get Info
+
+Long-press any song, album, or artist and choose **Get Info** to inspect its metadata:
+
+- **Overview** tab: cover art, title, year, duration, bitrate/format, ReplayGain, MusicBrainz and Last.fm links.
+- **Raw Metadata** tab: the full Subsonic API response plus Navidrome file tags (rawTags) for deeper diagnostics.
+
+On iOS, Get Info opens as a sheet. On macOS it opens its own window, so you can have several open at once while you keep browsing.
+
+## macOS Keyboard Shortcuts
+
+- **⌘K** -- Go to Search tab.
+- **⌘F** -- Focus the search bar in the current view.
+
+Both shortcuts are listed in the **Navigate** menu in the menu bar. CMD+F is intercepted before AppKit's Find panel can claim it, so it focuses Vibrdrome's search instead of making a beep.
 
 ## Downloads (Offline Playback)
 
@@ -69,8 +86,12 @@ Bookmarks sync with your server.
 Add and listen to internet radio streams:
 
 - Go to **Radio** in the Library tab.
-- Tap **Add Radio Station** and enter the stream URL and a name.
+- Tap **Add Radio Station** and fill in the labeled sections:
+  - **Name** -- the display name shown in the Radio grid.
+  - **Stream URL** -- the actual audio stream (e.g. `https://example.com/stream.mp3`, or a `.pls` / `.m3u` playlist).
+  - **Homepage** (optional) -- the station's website, used for the favicon and info.
 - Tap a station to start streaming.
+- To delete a station, long-press its card and choose **Delete Station**. This works in portrait and landscape, iPhone, iPad, and Mac.
 
 ## Settings
 
@@ -78,7 +99,7 @@ Access settings from the **Settings** tab:
 
 - **Server Management** -- Add, edit, or remove servers.
 - **Playback Quality** -- Set bitrate limits separately for Wi-Fi and cellular connections. Lower bitrates save data and battery; higher bitrates improve audio quality.
-- **Appearance** -- Choose a theme (light, dark, or system), pick an accent color, and adjust text size via Dynamic Type.
+- **Appearance** -- Choose a theme (light, dark, or system), pick an accent color, and adjust text size via Dynamic Type. On iOS 26, enable **Liquid Glass** to give the Now Playing toolbar and mini player a frosted, glass-like background.
 - **Cache** -- Clear the image or audio cache to free storage.
 
 ## Multi-Server Support

--- a/docs/features.html
+++ b/docs/features.html
@@ -435,7 +435,9 @@
                     <li>Tap song, artist, or album name to navigate to detail pages</li>
                     <li>Heart, 5-star rating, and queue in one row</li>
                     <li>Shuffle and repeat alongside transport controls</li>
-                    <li>Drag-to-reorder toolbar: Visualizer, EQ, AirPlay, Lyrics, Settings</li>
+                    <li>Drag-to-reorder toolbar: Visualizer, EQ, AirPlay, Lyrics, Radio Mix, Settings</li>
+                    <li>Radio Mix button spins up a queue of songs similar to the current track</li>
+                    <li>Optional toolbar background pill (Settings &gt; Player)</li>
                     <li>Landscape layout: album art left, controls right</li>
                     <li>Quick Settings sheet with crossfade preview</li>
                     <li>Now playing indicator: animated waveform on current track</li>
@@ -522,6 +524,44 @@
                 </ul>
                 <div class="platforms">
                     <span class="platform-badge">iOS</span>
+                </div>
+            </div>
+            <div class="feature-media">
+            </div>
+        </div>
+
+        <!-- Get Info -->
+        <div class="feature-section" data-animate>
+            <div class="feature-text">
+                <h2>Get Info</h2>
+                <ul>
+                    <li>Long-press any song, album, or artist to open Get Info</li>
+                    <li>Overview tab: cover art, title, year, duration, bitrate, format, ReplayGain, MusicBrainz and Last.fm links</li>
+                    <li>Raw Metadata tab: full Subsonic API payload plus Navidrome file tags (rawTags)</li>
+                    <li>iOS opens as a sheet; macOS opens its own window (multiple can be open at once)</li>
+                    <li>Mac supports a keyboard shortcut via the Navigate menu</li>
+                </ul>
+                <div class="platforms">
+                    <span class="platform-badge">iOS &amp; macOS</span>
+                </div>
+            </div>
+            <div class="feature-media">
+            </div>
+        </div>
+
+        <!-- macOS Power User -->
+        <div class="feature-section" data-animate>
+            <div class="feature-text">
+                <h2>macOS Power User</h2>
+                <ul>
+                    <li>Navigate menu: Go to Search (⌘K) and Focus Search (⌘F)</li>
+                    <li>CMD+F is intercepted before AppKit's Find panel can claim it</li>
+                    <li>Get Info opens as its own window, not a modal</li>
+                    <li>Menu bar commands for Playback and Navigation</li>
+                    <li>Standalone Mini Player window and dedicated Settings window</li>
+                </ul>
+                <div class="platforms">
+                    <span class="platform-badge">macOS</span>
                 </div>
             </div>
             <div class="feature-media">

--- a/docs/index.html
+++ b/docs/index.html
@@ -842,6 +842,18 @@
                     <span class="platform-tag tag-ios">iOS</span>
                 </div>
                 <div class="feature" data-animate>
+                    <span class="icon">ℹ️ (・ω・)</span>
+                    <h3>Get Info</h3>
+                    <p>Long-press any song, album, or artist to see full metadata. Overview + Raw Metadata tabs with MusicBrainz, Last.fm, ReplayGain, and Navidrome rawTags.</p>
+                    <span class="platform-tag tag-ios">iOS &amp; macOS</span>
+                </div>
+                <div class="feature" data-animate>
+                    <span class="icon">⌨️ (•̀ᴗ•́)و</span>
+                    <h3>macOS Keyboard Shortcuts</h3>
+                    <p>Navigate menu with Go to Search (⌘K) and Focus Search (⌘F). Get Info opens as its own window. Mini Player and Settings each get a dedicated window.</p>
+                    <span class="platform-tag tag-ios">macOS</span>
+                </div>
+                <div class="feature" data-animate>
                     <span class="icon">🔓 ╰(*°▽°*)╯</span>
                     <h3>Open Source</h3>
                     <p>Free, no ads, no tracking. Your music, your server, your data. MIT licensed.</p>

--- a/scripts/hooks/install-hooks.sh
+++ b/scripts/hooks/install-hooks.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Install Vibrdrome git hooks.
+#
+# Run once after cloning. Re-run after pulling new hooks from scripts/hooks/.
+
+set -euo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+HOOKS_SRC="$REPO_ROOT/scripts/hooks"
+HOOKS_DST="$REPO_ROOT/.git/hooks"
+
+for hook in pre-commit; do
+    src="$HOOKS_SRC/$hook"
+    dst="$HOOKS_DST/$hook"
+    if [ ! -f "$src" ]; then
+        echo "install-hooks: missing source hook $src" >&2
+        exit 1
+    fi
+    cp "$src" "$dst"
+    chmod +x "$dst"
+    echo "install-hooks: installed $hook"
+done

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Pre-commit guard for Vibrdrome version bumps.
+#
+# If a commit changes CURRENT_PROJECT_VERSION in project.yml, it MUST also
+# touch every doc file listed in REQUIRED_DOCS. This exists because the
+# human owner got burned repeatedly by version bumps that shipped without
+# the corresponding changelog/feature/testing/metadata updates.
+#
+# Install with: scripts/hooks/install-hooks.sh
+# Bypass (--no-verify) is explicitly not tolerated -- if you think the bump
+# really doesn't need a doc touch, update the file with a dated "no-op"
+# note so the thought is at least recorded.
+
+set -euo pipefail
+
+REQUIRED_DOCS=(
+    "CHANGELOG.md"
+    "docs/changelog.html"
+    "docs/features.html"
+    "docs/index.html"
+    "docs/User-Guide.md"
+    "docs/TESTING-CHECKLIST.md"
+    "docs/APPSTORE-METADATA.md"
+    "TESTING.md"
+)
+
+# Files staged in this commit
+STAGED=$(git diff --cached --name-only)
+
+# Nothing to do if project.yml isn't staged
+if ! printf '%s\n' "$STAGED" | grep -qx "project.yml"; then
+    exit 0
+fi
+
+# Check if CURRENT_PROJECT_VERSION actually changed in the staged diff
+if ! git diff --cached -- project.yml | grep -qE '^\+\s*CURRENT_PROJECT_VERSION:'; then
+    exit 0
+fi
+
+# At this point: the commit bumps the build number. Enforce doc touches.
+MISSING=()
+for doc in "${REQUIRED_DOCS[@]}"; do
+    if ! printf '%s\n' "$STAGED" | grep -qx "$doc"; then
+        MISSING+=("$doc")
+    fi
+done
+
+if [ ${#MISSING[@]} -eq 0 ]; then
+    exit 0
+fi
+
+cat <<EOF >&2
+pre-commit: version bump detected in project.yml but these doc files
+were NOT touched in the same commit:
+
+EOF
+for doc in "${MISSING[@]}"; do
+    printf '  - %s\n' "$doc" >&2
+done
+cat <<EOF >&2
+
+Every version bump must carry corresponding doc updates. If a file has
+genuinely no content change, touch it anyway with a dated "no-op" note
+so the thought was recorded.
+
+Aborting commit. Do not bypass with --no-verify.
+EOF
+
+exit 1


### PR DESCRIPTION
## Summary
Two linked changes to stop docs from falling out of sync with builds:

**1. Doc refresh (Build 50)**
- `features.html`: Get Info section, macOS Power User section, Radio Mix + optional toolbar background in Now Playing
- `index.html`: Get Info and macOS Keyboard Shortcuts cards in feature grid
- `User-Guide.md`: Get Info, ⌘K/⌘F, Radio Mix, Delete Station, Add Station labeled sections, Liquid Glass, iPad mini player keyboard pinning
- `TESTING-CHECKLIST.md`: full rewrite covering all Build 50 regressions
- `APPSTORE-METADATA.md`: fix visualizer count (6 -> 18), rewrite "What's New" for Build 50, add Built for Mac section, refresh description, add Mac screenshot size

**2. Pre-commit hook (scripts/hooks/pre-commit)**
- Rejects any commit that bumps `CURRENT_PROJECT_VERSION` in `project.yml` unless every required doc file is also staged
- Required files: CHANGELOG.md, docs/changelog.html, docs/features.html, docs/index.html, docs/User-Guide.md, docs/TESTING-CHECKLIST.md, docs/APPSTORE-METADATA.md, TESTING.md
- `scripts/hooks/install-hooks.sh` copies hooks into `.git/hooks/`
- `CLAUDE.md` pre-TestFlight checklist rewritten: 18 mandatory steps, escape hatches ("if new features were added") removed

Docs only + build tooling, no runtime code. `[skip ci]`.

## Test plan
- [x] Hook tested with synthetic bad bump: correctly lists all 8 missing files and aborts with exit 1
- [x] No em dashes in new content
- [x] Visualizer preset count verified from `VisualizerView.swift` enum (18 cases)
- [x] Hook installed locally via `scripts/hooks/install-hooks.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)