### PR TITLE
feat(macOS): hover overlay on album grid cards for favorite and rating

### DIFF
--- a/Vibrdrome/Core/Networking/OfflineActionQueue.swift
+++ b/Vibrdrome/Core/Networking/OfflineActionQueue.swift
@@ -86,6 +86,31 @@ final class OfflineActionQueue {
         enqueue(actionType: "scrobble", targetId: id, submission: submission)
     }
 
+    /// Set rating on a song or album — queues offline if no network
+    func setRating(id: String, rating: Int) async throws {
+        let client = AppState.shared.subsonicClient
+        if isConnected {
+            do {
+                try await client.setRating(id: id, rating: rating)
+                return
+            } catch {
+                offlineLog.info("setRating failed, queuing for offline sync")
+            }
+        }
+        let serverId = AppState.shared.activeServerId ?? ""
+        let action = PendingAction(serverId: serverId, actionType: "setRating", targetId: id)
+        action.ratingValue = rating
+        let context = PersistenceController.shared.container.mainContext
+        context.insert(action)
+        do {
+            try context.save()
+            refreshCounts()
+            offlineLog.info("Queued setRating(\(rating)) for \(id)")
+        } catch {
+            offlineLog.error("Failed to save pending setRating: \(error)")
+        }
+    }
+
     /// Queue a ListenBrainz scrobble — submits immediately if online, queues if offline
     func listenBrainzScrobble(song: Song) async {
         if isConnected {
@@ -261,6 +286,8 @@ final class OfflineActionQueue {
             try await client.star(artistId: action.targetId)
         case "unstarArtist":
             try await client.unstar(artistId: action.targetId)
+        case "setRating":
+            try await client.setRating(id: action.targetId, rating: action.ratingValue)
         case "scrobble":
             try await client.scrobble(id: action.targetId, submission: action.submission)
         case "listenBrainzScrobble":

--- a/Vibrdrome/Core/Persistence/Models/PendingAction.swift
+++ b/Vibrdrome/Core/Persistence/Models/PendingAction.swift
@@ -12,6 +12,9 @@ final class PendingAction {
     /// "pending", "failed"
     var status: String = "pending"
 
+    // Rating value for setRating actions (0 = clear)
+    var ratingValue: Int = 0
+
     // Song metadata for external scrobble services (ListenBrainz, Last.fm)
     var songTitle: String?
     var songArtist: String?

--- a/Vibrdrome/Features/Library/AlbumsView.swift
+++ b/Vibrdrome/Features/Library/AlbumsView.swift
@@ -435,7 +435,7 @@ struct AlbumsView: View {
                             if index < cachedFilteredAlbums.count {
                                 let album = cachedFilteredAlbums[index]
                                 NavigationLink(value: AlbumNavItem(id: album.id)) {
-                                    albumGridCard(album)
+                                    AlbumGridCard(album: album)
                                 }
                                 .buttonStyle(.plain)
                                 .accessibilityIdentifier("albumCard_\(album.id)")
@@ -455,29 +455,6 @@ struct AlbumsView: View {
                 .padding(16)
             }
             .onAppear { restoreScroll(proxy: proxy) }
-        }
-    }
-
-    private func albumGridCard(_ album: Album) -> some View {
-        VStack(alignment: .leading, spacing: 6) {
-            GeometryReader { geo in
-                AlbumArtView(coverArtId: album.coverArt, size: geo.size.width, cornerRadius: 10)
-            }
-            .aspectRatio(1, contentMode: .fit)
-            .shadow(color: .black.opacity(0.15), radius: 6, y: 3)
-
-            Text(album.name)
-                .font(.subheadline)
-                .fontWeight(.medium)
-                .foregroundColor(.primary)
-                .lineLimit(1)
-
-            if let artist = album.artist {
-                Text(artist)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-            }
         }
     }
 

--- a/Vibrdrome/Shared/Components/AlbumGridCard.swift
+++ b/Vibrdrome/Shared/Components/AlbumGridCard.swift
@@ -92,7 +92,8 @@ struct AlbumGridCard: View {
             Image(systemName: isStarred ? "heart.fill" : "heart")
                 .font(.system(size: 14, weight: .medium))
                 .foregroundStyle(isStarred ? .pink : .white)
-                .shadow(color: .black.opacity(0.4), radius: 2)
+                .shadow(color: .black.opacity(0.9), radius: 6, y: 2)
+                .shadow(color: .black.opacity(0.7), radius: 2, y: 1)
         }
         .buttonStyle(.plain)
         .accessibilityLabel(isStarred ? "Remove from Favorites" : "Add to Favorites")
@@ -115,7 +116,8 @@ struct AlbumGridCard: View {
                     Image(systemName: star <= currentRating ? "star.fill" : "star")
                         .font(.system(size: 11, weight: .medium))
                         .foregroundStyle(star <= currentRating ? .yellow : .white)
-                        .shadow(color: .black.opacity(0.4), radius: 2)
+                        .shadow(color: .black.opacity(0.9), radius: 6, y: 2)
+                        .shadow(color: .black.opacity(0.7), radius: 2, y: 1)
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("\(star) star\(star == 1 ? "" : "s")")

--- a/Vibrdrome/Shared/Components/AlbumGridCard.swift
+++ b/Vibrdrome/Shared/Components/AlbumGridCard.swift
@@ -1,0 +1,126 @@
+import SwiftUI
+
+struct AlbumGridCard: View {
+    let album: Album
+
+    @State private var isStarred: Bool
+    @State private var currentRating: Int
+    #if os(macOS)
+    @State private var isHovered = false
+    #endif
+
+    init(album: Album) {
+        self.album = album
+        self._isStarred = State(initialValue: album.starred != nil)
+        self._currentRating = State(initialValue: album.userRating ?? 0)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            artworkWithOverlay
+            Text(album.name)
+                .font(.subheadline)
+                .fontWeight(.medium)
+                .foregroundColor(.primary)
+                .lineLimit(1)
+            if let artist = album.artist {
+                Text(artist)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+        }
+        .onChange(of: album.starred) { isStarred = album.starred != nil }
+        .onChange(of: album.userRating) { currentRating = album.userRating ?? 0 }
+    }
+
+    private var artworkWithOverlay: some View {
+        GeometryReader { geo in
+            ZStack(alignment: .bottom) {
+                AlbumArtView(coverArtId: album.coverArt, size: geo.size.width, cornerRadius: 10)
+                #if os(macOS)
+                if isHovered {
+                    hoverOverlay
+                }
+                #endif
+            }
+        }
+        .aspectRatio(1, contentMode: .fit)
+        .shadow(color: .black.opacity(0.15), radius: 6, y: 3)
+        #if os(macOS)
+        .onHover { isHovered = $0 }
+        #endif
+    }
+
+    #if os(macOS)
+    private var hoverOverlay: some View {
+        HStack(spacing: 8) {
+            favoriteButton
+            Spacer()
+            ratingButtons
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 6)
+        .clipShape(
+            .rect(
+                topLeadingRadius: 0,
+                bottomLeadingRadius: 10,
+                bottomTrailingRadius: 10,
+                topTrailingRadius: 0
+            )
+        )
+        .transition(.opacity.combined(with: .move(edge: .bottom)))
+        .animation(.easeInOut(duration: 0.15), value: isHovered)
+    }
+
+    private var favoriteButton: some View {
+        Button {
+            isStarred.toggle()
+            let newValue = isStarred
+            Task {
+                do {
+                    if newValue {
+                        try await OfflineActionQueue.shared.star(albumId: album.id)
+                    } else {
+                        try await OfflineActionQueue.shared.unstar(albumId: album.id)
+                    }
+                } catch {
+                    isStarred.toggle()
+                }
+            }
+        } label: {
+            Image(systemName: isStarred ? "heart.fill" : "heart")
+                .font(.system(size: 14, weight: .medium))
+                .foregroundStyle(isStarred ? .pink : .white)
+                .shadow(color: .black.opacity(0.4), radius: 2)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(isStarred ? "Remove from Favorites" : "Add to Favorites")
+    }
+
+    private var ratingButtons: some View {
+        HStack(spacing: 3) {
+            ForEach(1...5, id: \.self) { star in
+                Button {
+                    let newRating = (star == currentRating) ? 0 : star
+                    currentRating = newRating
+                    Task {
+                        do {
+                            try await OfflineActionQueue.shared.setRating(id: album.id, rating: newRating)
+                        } catch {
+                            currentRating = album.userRating ?? 0
+                        }
+                    }
+                } label: {
+                    Image(systemName: star <= currentRating ? "star.fill" : "star")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(star <= currentRating ? .yellow : .white)
+                        .shadow(color: .black.opacity(0.4), radius: 2)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("\(star) star\(star == 1 ? "" : "s")")
+            }
+        }
+    }
+    #endif
+}


### PR DESCRIPTION
## Summary

- Extracts the album grid card into a new `AlbumGridCard` component
- On macOS, hovering an album grid card reveals a bottom overlay with a heart (favorite toggle) and 5-star rating buttons
- Buttons are outlined (unfilled) when unset; filled pink/yellow when active
- iOS is unaffected — all hover logic is gated behind `#if os(macOS)`

## Test plan

- [x] Hover an album card on macOS — overlay animates in at the bottom
- [x] Click the heart to favorite/unfavorite — persists correctly
- [x] Click stars to rate — star fills yellow up to selected rating; tap same star to clear
- [x] Moving cursor away hides the overlay
- [x] iOS build unaffected (no hover UI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)