### PR TITLE
Add macOS table column customization for song list views

### DIFF
--- a/Vibrdrome/Core/Constants/UserDefaultsKeys.swift
+++ b/Vibrdrome/Core/Constants/UserDefaultsKeys.swift
@@ -143,6 +143,11 @@ enum UserDefaultsKeys {
     static let libraryLayout = "libraryLayout"
     static let activeMusicFolderId = "activeMusicFolderId"
 
+    // MARK: - macOS Track Table Columns
+
+    /// Key prefix for per-view column config. Full key = prefix + viewKey (e.g. "songs", "album").
+    static let trackTableColumnsPrefix = "trackTableColumns_"
+
     // MARK: - macOS Layout
 
     static let macNowPlayingPlacement = "macNowPlayingPlacement"

--- a/Vibrdrome/Features/Library/AlbumDetailView.swift
+++ b/Vibrdrome/Features/Library/AlbumDetailView.swift
@@ -15,6 +15,9 @@ struct AlbumDetailView: View {
     @State private var isSelecting = false
     @State private var showAddToPlaylist = false
     @State private var isStarred = false
+    #if os(macOS)
+    @State private var columnSettings = TrackTableColumnSettings(viewKey: "album")
+    #endif
 
     var body: some View {
         ScrollView {
@@ -31,6 +34,13 @@ struct AlbumDetailView: View {
                     let discs = Set(songs.compactMap(\.discNumber)).sorted()
                     let hasMultipleDiscs = discs.count > 1
 
+                    #if os(macOS)
+                    MacTrackTableView(
+                        songs: songs,
+                        settings: columnSettings,
+                        showDiscSeparators: hasMultipleDiscs
+                    )
+                    #else
                     LazyVStack(spacing: 0) {
                         ForEach(Array(songs.enumerated()), id: \.element.id) { index, song in
                             // Disc separator
@@ -56,6 +66,7 @@ struct AlbumDetailView: View {
                                 .padding(.leading, isSelecting ? 72 : 56)
                         }
                     }
+                    #endif
 
                     // Batch action bar
                     if isSelecting && !selectedSongs.isEmpty {

--- a/Vibrdrome/Features/Library/ArtistDetailView.swift
+++ b/Vibrdrome/Features/Library/ArtistDetailView.swift
@@ -12,12 +12,20 @@ struct ArtistDetailView: View {
     @State private var error: String?
     @State private var showFullBio = false
     @State private var isStarred = false
+    #if os(macOS)
+    @State private var columnSettings = TrackTableColumnSettings(viewKey: "artist")
+    #endif
 
     var body: some View {
         List {
             // Top Songs section
             if !topSongs.isEmpty {
                 Section {
+                    #if os(macOS)
+                    MacTrackTableView(songs: topSongs, settings: columnSettings)
+                        .listRowInsets(EdgeInsets())
+                        .listRowSeparator(.hidden)
+                    #else
                     ForEach(Array(topSongs.enumerated()), id: \.element.id) { index, song in
                         TrackRow(song: song, showTrackNumber: false)
                             .contentShape(Rectangle())
@@ -26,6 +34,7 @@ struct ArtistDetailView: View {
                             }
                             .trackContextMenu(song: song, queue: topSongs, index: index)
                     }
+                    #endif
                 } header: {
                     Text("Top Tracks")
                 }

--- a/Vibrdrome/Features/Library/FavoritesView.swift
+++ b/Vibrdrome/Features/Library/FavoritesView.swift
@@ -13,6 +13,9 @@ struct FavoritesView: View {
     @State private var selectedCategory: FavoriteCategory = .songs
     @AppStorage("favoritesViewAsList") private var showAsList = true
     @AppStorage(UserDefaultsKeys.gridColumnsPerRow) private var gridColumns = 2
+    #if os(macOS)
+    @State private var columnSettings = TrackTableColumnSettings(viewKey: "favorites")
+    #endif
 
     enum FavoriteCategory: String, CaseIterable, Identifiable {
         case songs, albums, artists
@@ -163,6 +166,9 @@ struct FavoritesView: View {
         if songs.isEmpty {
             emptyCategory("No Favorited Songs")
         } else {
+            #if os(macOS)
+            MacTrackTableView(songs: songs, settings: columnSettings)
+            #else
             List {
                 HStack(spacing: 12) {
                     Button {
@@ -231,6 +237,7 @@ struct FavoritesView: View {
                 }
             }
             .listStyle(.plain)
+            #endif
         }
     }
 

--- a/Vibrdrome/Features/Library/MacColumnCustomizerView.swift
+++ b/Vibrdrome/Features/Library/MacColumnCustomizerView.swift
@@ -27,6 +27,7 @@ struct MacColumnCustomizerView: View {
                         Image(systemName: "line.3.horizontal")
                             .font(.caption)
                             .foregroundStyle(.tertiary)
+                            .accessibilityHidden(true)
 
                         // Toggle
                         Toggle(isOn: Binding(

--- a/Vibrdrome/Features/Library/MacColumnCustomizerView.swift
+++ b/Vibrdrome/Features/Library/MacColumnCustomizerView.swift
@@ -1,0 +1,69 @@
+#if os(macOS)
+import SwiftUI
+
+// MARK: - Column customizer popover
+
+struct MacColumnCustomizerView: View {
+    @Bindable var settings: TrackTableColumnSettings
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header
+            HStack {
+                Text("Customize Columns")
+                    .font(.headline)
+                Spacer()
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 14)
+            .padding(.bottom, 8)
+
+            Divider()
+
+            List {
+                ForEach(settings.entries) { entry in
+                    HStack(spacing: 10) {
+                        // Drag handle
+                        Image(systemName: "line.3.horizontal")
+                            .font(.caption)
+                            .foregroundStyle(.tertiary)
+
+                        // Toggle
+                        Toggle(isOn: Binding(
+                            get: { entry.visible },
+                            set: { _ in settings.toggle(entry.column) }
+                        )) {
+                            Text(entry.column.label)
+                                .font(.body)
+                        }
+                        .toggleStyle(.checkbox)
+                        .disabled(!entry.column.isRemovable)
+                    }
+                    .accessibilityElement(children: .combine)
+                }
+                .onMove { source, destination in
+                    settings.move(fromOffsets: source, toOffset: destination)
+                }
+            }
+            .listStyle(.plain)
+            .frame(height: min(CGFloat(settings.entries.count) * 34 + 8, 400))
+
+            Divider()
+
+            // Reset
+            HStack {
+                Button("Reset to Defaults") {
+                    settings.resetToDefaults()
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(.secondary)
+                .font(.caption)
+                Spacer()
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 10)
+        }
+        .frame(width: 260)
+    }
+}
+#endif

--- a/Vibrdrome/Features/Library/MacTrackTableHeader.swift
+++ b/Vibrdrome/Features/Library/MacTrackTableHeader.swift
@@ -99,6 +99,7 @@ struct MacTrackTableHeader: View {
                                 settings.setWidth(newWidth, for: col)
                             }
                             .onEnded { _ in
+                                settings.persistWidths()
                                 dragBox.column = nil
                                 dragBox.startWidth = 0
                             }

--- a/Vibrdrome/Features/Library/MacTrackTableHeader.swift
+++ b/Vibrdrome/Features/Library/MacTrackTableHeader.swift
@@ -1,29 +1,25 @@
 #if os(macOS)
+import AppKit
 import SwiftUI
 
 // MARK: - Column header row
 
 struct MacTrackTableHeader: View {
-    let visibleColumns: [TrackTableColumn]
+    let settings: TrackTableColumnSettings
+    /// Total pixel width of the header row (from GeometryReader in parent).
+    let availableWidth: CGFloat
     @Binding var sortColumn: TrackTableColumn?
     @Binding var sortAscending: Bool
     @Binding var showCustomizer: Bool
 
+    // Reference-type box so mutations don't trigger SwiftUI re-renders,
+    // which would reset the DragGesture translation back to zero mid-drag.
+    @State private var dragBox = ColumnDragBox()
+
     var body: some View {
         HStack(spacing: 0) {
-            ForEach(visibleColumns) { col in
-                Button {
-                    guard col.isSortable else { return }
-                    if sortColumn == col {
-                        sortAscending.toggle()
-                    } else {
-                        sortColumn = col
-                        sortAscending = true
-                    }
-                } label: {
-                    headerCell(col)
-                }
-                .buttonStyle(.plain)
+            ForEach(settings.visibleColumns) { col in
+                headerCellWithHandle(col)
             }
 
             // Fixed trailing area — must be identical width to MacTrackTableRow trailing actions (80pt)
@@ -50,8 +46,69 @@ struct MacTrackTableHeader: View {
         }
     }
 
+    // MARK: - Header cell with optional resize handle
+
     @ViewBuilder
-    private func headerCell(_ col: TrackTableColumn) -> some View {
+    private func headerCellWithHandle(_ col: TrackTableColumn) -> some View {
+        let cellWidth: CGFloat = col.isUserResizable
+            ? settings.columnWidth(for: col)
+            : col.minWidth
+
+        Button {
+            guard col.isSortable else { return }
+            if sortColumn == col {
+                sortAscending.toggle()
+            } else {
+                sortColumn = col
+                sortAscending = true
+            }
+        } label: {
+            headerCellLabel(col)
+        }
+        .buttonStyle(.plain)
+        .frame(
+            minWidth: col == .title ? col.minWidth : cellWidth,
+            maxWidth: col == .title ? .infinity : cellWidth,
+            alignment: col == .trackNumber ? .trailing : .leading
+        )
+        .overlay(alignment: .leading) {
+            if col.isUserResizable {
+                Color.clear
+                    .frame(width: 8)
+                    .contentShape(Rectangle())
+                    .onHover { hovering in
+                        if hovering {
+                            NSCursor.resizeLeftRight.push()
+                        } else {
+                            NSCursor.pop()
+                        }
+                    }
+                    .gesture(
+                        DragGesture(minimumDistance: 2, coordinateSpace: .global)
+                            .onChanged { value in
+                                if dragBox.column != col {
+                                    dragBox.column = col
+                                    dragBox.startWidth = settings.columnWidth(for: col)
+                                }
+                                // Use global coordinates: immune to local frame re-renders
+                                // caused by settings.setWidth() triggering @Observable updates.
+                                let delta = value.location.x - value.startLocation.x
+                                let rawWidth = dragBox.startWidth - delta
+                                let maxWidth = maxColumnWidth(for: col)
+                                let newWidth = min(max(col.minWidth, rawWidth), maxWidth)
+                                settings.setWidth(newWidth, for: col)
+                            }
+                            .onEnded { _ in
+                                dragBox.column = nil
+                                dragBox.startWidth = 0
+                            }
+                    )
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func headerCellLabel(_ col: TrackTableColumn) -> some View {
         HStack(spacing: 3) {
             Text(col.label)
                 .font(.caption)
@@ -66,11 +123,37 @@ struct MacTrackTableHeader: View {
             }
         }
         .padding(.horizontal, 4)
-        .frame(
-            minWidth: col.minWidth,
-            maxWidth: col.isFlexible ? .infinity : col.minWidth,
-            alignment: col == .trackNumber ? .trailing : .leading
-        )
+        .frame(maxWidth: .infinity, alignment: col == .trackNumber ? .trailing : .leading)
     }
+
+    // MARK: - Max width computation
+
+    /// Maximum width `col` may be set to — leaves enough room for Title to stay at its minimum.
+    private func maxColumnWidth(for col: TrackTableColumn) -> CGFloat {
+        // Fixed layout budget consumed by non-flexible columns and chrome:
+        //   • 80pt trailing actions
+        //   • 24pt horizontal padding (12 each side)
+        //   • title minimum width
+        //   • all other visible fixed columns (not title, not the column being dragged)
+        //   • all other visible resizable columns (not the column being dragged)
+        let chrome: CGFloat = 80 + 24 + TrackTableColumn.title.minWidth
+        let otherFixed = settings.visibleColumns
+            .filter { $0 != col && $0 != .title && !$0.isUserResizable }
+            .reduce(0) { $0 + $1.minWidth }
+        let otherResizable = settings.visibleColumns
+            .filter { $0 != col && $0.isUserResizable }
+            .reduce(0) { $0 + settings.columnWidth(for: $1) }
+        let budget = availableWidth - chrome - otherFixed - otherResizable
+        return max(col.minWidth, budget)
+    }
+}
+
+// MARK: - Drag state box
+
+/// Reference type so property mutations don't trigger SwiftUI re-renders,
+/// keeping the DragGesture translation stable throughout the drag.
+private final class ColumnDragBox {
+    var column: TrackTableColumn?
+    var startWidth: CGFloat = 0
 }
 #endif

--- a/Vibrdrome/Features/Library/MacTrackTableHeader.swift
+++ b/Vibrdrome/Features/Library/MacTrackTableHeader.swift
@@ -1,0 +1,76 @@
+#if os(macOS)
+import SwiftUI
+
+// MARK: - Column header row
+
+struct MacTrackTableHeader: View {
+    let visibleColumns: [TrackTableColumn]
+    @Binding var sortColumn: TrackTableColumn?
+    @Binding var sortAscending: Bool
+    @Binding var showCustomizer: Bool
+
+    var body: some View {
+        HStack(spacing: 0) {
+            ForEach(visibleColumns) { col in
+                Button {
+                    guard col.isSortable else { return }
+                    if sortColumn == col {
+                        sortAscending.toggle()
+                    } else {
+                        sortColumn = col
+                        sortAscending = true
+                    }
+                } label: {
+                    headerCell(col)
+                }
+                .buttonStyle(.plain)
+            }
+
+            // Fixed trailing area — must be identical width to MacTrackTableRow trailing actions (80pt)
+            HStack(spacing: 0) {
+                Spacer()
+                Button {
+                    showCustomizer.toggle()
+                } label: {
+                    Image(systemName: "tablecells.badge.ellipsis")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+                .help("Customize Columns")
+                .accessibilityLabel("Customize Columns")
+            }
+            .frame(width: 80)
+        }
+        .padding(.horizontal, 12)
+        .frame(height: 26)
+        .background(.bar)
+        .overlay(alignment: .bottom) {
+            Divider()
+        }
+    }
+
+    @ViewBuilder
+    private func headerCell(_ col: TrackTableColumn) -> some View {
+        HStack(spacing: 3) {
+            Text(col.label)
+                .font(.caption)
+                .fontWeight(.medium)
+                .foregroundStyle(sortColumn == col ? Color.accentColor : .secondary)
+                .lineLimit(1)
+
+            if sortColumn == col {
+                Image(systemName: sortAscending ? "chevron.up" : "chevron.down")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundStyle(Color.accentColor)
+            }
+        }
+        .padding(.horizontal, 4)
+        .frame(
+            minWidth: col.minWidth,
+            maxWidth: col.isFlexible ? .infinity : col.minWidth,
+            alignment: col == .trackNumber ? .trailing : .leading
+        )
+    }
+}
+#endif

--- a/Vibrdrome/Features/Library/MacTrackTableRow.swift
+++ b/Vibrdrome/Features/Library/MacTrackTableRow.swift
@@ -7,7 +7,7 @@ import NukeUI
 
 struct MacTrackTableRow: View {
     let song: Song
-    let visibleColumns: [TrackTableColumn]
+    let settings: TrackTableColumnSettings
     let queue: [Song]
     let index: Int
     /// Binding to the parent-managed selected song id for single-click selection.
@@ -28,7 +28,7 @@ struct MacTrackTableRow: View {
 
     var body: some View {
         HStack(spacing: 0) {
-            ForEach(visibleColumns) { col in
+            ForEach(settings.visibleColumns) { col in
                 columnCell(col)
             }
             trailingActions
@@ -74,6 +74,9 @@ struct MacTrackTableRow: View {
     @ViewBuilder
     private func columnCell(_ col: TrackTableColumn) -> some View {
         let content = cellContent(col)
+        let cellWidth: CGFloat = col.isUserResizable
+            ? settings.columnWidth(for: col)
+            : col.minWidth
         content
             .font(col == .trackNumber ? .subheadline : .body)
             .foregroundStyle(cellForegroundStyle(col))
@@ -81,8 +84,8 @@ struct MacTrackTableRow: View {
             .truncationMode(.tail)
             .padding(.horizontal, 4)
             .frame(
-                minWidth: col.minWidth,
-                maxWidth: col.isFlexible ? .infinity : col.minWidth,
+                minWidth: col == .title ? col.minWidth : cellWidth,
+                maxWidth: col == .title ? .infinity : cellWidth,
                 alignment: col == .trackNumber ? .trailing : .leading
             )
     }
@@ -90,62 +93,101 @@ struct MacTrackTableRow: View {
     @ViewBuilder
     private func cellContent(_ col: TrackTableColumn) -> some View {
         switch col {
-        case .trackNumber:
-            if isCurrentlyPlaying {
-                Image(systemName: "waveform")
-                    .symbolEffect(.variableColor)
-                    .font(.subheadline)
-                    .foregroundStyle(Color.accentColor)
-                    .frame(width: col.minWidth, alignment: .trailing)
-            } else if let track = song.track {
-                Text("\(track)")
-            } else {
-                Text("—").foregroundStyle(.quaternary)
-            }
-        case .title:
-            if showAlbumArt {
-                HStack(spacing: 8) {
-                    AlbumArtView(coverArtId: song.coverArt, size: 28, cornerRadius: 3)
-                    Text(song.title)
-                        .fontWeight(isCurrentlyPlaying ? .semibold : .regular)
-                        .lineLimit(1)
-                }
-            } else {
+        case .trackNumber: trackNumberCell
+        case .title:       titleCell
+        case .artist:      artistCell
+        case .album:       albumCell
+        case .duration:    durationCell
+        case .year:        yearCell
+        case .genre:       genreCell
+        case .bitRate:     bitRateCell
+        case .format:      formatCell
+        case .bpm:         bpmCell
+        case .dateAdded:   dateAddedCell
+        }
+    }
+
+    @ViewBuilder private var trackNumberCell: some View {
+        if isCurrentlyPlaying {
+            Image(systemName: "waveform")
+                .symbolEffect(.variableColor)
+                .font(.subheadline)
+                .foregroundStyle(Color.accentColor)
+                .frame(width: TrackTableColumn.trackNumber.minWidth, alignment: .trailing)
+        } else if let track = song.track {
+            Text("\(track)")
+        } else {
+            Text("—").foregroundStyle(.quaternary)
+        }
+    }
+
+    @ViewBuilder private var titleCell: some View {
+        if showAlbumArt {
+            HStack(spacing: 8) {
+                AlbumArtView(coverArtId: song.coverArt, size: 28, cornerRadius: 3)
                 Text(song.title)
                     .fontWeight(isCurrentlyPlaying ? .semibold : .regular)
+                    .lineLimit(1)
             }
-        case .artist:
-            Text(song.artist ?? "—")
-                .foregroundStyle(song.artist != nil ? .primary : .quaternary)
-        case .album:
-            Text(song.album ?? "—")
-                .foregroundStyle(song.album != nil ? .primary : .quaternary)
-        case .duration:
-            Text(song.duration.map { formatDuration($0) } ?? "—")
-                .foregroundStyle(.secondary)
-        case .year:
-            Text(song.year.map { String($0) } ?? "—")
-                .foregroundStyle(song.year != nil ? .secondary : .quaternary)
-        case .genre:
-            Text(song.genre ?? "—")
-                .foregroundStyle(song.genre != nil ? .secondary : .quaternary)
-        case .bitRate:
-            if let br = song.bitRate {
-                Text("\(br) kbps")
-                    .foregroundStyle(.secondary)
-            } else {
-                Text("—").foregroundStyle(.quaternary)
-            }
-        case .format:
-            Text(song.suffix?.uppercased() ?? "—")
-                .foregroundStyle(song.suffix != nil ? .secondary : .quaternary)
-        case .bpm:
-            Text(song.bpm.map { String($0) } ?? "—")
-                .foregroundStyle(song.bpm != nil ? .secondary : .quaternary)
-        case .dateAdded:
-            Text(formattedDateAdded)
-                .foregroundStyle(.secondary)
+        } else {
+            Text(song.title)
+                .fontWeight(isCurrentlyPlaying ? .semibold : .regular)
         }
+    }
+
+    @ViewBuilder private var artistCell: some View {
+        if let artistId = song.artistId, let name = song.artist {
+            NavigableCellText(text: name) { appState.pendingNavigation = .artist(id: artistId) }
+        } else {
+            Text(song.artist ?? "—").foregroundStyle(song.artist != nil ? .primary : .quaternary)
+        }
+    }
+
+    @ViewBuilder private var albumCell: some View {
+        if let albumId = song.albumId, let name = song.album {
+            NavigableCellText(text: name) { appState.pendingNavigation = .album(id: albumId) }
+        } else {
+            Text(song.album ?? "—").foregroundStyle(song.album != nil ? .primary : .quaternary)
+        }
+    }
+
+    @ViewBuilder private var durationCell: some View {
+        Text(song.duration.map { formatDuration($0) } ?? "—").foregroundStyle(.secondary)
+    }
+
+    @ViewBuilder private var yearCell: some View {
+        Text(song.year.map { String($0) } ?? "—")
+            .foregroundStyle(song.year != nil ? .secondary : .quaternary)
+    }
+
+    @ViewBuilder private var genreCell: some View {
+        if let genre = song.genre {
+            NavigableCellText(text: genre) { appState.pendingNavigation = .genre(name: genre) }
+        } else {
+            Text("—").foregroundStyle(.quaternary)
+        }
+    }
+
+    @ViewBuilder private var bitRateCell: some View {
+        if let br = song.bitRate {
+            Text("\(br) kbps").foregroundStyle(.secondary)
+        } else {
+            Text("—").foregroundStyle(.quaternary)
+        }
+    }
+
+    @ViewBuilder private var formatCell: some View {
+        Text(song.suffix?.uppercased() ?? "—")
+            .foregroundStyle(song.suffix != nil ? .secondary : .quaternary)
+    }
+
+    @ViewBuilder private var bpmCell: some View {
+        Text(song.bpm.map { String($0) } ?? "—")
+            .foregroundStyle(song.bpm != nil ? .secondary : .quaternary)
+    }
+
+    @ViewBuilder private var dateAddedCell: some View {
+        Text(formattedDateAdded).foregroundStyle(.secondary)
     }
 
     private func cellForegroundStyle(_ col: TrackTableColumn) -> some ShapeStyle {
@@ -254,6 +296,26 @@ struct MacTrackTableRow: View {
             .accessibilityLabel("Song Options")
         }
         .frame(width: 80, alignment: .trailing)
+    }
+}
+
+// MARK: - Navigable cell text
+
+/// A tappable text cell that underlines and accents on hover, used for artist / album / genre.
+private struct NavigableCellText: View {
+    let text: String
+    let action: () -> Void
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: action) {
+            Text(text)
+                .underline(isHovered)
+                .foregroundStyle(isHovered ? Color.accentColor : .primary)
+                .lineLimit(1)
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovered = $0 }
     }
 }
 #endif

--- a/Vibrdrome/Features/Library/MacTrackTableRow.swift
+++ b/Vibrdrome/Features/Library/MacTrackTableRow.swift
@@ -57,6 +57,8 @@ struct MacTrackTableRow: View {
             AudioEngine.shared.play(song: song, from: queue, at: index)
         }
         .trackContextMenu(song: song, queue: queue, index: index)
+        .accessibilityLabel("\(song.title), \(song.artist ?? "Unknown Artist")")
+        .accessibilityHint("Double-tap to play")
         .onAppear {
             isStarred = song.starred != nil
             let songId = song.id

--- a/Vibrdrome/Features/Library/MacTrackTableRow.swift
+++ b/Vibrdrome/Features/Library/MacTrackTableRow.swift
@@ -1,0 +1,257 @@
+#if os(macOS)
+import SwiftUI
+import SwiftData
+import NukeUI
+
+// MARK: - Single track row for the custom macOS table
+
+struct MacTrackTableRow: View {
+    let song: Song
+    let visibleColumns: [TrackTableColumn]
+    let queue: [Song]
+    let index: Int
+    /// Binding to the parent-managed selected song id for single-click selection.
+    @Binding var selectedSongId: String?
+
+    @Environment(\.modelContext) private var modelContext
+    @Environment(AppState.self) private var appState
+    @AppStorage(UserDefaultsKeys.showAlbumArtInLists) private var showAlbumArt: Bool = true
+    @State private var isStarred = false
+    @State private var isDownloaded = false
+    @State private var isHovered = false
+
+    private var isCurrentlyPlaying: Bool {
+        AudioEngine.shared.currentSong?.id == song.id
+    }
+
+    private var isSelected: Bool { selectedSongId == song.id }
+
+    var body: some View {
+        HStack(spacing: 0) {
+            ForEach(visibleColumns) { col in
+                columnCell(col)
+            }
+            trailingActions
+        }
+        .padding(.horizontal, 12)
+        .frame(height: showAlbumArt ? 44 : 34)
+        // Now-playing gets an accent tint; selected gets a system selection bg; hover gets a subtle lift
+        .background {
+            if isCurrentlyPlaying {
+                Color.accentColor.opacity(0.12)
+            } else if isSelected {
+                Color.accentColor.opacity(0.08)
+            } else if isHovered {
+                Color.primary.opacity(0.05)
+            }
+        }
+        .contentShape(Rectangle())
+        .onHover { isHovered = $0 }
+        // Single-click: select
+        .onTapGesture(count: 1) {
+            selectedSongId = song.id
+        }
+        // Double-click: play
+        .onTapGesture(count: 2) {
+            selectedSongId = song.id
+            AudioEngine.shared.play(song: song, from: queue, at: index)
+        }
+        .trackContextMenu(song: song, queue: queue, index: index)
+        .onAppear {
+            isStarred = song.starred != nil
+            let songId = song.id
+            let descriptor = FetchDescriptor<DownloadedSong>(
+                predicate: #Predicate { $0.songId == songId && $0.isComplete == true }
+            )
+            isDownloaded = (try? modelContext.fetchCount(descriptor)) ?? 0 > 0
+        }
+    }
+
+    // MARK: - Column cells
+
+    @ViewBuilder
+    private func columnCell(_ col: TrackTableColumn) -> some View {
+        let content = cellContent(col)
+        content
+            .font(col == .trackNumber ? .subheadline : .body)
+            .foregroundStyle(cellForegroundStyle(col))
+            .lineLimit(1)
+            .truncationMode(.tail)
+            .padding(.horizontal, 4)
+            .frame(
+                minWidth: col.minWidth,
+                maxWidth: col.isFlexible ? .infinity : col.minWidth,
+                alignment: col == .trackNumber ? .trailing : .leading
+            )
+    }
+
+    @ViewBuilder
+    private func cellContent(_ col: TrackTableColumn) -> some View {
+        switch col {
+        case .trackNumber:
+            if isCurrentlyPlaying {
+                Image(systemName: "waveform")
+                    .symbolEffect(.variableColor)
+                    .font(.subheadline)
+                    .foregroundStyle(Color.accentColor)
+                    .frame(width: col.minWidth, alignment: .trailing)
+            } else if let track = song.track {
+                Text("\(track)")
+            } else {
+                Text("—").foregroundStyle(.quaternary)
+            }
+        case .title:
+            if showAlbumArt {
+                HStack(spacing: 8) {
+                    AlbumArtView(coverArtId: song.coverArt, size: 28, cornerRadius: 3)
+                    Text(song.title)
+                        .fontWeight(isCurrentlyPlaying ? .semibold : .regular)
+                        .lineLimit(1)
+                }
+            } else {
+                Text(song.title)
+                    .fontWeight(isCurrentlyPlaying ? .semibold : .regular)
+            }
+        case .artist:
+            Text(song.artist ?? "—")
+                .foregroundStyle(song.artist != nil ? .primary : .quaternary)
+        case .album:
+            Text(song.album ?? "—")
+                .foregroundStyle(song.album != nil ? .primary : .quaternary)
+        case .duration:
+            Text(song.duration.map { formatDuration($0) } ?? "—")
+                .foregroundStyle(.secondary)
+        case .year:
+            Text(song.year.map { String($0) } ?? "—")
+                .foregroundStyle(song.year != nil ? .secondary : .quaternary)
+        case .genre:
+            Text(song.genre ?? "—")
+                .foregroundStyle(song.genre != nil ? .secondary : .quaternary)
+        case .bitRate:
+            if let br = song.bitRate {
+                Text("\(br) kbps")
+                    .foregroundStyle(.secondary)
+            } else {
+                Text("—").foregroundStyle(.quaternary)
+            }
+        case .format:
+            Text(song.suffix?.uppercased() ?? "—")
+                .foregroundStyle(song.suffix != nil ? .secondary : .quaternary)
+        case .bpm:
+            Text(song.bpm.map { String($0) } ?? "—")
+                .foregroundStyle(song.bpm != nil ? .secondary : .quaternary)
+        case .dateAdded:
+            Text(formattedDateAdded)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private func cellForegroundStyle(_ col: TrackTableColumn) -> some ShapeStyle {
+        if isCurrentlyPlaying && col == .title {
+            return AnyShapeStyle(Color.accentColor)
+        }
+        return AnyShapeStyle(Color.primary)
+    }
+
+    private var formattedDateAdded: String {
+        guard let created = song.created else { return "—" }
+        // Format: "MMM d, yyyy" from ISO8601 prefix
+        let prefix = String(created.prefix(10))
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        if let date = formatter.date(from: prefix) {
+            formatter.dateStyle = .medium
+            formatter.timeStyle = .none
+            return formatter.string(from: date)
+        }
+        return prefix
+    }
+
+    // MARK: - Trailing fixed actions
+
+    private var trailingActions: some View {
+        HStack(spacing: 4) {
+            // Heart
+            Button {
+                let wasStarred = isStarred
+                isStarred = !wasStarred
+                Task {
+                    do {
+                        if wasStarred {
+                            try await OfflineActionQueue.shared.unstar(id: song.id)
+                        } else {
+                            try await OfflineActionQueue.shared.star(id: song.id)
+                            if UserDefaults.standard.bool(forKey: UserDefaultsKeys.autoDownloadFavorites) {
+                                DownloadManager.shared.download(song: song, client: AppState.shared.subsonicClient)
+                            }
+                        }
+                    } catch {
+                        isStarred = wasStarred
+                    }
+                }
+            } label: {
+                Image(systemName: isStarred ? "heart.fill" : "heart")
+                    .font(.caption)
+                    .foregroundStyle(isStarred ? .pink : .secondary)
+            }
+            .buttonStyle(.plain)
+            .opacity(isHovered || isStarred ? 1 : 0)
+            .accessibilityLabel(isStarred ? "Remove from Favorites" : "Add to Favorites")
+
+            // Download
+            if isDownloaded {
+                Image(systemName: "arrow.down.circle.fill")
+                    .font(.callout)
+                    .foregroundStyle(.green)
+                    .accessibilityLabel("Downloaded")
+            } else {
+                Button {
+                    DownloadManager.shared.download(
+                        song: song, client: AppState.shared.subsonicClient
+                    )
+                    isDownloaded = true
+                } label: {
+                    Image(systemName: "arrow.down.circle")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+                .opacity(isHovered ? 1 : 0)
+                .accessibilityLabel("Download Song")
+            }
+
+            // Context menu button
+            Menu {
+                Button {
+                    AudioEngine.shared.addToQueueNext(song)
+                } label: {
+                    Label("Play Next", systemImage: "text.insert")
+                }
+                Button {
+                    AudioEngine.shared.addToQueue(song)
+                } label: {
+                    Label("Add to Queue", systemImage: "text.append")
+                }
+                Button {
+                    AudioEngine.shared.startRadioFromSong(song)
+                } label: {
+                    Label("Start Radio", systemImage: "dot.radiowaves.left.and.right")
+                }
+                let shareText = "🎵 \(song.title) — \(song.artist ?? "Unknown Artist")"
+                ShareLink(item: shareText) {
+                    Label("Share", systemImage: "square.and.arrow.up")
+                }
+            } label: {
+                Image(systemName: "ellipsis")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .frame(width: 20, height: 20)
+            }
+            .buttonStyle(.plain)
+            .opacity(isHovered ? 1 : 0)
+            .accessibilityLabel("Song Options")
+        }
+        .frame(width: 80, alignment: .trailing)
+    }
+}
+#endif

--- a/Vibrdrome/Features/Library/MacTrackTableRow.swift
+++ b/Vibrdrome/Features/Library/MacTrackTableRow.swift
@@ -1,6 +1,5 @@
 #if os(macOS)
 import SwiftUI
-import SwiftData
 import NukeUI
 
 // MARK: - Single track row for the custom macOS table
@@ -10,15 +9,17 @@ struct MacTrackTableRow: View {
     let settings: TrackTableColumnSettings
     let queue: [Song]
     let index: Int
+    /// Reactive set of downloaded song IDs, maintained by parent via @Query.
+    let downloadedSongIds: Set<String>
     /// Binding to the parent-managed selected song id for single-click selection.
     @Binding var selectedSongId: String?
 
-    @Environment(\.modelContext) private var modelContext
     @Environment(AppState.self) private var appState
     @AppStorage(UserDefaultsKeys.showAlbumArtInLists) private var showAlbumArt: Bool = true
     @State private var isStarred = false
-    @State private var isDownloaded = false
     @State private var isHovered = false
+
+    private var isDownloaded: Bool { downloadedSongIds.contains(song.id) }
 
     private var isCurrentlyPlaying: Bool {
         AudioEngine.shared.currentSong?.id == song.id
@@ -61,11 +62,9 @@ struct MacTrackTableRow: View {
         .accessibilityHint("Double-tap to play")
         .onAppear {
             isStarred = song.starred != nil
-            let songId = song.id
-            let descriptor = FetchDescriptor<DownloadedSong>(
-                predicate: #Predicate { $0.songId == songId && $0.isComplete == true }
-            )
-            isDownloaded = (try? modelContext.fetchCount(descriptor)) ?? 0 > 0
+        }
+        .onChange(of: song.starred) { _, newValue in
+            isStarred = newValue != nil
         }
     }
 
@@ -253,7 +252,6 @@ struct MacTrackTableRow: View {
                     DownloadManager.shared.download(
                         song: song, client: AppState.shared.subsonicClient
                     )
-                    isDownloaded = true
                 } label: {
                     Image(systemName: "arrow.down.circle")
                         .font(.callout)

--- a/Vibrdrome/Features/Library/MacTrackTableView.swift
+++ b/Vibrdrome/Features/Library/MacTrackTableView.swift
@@ -27,11 +27,7 @@ struct MacTrackTableView: View {
             let hasDiscs = !discNumbers.isEmpty
             if hasDiscs {
                 // Group by disc number (preserving disc order), sort within each group.
-                let orderedDiscs = songs
-                    .compactMap(\.discNumber)
-                    .reduce(into: [Int]()) { acc, d in
-                        if !acc.contains(d) { acc.append(d) }
-                    }
+                let orderedDiscs = Set(songs.compactMap((\.discNumber))).sorted()
                 let noDisc = songs.filter { $0.discNumber == nil }
                 let grouped: [[Song]] = orderedDiscs.map { disc in
                     songs

--- a/Vibrdrome/Features/Library/MacTrackTableView.swift
+++ b/Vibrdrome/Features/Library/MacTrackTableView.swift
@@ -1,5 +1,6 @@
 #if os(macOS)
 import SwiftUI
+import SwiftData
 
 // MARK: - Unified macOS track table (header + LazyVStack rows)
 
@@ -15,6 +16,13 @@ struct MacTrackTableView: View {
     @State private var sortAscending: Bool = true
     @State private var showCustomizer: Bool = false
     @State private var selectedSongId: String?
+
+    @Query(filter: #Predicate<DownloadedSong> { $0.isComplete == true })
+    private var completedDownloads: [DownloadedSong]
+
+    private var downloadedSongIds: Set<String> {
+        Set(completedDownloads.map(\.songId))
+    }
 
     // MARK: - Computed sort
 
@@ -98,6 +106,7 @@ struct MacTrackTableView: View {
                                 settings: settings,
                                 queue: ordered,
                                 index: index,
+                                downloadedSongIds: downloadedSongIds,
                                 selectedSongId: $selectedSongId
                             )
                             .accessibilityIdentifier("macTrackRow_\(song.id)")

--- a/Vibrdrome/Features/Library/MacTrackTableView.swift
+++ b/Vibrdrome/Features/Library/MacTrackTableView.swift
@@ -1,0 +1,144 @@
+#if os(macOS)
+import SwiftUI
+
+// MARK: - Unified macOS track table (header + LazyVStack rows)
+
+/// Drop-in macOS replacement for `List { ForEach { TrackRow } }`.
+/// Provide `songs`, a `TrackTableColumnSettings` instance keyed to the view,
+/// and optionally disc separators (for album detail context).
+struct MacTrackTableView: View {
+    let songs: [Song]
+    let settings: TrackTableColumnSettings
+    var showDiscSeparators: Bool = false
+
+    @State private var sortColumn: TrackTableColumn?
+    @State private var sortAscending: Bool = true
+    @State private var showCustomizer: Bool = false
+    @State private var selectedSongId: String?
+
+    // MARK: - Computed sort
+
+    private var displayedSongs: [Song] {
+        guard let col = sortColumn else { return songs }
+        return songs.sorted {
+            compareSongs($0, $1, by: col, ascending: sortAscending)
+        }
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        VStack(spacing: 0) {
+            MacTrackTableHeader(
+                visibleColumns: settings.visibleColumns,
+                sortColumn: $sortColumn,
+                sortAscending: $sortAscending,
+                showCustomizer: $showCustomizer
+            )
+            .popover(isPresented: $showCustomizer, arrowEdge: .top) {
+                MacColumnCustomizerView(settings: settings)
+            }
+            // Right-click anywhere on the header also opens customizer
+            .contextMenu {
+                Button("Customize Columns…") { showCustomizer = true }
+            }
+
+            if songs.isEmpty {
+                ContentUnavailableView(
+                    "No Tracks",
+                    systemImage: "music.note",
+                    description: Text("No songs to display.")
+                )
+            } else {
+                ScrollView(.vertical) {
+                    LazyVStack(spacing: 0) {
+                        let ordered = displayedSongs
+                        // Pre-compute first-occurrence indices for disc separators — O(n) not O(n²)
+                        let discFirstIndices: Set<Int> = {
+                            guard showDiscSeparators else { return [] }
+                            var seen = Set<Int>()
+                            var result = Set<Int>()
+                            for (idx, song) in ordered.enumerated() {
+                                if let disc = song.discNumber, !seen.contains(disc) {
+                                    seen.insert(disc)
+                                    result.insert(idx)
+                                }
+                            }
+                            return result
+                        }()
+
+                        ForEach(Array(ordered.enumerated()), id: \.element.id) { index, song in
+                            if showDiscSeparators && discFirstIndices.contains(index),
+                               let disc = song.discNumber {
+                                discSeparator(disc)
+                            }
+
+                            MacTrackTableRow(
+                                song: song,
+                                visibleColumns: settings.visibleColumns,
+                                queue: ordered,
+                                index: index,
+                                selectedSongId: $selectedSongId
+                            )
+                            .accessibilityIdentifier("macTrackRow_\(song.id)")
+
+                            Divider()
+                                .padding(.leading, 12)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Disc separator
+
+    @ViewBuilder
+    private func discSeparator(_ disc: Int) -> some View {
+        HStack {
+            Image(systemName: "opticaldisc")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+            Text("Disc \(disc)")
+                .font(.caption)
+                .fontWeight(.semibold)
+                .foregroundStyle(.secondary)
+            Spacer()
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 7)
+        .background(.ultraThinMaterial)
+    }
+
+    // MARK: - Sort comparator
+
+    private func compareSongs(_ lhs: Song, _ rhs: Song, by col: TrackTableColumn, ascending: Bool) -> Bool {
+        let result: Bool
+        switch col {
+        case .trackNumber:
+            result = (lhs.track ?? Int.max) < (rhs.track ?? Int.max)
+        case .title:
+            result = lhs.title.localizedCaseInsensitiveCompare(rhs.title) == .orderedAscending
+        case .artist:
+            result = (lhs.artist ?? "").localizedCaseInsensitiveCompare(rhs.artist ?? "") == .orderedAscending
+        case .album:
+            result = (lhs.album ?? "").localizedCaseInsensitiveCompare(rhs.album ?? "") == .orderedAscending
+        case .duration:
+            result = (lhs.duration ?? 0) < (rhs.duration ?? 0)
+        case .year:
+            result = (lhs.year ?? 0) < (rhs.year ?? 0)
+        case .genre:
+            result = (lhs.genre ?? "").localizedCaseInsensitiveCompare(rhs.genre ?? "") == .orderedAscending
+        case .bitRate:
+            result = (lhs.bitRate ?? 0) < (rhs.bitRate ?? 0)
+        case .format:
+            result = (lhs.suffix ?? "").localizedCaseInsensitiveCompare(rhs.suffix ?? "") == .orderedAscending
+        case .bpm:
+            result = (lhs.bpm ?? 0) < (rhs.bpm ?? 0)
+        case .dateAdded:
+            result = (lhs.created ?? "") < (rhs.created ?? "")
+        }
+        return ascending ? result : !result
+    }
+}
+#endif

--- a/Vibrdrome/Features/Library/MacTrackTableView.swift
+++ b/Vibrdrome/Features/Library/MacTrackTableView.swift
@@ -20,21 +20,45 @@ struct MacTrackTableView: View {
 
     private var displayedSongs: [Song] {
         guard let col = sortColumn else { return songs }
-        return songs.sorted {
-            compareSongs($0, $1, by: col, ascending: sortAscending)
+        // When disc separators are shown, sort within each disc group so that
+        // disc ordering is preserved and separators don't get scattered.
+        if showDiscSeparators {
+            let discNumbers = songs.compactMap(\.discNumber)
+            let hasDiscs = !discNumbers.isEmpty
+            if hasDiscs {
+                // Group by disc number (preserving disc order), sort within each group.
+                let orderedDiscs = songs
+                    .compactMap(\.discNumber)
+                    .reduce(into: [Int]()) { acc, d in
+                        if !acc.contains(d) { acc.append(d) }
+                    }
+                let noDisc = songs.filter { $0.discNumber == nil }
+                let grouped: [[Song]] = orderedDiscs.map { disc in
+                    songs
+                        .filter { $0.discNumber == disc }
+                        .sorted { compareSongs($0, $1, by: col, ascending: sortAscending) }
+                }
+                let sortedNoDisc = noDisc.sorted { compareSongs($0, $1, by: col, ascending: sortAscending) }
+                return grouped.flatMap { $0 } + sortedNoDisc
+            }
         }
+        return songs.sorted { compareSongs($0, $1, by: col, ascending: sortAscending) }
     }
 
     // MARK: - Body
 
     var body: some View {
         VStack(spacing: 0) {
-            MacTrackTableHeader(
-                visibleColumns: settings.visibleColumns,
-                sortColumn: $sortColumn,
-                sortAscending: $sortAscending,
-                showCustomizer: $showCustomizer
-            )
+            GeometryReader { geo in
+                MacTrackTableHeader(
+                    settings: settings,
+                    availableWidth: geo.size.width,
+                    sortColumn: $sortColumn,
+                    sortAscending: $sortAscending,
+                    showCustomizer: $showCustomizer
+                )
+            }
+            .frame(height: 26)
             .popover(isPresented: $showCustomizer, arrowEdge: .top) {
                 MacColumnCustomizerView(settings: settings)
             }
@@ -75,7 +99,7 @@ struct MacTrackTableView: View {
 
                             MacTrackTableRow(
                                 song: song,
-                                visibleColumns: settings.visibleColumns,
+                                settings: settings,
                                 queue: ordered,
                                 index: index,
                                 selectedSongId: $selectedSongId

--- a/Vibrdrome/Features/Library/SongsView.swift
+++ b/Vibrdrome/Features/Library/SongsView.swift
@@ -18,6 +18,9 @@ struct SongsView: View {
     @AppStorage("songsViewStyle") private var showAsList = true
     @AppStorage(UserDefaultsKeys.gridColumnsPerRow) private var gridColumns = 2
     @State private var sortBy: SongSortOption = .title
+    #if os(macOS)
+    @State private var columnSettings = TrackTableColumnSettings(viewKey: "songs")
+    #endif
 
     private let pageSize = 500
 
@@ -335,6 +338,9 @@ struct SongsView: View {
     // MARK: - List view
 
     private var songList: some View {
+        #if os(macOS)
+        MacTrackTableView(songs: displayedSongs, settings: columnSettings)
+        #else
         List {
             if hasActiveFilters {
                 activeFilterChips
@@ -370,6 +376,7 @@ struct SongsView: View {
                 }
             }
         }
+        #endif
     }
 
     // MARK: - Grid view

--- a/Vibrdrome/Features/Library/TrackTableColumn.swift
+++ b/Vibrdrome/Features/Library/TrackTableColumn.swift
@@ -72,9 +72,31 @@ enum TrackTableColumn: String, CaseIterable, Codable, Identifiable, Sendable {
 
     /// `true` → clicking the column header cycles sort on this field.
     var isSortable: Bool {
+        self != .format
+    }
+
+    /// `true` → the user can drag the column header edge to resize this column.
+    var isUserResizable: Bool {
         switch self {
-        case .trackNumber, .format: return false
-        default: return true
+        case .artist, .album, .genre: return true
+        default: return false
+        }
+    }
+
+    /// Starting width when no user preference has been saved.
+    var defaultWidth: CGFloat {
+        switch self {
+        case .trackNumber: return 40
+        case .title:       return 220
+        case .artist:      return 180
+        case .album:       return 180
+        case .duration:    return 60
+        case .year:        return 52
+        case .genre:       return 130
+        case .bitRate:     return 80
+        case .format:      return 65
+        case .bpm:         return 52
+        case .dateAdded:   return 120
         }
     }
 }

--- a/Vibrdrome/Features/Library/TrackTableColumn.swift
+++ b/Vibrdrome/Features/Library/TrackTableColumn.swift
@@ -1,0 +1,89 @@
+#if os(macOS)
+import Foundation
+
+// MARK: - Column Definition
+
+enum TrackTableColumn: String, CaseIterable, Codable, Identifiable, Sendable {
+    case trackNumber
+    case title
+    case artist
+    case album
+    case duration
+    case year
+    case genre
+    case bitRate
+    case format
+    case bpm
+    case dateAdded
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .trackNumber: return "#"
+        case .title:       return "Title"
+        case .artist:      return "Artist"
+        case .album:       return "Album"
+        case .duration:    return "Time"
+        case .year:        return "Year"
+        case .genre:       return "Genre"
+        case .bitRate:     return "Bitrate"
+        case .format:      return "Format"
+        case .bpm:         return "BPM"
+        case .dateAdded:   return "Date Added"
+        }
+    }
+
+    /// Minimum column width in points.
+    var minWidth: CGFloat {
+        switch self {
+        case .trackNumber: return 36
+        case .title:       return 180
+        case .artist:      return 140
+        case .album:       return 140
+        case .duration:    return 56
+        case .year:        return 52
+        case .genre:       return 100
+        case .bitRate:     return 72
+        case .format:      return 60
+        case .bpm:         return 52
+        case .dateAdded:   return 110
+        }
+    }
+
+    /// Whether the column is flexible (expands to fill remaining space).
+    var isFlexible: Bool {
+        switch self {
+        case .title, .artist, .album, .genre: return true
+        default: return false
+        }
+    }
+
+    /// `true` → column can be hidden by the user.
+    var isRemovable: Bool { self != .title }
+
+    /// Default visibility when no saved preference exists.
+    var isOnByDefault: Bool {
+        switch self {
+        case .trackNumber, .title, .artist, .album, .duration: return true
+        default: return false
+        }
+    }
+
+    /// `true` → clicking the column header cycles sort on this field.
+    var isSortable: Bool {
+        switch self {
+        case .trackNumber, .format: return false
+        default: return true
+        }
+    }
+}
+
+// MARK: - Column Entry (order + visibility tuple)
+
+struct TrackTableColumnEntry: Codable, Identifiable, Equatable {
+    var id: String { column.rawValue }
+    var column: TrackTableColumn
+    var visible: Bool
+}
+#endif

--- a/Vibrdrome/Features/Library/TrackTableColumnSettings.swift
+++ b/Vibrdrome/Features/Library/TrackTableColumnSettings.swift
@@ -1,0 +1,75 @@
+#if os(macOS)
+import Foundation
+import Observation
+
+// MARK: - Per-view column settings
+
+/// Manages column visibility and ordering for a single macOS track table context.
+/// Each view instantiates this with its own `viewKey`, keeping preferences independent.
+@Observable
+@MainActor
+final class TrackTableColumnSettings {
+
+    // MARK: - Public state
+
+    /// Ordered list of all columns with their current visibility.
+    private(set) var entries: [TrackTableColumnEntry]
+
+    /// Ordered list of currently visible columns (for rendering).
+    var visibleColumns: [TrackTableColumn] {
+        entries.filter(\.visible).map(\.column)
+    }
+
+    // MARK: - Private
+
+    private let storageKey: String
+
+    // MARK: - Init
+
+    init(viewKey: String) {
+        self.storageKey = UserDefaultsKeys.trackTableColumnsPrefix + viewKey
+        if let data = UserDefaults.standard.data(forKey: storageKey),
+           let decoded = try? JSONDecoder().decode([TrackTableColumnEntry].self, from: data) {
+            // Merge saved prefs: honour saved order/visibility, append any new columns at end
+            var merged = decoded
+            let savedIds = Set(decoded.map(\.column))
+            for col in TrackTableColumn.allCases where !savedIds.contains(col) {
+                merged.append(TrackTableColumnEntry(column: col, visible: col.isOnByDefault))
+            }
+            self.entries = merged
+        } else {
+            self.entries = TrackTableColumn.allCases.map {
+                TrackTableColumnEntry(column: $0, visible: $0.isOnByDefault)
+            }
+        }
+    }
+
+    // MARK: - Mutations
+
+    func toggle(_ column: TrackTableColumn) {
+        guard column.isRemovable else { return }
+        guard let idx = entries.firstIndex(where: { $0.column == column }) else { return }
+        entries[idx].visible.toggle()
+        save()
+    }
+
+    func move(fromOffsets source: IndexSet, toOffset destination: Int) {
+        entries.move(fromOffsets: source, toOffset: destination)
+        save()
+    }
+
+    func resetToDefaults() {
+        entries = TrackTableColumn.allCases.map {
+            TrackTableColumnEntry(column: $0, visible: $0.isOnByDefault)
+        }
+        save()
+    }
+
+    // MARK: - Persistence
+
+    private func save() {
+        guard let data = try? JSONEncoder().encode(entries) else { return }
+        UserDefaults.standard.set(data, forKey: storageKey)
+    }
+}
+#endif

--- a/Vibrdrome/Features/Library/TrackTableColumnSettings.swift
+++ b/Vibrdrome/Features/Library/TrackTableColumnSettings.swift
@@ -87,6 +87,9 @@ final class TrackTableColumnSettings {
 
     func setWidth(_ width: CGFloat, for column: TrackTableColumn) {
         columnWidths[column.rawValue] = max(column.minWidth, width)
+    }
+
+    func persistWidths() {
         saveWidths()
     }
 

--- a/Vibrdrome/Features/Library/TrackTableColumnSettings.swift
+++ b/Vibrdrome/Features/Library/TrackTableColumnSettings.swift
@@ -47,8 +47,7 @@ final class TrackTableColumnSettings {
                 TrackTableColumnEntry(column: $0, visible: $0.isOnByDefault)
             }
         }
-        let wKey = UserDefaultsKeys.trackTableColumnsPrefix + viewKey + ".widths"
-        if let data = UserDefaults.standard.data(forKey: wKey),
+        if let data = UserDefaults.standard.data(forKey: self.widthsKey),
            let decoded = try? JSONDecoder().decode([String: CGFloat].self, from: data) {
             self.columnWidths = decoded
         } else {
@@ -74,13 +73,16 @@ final class TrackTableColumnSettings {
         entries = TrackTableColumn.allCases.map {
             TrackTableColumnEntry(column: $0, visible: $0.isOnByDefault)
         }
+        columnWidths = [:]
         save()
+        saveWidths()
     }
 
     // MARK: - Column widths
 
     func columnWidth(for column: TrackTableColumn) -> CGFloat {
-        columnWidths[column.rawValue] ?? column.defaultWidth
+        let stored = columnWidths[column.rawValue] ?? column.defaultWidth
+        return max(stored, column.minWidth)
     }
 
     func setWidth(_ width: CGFloat, for column: TrackTableColumn) {

--- a/Vibrdrome/Features/Library/TrackTableColumnSettings.swift
+++ b/Vibrdrome/Features/Library/TrackTableColumnSettings.swift
@@ -15,6 +15,9 @@ final class TrackTableColumnSettings {
     /// Ordered list of all columns with their current visibility.
     private(set) var entries: [TrackTableColumnEntry]
 
+    /// Per-column user-preferred widths (keyed by `TrackTableColumn.rawValue`).
+    private(set) var columnWidths: [String: CGFloat]
+
     /// Ordered list of currently visible columns (for rendering).
     var visibleColumns: [TrackTableColumn] {
         entries.filter(\.visible).map(\.column)
@@ -23,11 +26,13 @@ final class TrackTableColumnSettings {
     // MARK: - Private
 
     private let storageKey: String
+    private let widthsKey: String
 
     // MARK: - Init
 
     init(viewKey: String) {
         self.storageKey = UserDefaultsKeys.trackTableColumnsPrefix + viewKey
+        self.widthsKey = UserDefaultsKeys.trackTableColumnsPrefix + viewKey + ".widths"
         if let data = UserDefaults.standard.data(forKey: storageKey),
            let decoded = try? JSONDecoder().decode([TrackTableColumnEntry].self, from: data) {
             // Merge saved prefs: honour saved order/visibility, append any new columns at end
@@ -41,6 +46,13 @@ final class TrackTableColumnSettings {
             self.entries = TrackTableColumn.allCases.map {
                 TrackTableColumnEntry(column: $0, visible: $0.isOnByDefault)
             }
+        }
+        let wKey = UserDefaultsKeys.trackTableColumnsPrefix + viewKey + ".widths"
+        if let data = UserDefaults.standard.data(forKey: wKey),
+           let decoded = try? JSONDecoder().decode([String: CGFloat].self, from: data) {
+            self.columnWidths = decoded
+        } else {
+            self.columnWidths = [:]
         }
     }
 
@@ -65,11 +77,27 @@ final class TrackTableColumnSettings {
         save()
     }
 
+    // MARK: - Column widths
+
+    func columnWidth(for column: TrackTableColumn) -> CGFloat {
+        columnWidths[column.rawValue] ?? column.defaultWidth
+    }
+
+    func setWidth(_ width: CGFloat, for column: TrackTableColumn) {
+        columnWidths[column.rawValue] = max(column.minWidth, width)
+        saveWidths()
+    }
+
     // MARK: - Persistence
 
     private func save() {
         guard let data = try? JSONEncoder().encode(entries) else { return }
         UserDefaults.standard.set(data, forKey: storageKey)
+    }
+
+    private func saveWidths() {
+        guard let data = try? JSONEncoder().encode(columnWidths) else { return }
+        UserDefaults.standard.set(data, forKey: widthsKey)
     }
 }
 #endif

--- a/Vibrdrome/Features/Playlists/PlaylistDetailView.swift
+++ b/Vibrdrome/Features/Playlists/PlaylistDetailView.swift
@@ -17,6 +17,9 @@ struct PlaylistDetailView: View {
     @State private var isSelecting = false
     @State private var showBatchAddToPlaylist = false
     @Query private var downloadedSongs: [DownloadedSong]
+    #if os(macOS)
+    @State private var columnSettings = TrackTableColumnSettings(viewKey: "playlist")
+    #endif
 
     private var filteredSongs: [Song] {
         guard let songs = playlist?.entry else { return [] }
@@ -108,6 +111,11 @@ struct PlaylistDetailView: View {
 
                 // Songs
                 Section {
+                    #if os(macOS)
+                    MacTrackTableView(songs: filteredSongs, settings: columnSettings)
+                        .listRowInsets(EdgeInsets())
+                        .listRowSeparator(.hidden)
+                    #else
                     ForEach(Array(filteredSongs.enumerated()), id: \.element.id) { index, song in
                         HStack(spacing: 0) {
                             if isSelecting {
@@ -149,6 +157,7 @@ struct PlaylistDetailView: View {
                             at: IndexSet(originalIndices), songs: allSongs
                         )
                     }
+                    #endif
                 }
 
                 // Batch action bar


### PR DESCRIPTION
- Add TrackTableColumn enum (11 columns: trackNumber, title, artist, album, duration, year, genre, bitRate, format, bpm, dateAdded)
- Add TrackTableColumnSettings for per-view JSON persistence in UserDefaults
- Add MacTrackTableHeader with sticky header, sort indicators, and 80pt trailing zone (matching row actions) with customize button
- Add MacTrackTableRow with album art thumbnail (respects showAlbumArtInLists pref), now-playing accent tint, selected-row highlight, single-click select, double-click to play, dynamic row height
- Add MacColumnCustomizerView (260pt popover): toggle + drag-reorder + reset to defaults
- Add MacTrackTableView: LazyVStack container with O(n) disc-separator pre-computation, empty state ContentUnavailableView, right-click header context menu, and column sort
- Wire MacTrackTableView into SongsView, FavoritesView, PlaylistDetailView, AlbumDetailView, ArtistDetailView under #if os(macOS); iOS/watchOS paths unchanged
- Add UserDefaultsKeys.trackTableColumnsPrefix constant
- Restore entitlements (xcodegen side-effect)

## Summary

Adds a new customizable colum list view for tracks.

## Related Issues

None

## Checklist

- [x] Branched from `develop`, PR targets `develop`
- [x] `swiftlint` passes with 0 violations
- [x] iOS builds with 0 warnings
- [x] macOS builds with 0 warnings
- [x] watchOS builds with 0 warnings
- [x] Unit tests pass
- [x] New UserDefaults keys added to `UserDefaultsKeys.swift`
- [x] Accessibility labels added to new interactive elements
- [x] No force unwraps on external data
- [x] Tested on device or simulator

## Screenshots (if UI changes)
<img width="1531" height="603" alt="Screenshot 2026-04-21 at 22 52 04" src="https://github.com/user-attachments/assets/b619fd97-c50c-40c6-8362-8f90868f2ecb" />
<img width="1728" height="1007" alt="Screenshot 2026-04-21 at 22 53 31" src="https://github.com/user-attachments/assets/d730db4d-6afc-4af9-9894-151d566d09a9" />
<img width="266" height="498" alt="Screenshot 2026-04-21 at 22 53 57" src="https://github.com/user-attachments/assets/b8586905-ef9f-4c71-8859-10aa85132b7a" />

