### PR TITLE
feat: advanced filter builder, smart playlist editor, ND API sync

### DIFF
--- a/Vibrdrome/App/AppState.swift
+++ b/Vibrdrome/App/AppState.swift
@@ -25,6 +25,8 @@ final class AppState {
     static let shared = AppState()
 
     var subsonicClient: SubsonicClient
+    /// Non-nil when the active server is Navidrome and native API auth succeeded.
+    var navidromeClient: NavidromeNativeClient?
     var isConfigured: Bool = false
     var requiresReAuth: Bool = false
 
@@ -59,10 +61,20 @@ final class AppState {
     }
     var activeSidePanel: SidePanel?
 
+    /// Context currently shown in the popped-out filter window. Stays up-to-date
+    /// as the user navigates between Albums / Songs / Artists in the main window.
+    var activeFilterWindowContext: FilterContext?
+
     /// Filter state for the macOS filter sidebars.
     var albumFilter = LibraryFilter()
     var artistFilter = LibraryFilter()
     var songFilter = LibraryFilter()
+
+    private func configureFilterPersistence() {
+        albumFilter.loadRuleSet(from: UserDefaultsKeys.albumFilterRuleSet)
+        artistFilter.loadRuleSet(from: UserDefaultsKeys.artistFilterRuleSet)
+        songFilter.loadRuleSet(from: UserDefaultsKeys.songFilterRuleSet)
+    }
 
     /// Cached albums state for back-navigation, keyed by view configuration.
     struct AlbumsViewSnapshot {
@@ -105,6 +117,7 @@ final class AppState {
         )
         loadServers()
         loadSavedCredentials()
+        configureFilterPersistence()
 
         // UI testing: auto-login with credentials from environment variables
         // so XCUITest doesn't have to type them (avoids idle-wait SIGKILL).
@@ -136,6 +149,11 @@ final class AppState {
         #endif
         LibrarySyncManager.shared.client = subsonicClient
         LibrarySyncManager.shared.container = PersistenceController.shared.container
+
+        // Probe Navidrome native API in the background — sets navidromeClient if available.
+        let ndClient = NavidromeNativeClient(baseURL: serverURL, username: username, password: password)
+        navidromeClient = ndClient
+        Task { await ndClient.probe() }
     }
 
     func loadSavedCredentials() {
@@ -228,6 +246,7 @@ final class AppState {
         albumFilter = LibraryFilter()
         artistFilter = LibraryFilter()
         songFilter = LibraryFilter()
+        configureFilterPersistence()
         albumsViewSnapshots = [:]
     }
 
@@ -239,6 +258,7 @@ final class AppState {
         requiresReAuth = false
         serverURL = ""
         username = ""
+        navidromeClient = nil
         resetLibraryFilterState()
         // Reset the client so stale creds aren't used
         subsonicClient.updateCredentials(

--- a/Vibrdrome/Core/Constants/UserDefaultsKeys.swift
+++ b/Vibrdrome/Core/Constants/UserDefaultsKeys.swift
@@ -155,6 +155,15 @@ enum UserDefaultsKeys {
     static let macSidePanelWidth = "macSidePanelWidth"
     static let macMiniPlayerPanelTrigger = "macMiniPlayerPanelTrigger"
 
+    // MARK: - Advanced Filter Rule Sets
+
+    static let albumFilterRuleSet = "albumFilterRuleSet"
+    static let songFilterRuleSet = "songFilterRuleSet"
+    static let artistFilterRuleSet = "artistFilterRuleSet"
+    static let albumFilterRuleBuilderExpanded = "albumFilterRuleBuilderExpanded"
+    static let songFilterRuleBuilderExpanded = "songFilterRuleBuilderExpanded"
+    static let artistFilterRuleBuilderExpanded = "artistFilterRuleBuilderExpanded"
+
     // MARK: - Library Sync
 
     static let lastLibrarySyncDate = "lastLibrarySyncDate"

--- a/Vibrdrome/Core/Models/FilterRule.swift
+++ b/Vibrdrome/Core/Models/FilterRule.swift
@@ -1,0 +1,659 @@
+import Foundation
+
+// MARK: - Field
+
+/// Metadata fields that can be targeted by a filter rule.
+enum FilterField: String, CaseIterable, Codable, Sendable {
+    // Text fields
+    case title
+    case artist
+    case albumTitle
+    case genre
+    case label
+    case suffix         // file extension
+    case contentType    // codec
+    case comment
+    case explicitStatus // explicit content flag string
+    case mbzRecordingId // MusicBrainz Recording ID
+    case mbzAlbumId     // MusicBrainz Album ID
+    case mbzArtistId    // MusicBrainz Artist ID
+    case mbzAlbumArtistId
+    case mbzReleaseTrackId
+    case mbzReleaseGroupId
+
+    // Numeric fields
+    case year
+    case duration       // seconds
+    case size           // bytes
+    case channels       // audio channels
+    case bitRate        // kbps
+    case bitDepth
+    case sampleRate
+    case bpm
+    case playCount
+    case rating         // 1-5 stars (0 = unrated)
+    case averageRating  // average across all users
+    case albumRating
+    case albumPlayCount
+    case artistRating
+    case artistPlayCount
+    case trackNumber
+    case discNumber
+
+    // Date-relative fields (value = number of days for inTheLast/notInTheLast)
+    case lastPlayed
+    case dateLoved      // track loved date
+    case dateRated      // track rated date
+    case dateAdded
+    case dateModified
+    case albumLastPlayed
+    case albumDateLoved
+    case albumDateRated
+    case artistLastPlayed
+    case artistDateLoved
+    case artistDateRated
+
+    // Boolean fields
+    case isFavorited
+    case albumFavorited
+    case artistFavorited
+    case hasCoverArt
+    case isCompilation
+    case isMissing
+    case isDownloaded
+
+    // Playlist membership (value = playlist ID string)
+    case inPlaylist
+    case notInPlaylist
+
+    var displayName: String {
+        switch self {
+        case .title:           "Title"
+        case .artist:          "Artist"
+        case .albumTitle:      "Album"
+        case .genre:           "Genre"
+        case .label:           "Label"
+        case .suffix:          "Format"
+        case .contentType:     "Codec"
+        case .comment:         "Comment"
+        case .explicitStatus:  "Explicit Status"
+        case .mbzRecordingId:  "MBZ Recording ID"
+        case .mbzAlbumId:      "MBZ Album ID"
+        case .mbzArtistId:     "MBZ Artist ID"
+        case .mbzAlbumArtistId: "MBZ Album Artist ID"
+        case .mbzReleaseTrackId: "MBZ Release Track ID"
+        case .mbzReleaseGroupId: "MBZ Release Group ID"
+        case .year:            "Year"
+        case .duration:        "Duration (s)"
+        case .size:            "File Size"
+        case .channels:        "Channels"
+        case .bitRate:         "Bit Rate (kbps)"
+        case .bitDepth:        "Bit Depth"
+        case .sampleRate:      "Sample Rate"
+        case .bpm:             "BPM"
+        case .playCount:       "Play Count"
+        case .averageRating:   "Avg Rating"
+        case .rating:          "Rating"
+        case .albumRating:     "Album Rating"
+        case .albumPlayCount:  "Album Play Count"
+        case .artistRating:    "Artist Rating"
+        case .artistPlayCount: "Artist Play Count"
+        case .trackNumber:     "Track #"
+        case .discNumber:      "Disc #"
+        case .lastPlayed:      "Last Played"
+        case .dateLoved:       "Date Loved"
+        case .dateRated:       "Date Rated"
+        case .dateAdded:       "Date Added"
+        case .dateModified:    "Date Modified"
+        case .albumLastPlayed: "Album Last Played"
+        case .albumDateLoved:  "Album Date Loved"
+        case .albumDateRated:  "Album Date Rated"
+        case .artistLastPlayed: "Artist Last Played"
+        case .artistDateLoved: "Artist Date Loved"
+        case .artistDateRated: "Artist Date Rated"
+        case .isFavorited:     "Loved"
+        case .albumFavorited:  "Album Loved"
+        case .artistFavorited: "Artist Loved"
+        case .hasCoverArt:     "Has Cover Art"
+        case .isCompilation:   "Compilation"
+        case .isMissing:       "File Missing"
+        case .isDownloaded:    "Is Downloaded"
+        case .inPlaylist:      "In Playlist"
+        case .notInPlaylist:   "Not In Playlist"
+        }
+    }
+
+    var kind: FieldKind {
+        switch self {
+        case .title, .artist, .albumTitle, .genre, .label, .suffix, .contentType, .comment,
+             .explicitStatus, .mbzRecordingId, .mbzAlbumId, .mbzArtistId, .mbzAlbumArtistId,
+             .mbzReleaseTrackId, .mbzReleaseGroupId:
+            return .text
+        case .year, .duration, .size, .channels, .bitRate, .bitDepth, .sampleRate, .bpm,
+             .playCount, .rating, .averageRating, .albumRating, .albumPlayCount,
+             .artistRating, .artistPlayCount, .trackNumber, .discNumber:
+            return .numeric
+        case .lastPlayed, .dateLoved, .dateRated, .dateAdded, .dateModified,
+             .albumLastPlayed, .albumDateLoved, .albumDateRated,
+             .artistLastPlayed, .artistDateLoved, .artistDateRated:
+            return .days
+        case .isFavorited, .albumFavorited, .artistFavorited,
+             .hasCoverArt, .isCompilation, .isMissing, .isDownloaded:
+            return .boolean
+        case .inPlaylist, .notInPlaylist:
+            return .playlist
+        }
+    }
+
+    enum FieldKind { case text, numeric, days, boolean, playlist }
+}
+
+// MARK: - Operator
+
+enum FilterOperator: String, CaseIterable, Codable, Sendable {
+    // Text operators
+    case contains
+    case notContains
+    case equals
+    case notEquals
+    case startsWith
+    case endsWith
+    case matchesRegex
+
+    // Numeric operators
+    case isEqualTo
+    case isNotEqualTo
+    case isGreaterThan
+    case isLessThan
+    case isGreaterOrEqual
+    case isLessOrEqual
+    case isBetween
+
+    // Days-ago operators (for date fields)
+    case inTheLast
+    case notInTheLast
+    case before         // absolute date "YYYY-MM-DD"
+    case after          // absolute date "YYYY-MM-DD"
+
+    // Boolean operator
+    case isTrue
+
+    // Playlist membership (no argument — field holds the playlist ID)
+    case isInPlaylist
+
+    var displayName: String {
+        switch self {
+        case .contains:        "contains"
+        case .notContains:     "does not contain"
+        case .equals:          "is"
+        case .notEquals:       "is not"
+        case .startsWith:      "starts with"
+        case .endsWith:        "ends with"
+        case .matchesRegex:    "matches regex"
+        case .isEqualTo:       "="
+        case .isNotEqualTo:    "≠"
+        case .isGreaterThan:   ">"
+        case .isLessThan:      "<"
+        case .isGreaterOrEqual: "≥"
+        case .isLessOrEqual:   "≤"
+        case .isBetween:       "between"
+        case .inTheLast:       "in the last"
+        case .notInTheLast:    "not in the last"
+        case .before:          "before"
+        case .after:           "after"
+        case .isTrue:          "is"
+        case .isInPlaylist:    "in playlist"
+        }
+    }
+
+    static func allowed(for kind: FilterField.FieldKind) -> [FilterOperator] {
+        switch kind {
+        case .text:
+            return [.contains, .notContains, .equals, .notEquals, .startsWith, .endsWith, .matchesRegex]
+        case .numeric:
+            return [.isEqualTo, .isNotEqualTo, .isGreaterThan, .isLessThan, .isGreaterOrEqual, .isLessOrEqual, .isBetween]
+        case .days:
+            return [.inTheLast, .notInTheLast, .before, .after]
+        case .boolean:
+            return [.isTrue]
+        case .playlist:
+            return [.isInPlaylist]
+        }
+    }
+}
+
+// MARK: - Value
+
+enum FilterValue: Codable, Sendable, Equatable {
+    case text(String)
+    case number(Int)
+    case range(Int, Int)
+    case boolean(Bool)
+
+    private enum CodingKeys: String, CodingKey { case type, text, number, low, high, boolean }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try c.decode(String.self, forKey: .type)
+        switch type {
+        case "text":    self = .text(try c.decode(String.self, forKey: .text))
+        case "number":  self = .number(try c.decode(Int.self, forKey: .number))
+        case "range":   self = .range(try c.decode(Int.self, forKey: .low), try c.decode(Int.self, forKey: .high))
+        case "boolean": self = .boolean(try c.decode(Bool.self, forKey: .boolean))
+        default:        self = .text("")
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .text(let s):
+            try c.encode("text", forKey: .type); try c.encode(s, forKey: .text)
+        case .number(let n):
+            try c.encode("number", forKey: .type); try c.encode(n, forKey: .number)
+        case .range(let lo, let hi):
+            try c.encode("range", forKey: .type); try c.encode(lo, forKey: .low); try c.encode(hi, forKey: .high)
+        case .boolean(let b):
+            try c.encode("boolean", forKey: .type); try c.encode(b, forKey: .boolean)
+        }
+    }
+
+    static func defaultValue(for kind: FilterField.FieldKind) -> FilterValue {
+        switch kind {
+        case .text:     return .text("")
+        case .numeric:  return .number(0)
+        case .days:     return .number(30)
+        case .boolean:  return .boolean(true)
+        case .playlist: return .text("")
+        }
+    }
+}
+
+// MARK: - Rule
+
+struct FilterRule: Identifiable, Codable, Sendable, Equatable {
+    var id: UUID
+    var field: FilterField
+    var `operator`: FilterOperator
+    var value: FilterValue
+
+    init(id: UUID = UUID(), field: FilterField = .title, operator op: FilterOperator = .contains, value: FilterValue = .text("")) {
+        self.id = id
+        self.field = field
+        self.operator = op
+        self.value = value
+    }
+
+    /// True when the rule has no meaningful value and should be treated as a no-op.
+    /// An empty text pattern or a boolean rule (which always has a value) is never empty.
+    var isEffectivelyEmpty: Bool {
+        switch value {
+        case .text(let s):  return s.isEmpty
+        case .number:       return false
+        case .range:        return false
+        case .boolean:      return false
+        }
+    }
+
+    /// Returns true when the rule passes for the given metadata values.
+    func matches(song: FilterRuleSet.SongMeta) -> Bool {
+        evaluate(against: song)
+    }
+
+    func matches(album: FilterRuleSet.AlbumMeta) -> Bool {
+        evaluate(against: album)
+    }
+
+    func matches(artist: FilterRuleSet.ArtistMeta) -> Bool {
+        evaluate(against: artist)
+    }
+
+    // MARK: Private evaluation
+
+    private func evaluate(against target: any FilterTarget) -> Bool {
+        switch field.kind {
+        case .text:
+            guard case .text(let pattern) = value, !pattern.isEmpty else { return true }
+            let haystack = target.textValue(for: field) ?? ""
+            return matchText(haystack: haystack, pattern: pattern)
+
+        case .numeric:
+            let actual = target.numericValue(for: field)
+            return matchNumeric(actual: actual)
+
+        case .days:
+            // Local evaluation not meaningful for date fields — server handles it.
+            return true
+
+        case .boolean:
+            guard case .boolean(let expected) = value else { return true }
+            return target.boolValue(for: field) == expected
+
+        case .playlist:
+            // Playlist membership cannot be evaluated locally — server handles it.
+            return true
+        }
+    }
+
+    private func matchText(haystack: String, pattern: String) -> Bool {
+        switch `operator` {
+        case .contains:
+            return haystack.localizedCaseInsensitiveContains(pattern)
+        case .notContains:
+            return !haystack.localizedCaseInsensitiveContains(pattern)
+        case .equals:
+            return haystack.localizedCaseInsensitiveCompare(pattern) == .orderedSame
+        case .notEquals:
+            return haystack.localizedCaseInsensitiveCompare(pattern) != .orderedSame
+        case .startsWith:
+            return haystack.lowercased().hasPrefix(pattern.lowercased())
+        case .endsWith:
+            return haystack.lowercased().hasSuffix(pattern.lowercased())
+        case .matchesRegex:
+            let (rawPattern, options) = Self.parseRegexLiteral(pattern)
+            return (try? NSRegularExpression(pattern: rawPattern, options: options))
+                .map { $0.firstMatch(in: haystack, range: NSRange(haystack.startIndex..., in: haystack)) != nil } ?? false
+        default:
+            return true
+        }
+    }
+
+    /// Parses an optional `/pattern/flags` regex literal, returning the raw pattern and options.
+    /// If the input doesn't start with `/`, it is returned as-is with no options (plain pattern).
+    /// Supported flags: i (caseInsensitive), s (dotMatchesLineSeparators), m (anchorsMatchLines).
+    static func parseRegexLiteral(_ input: String) -> (pattern: String, options: NSRegularExpression.Options) {
+        guard input.hasPrefix("/") else { return (input, []) }
+        // Find the closing slash — search from the second character onwards
+        let afterOpen = input.index(after: input.startIndex)
+        guard let closingSlash = input[afterOpen...].lastIndex(of: "/"), closingSlash != input.startIndex else {
+            // Malformed (no closing slash) — treat the whole string as a plain pattern
+            return (input, [])
+        }
+        let rawPattern = String(input[afterOpen..<closingSlash])
+        let flagString = String(input[input.index(after: closingSlash)...])
+        var options: NSRegularExpression.Options = []
+        for flag in flagString {
+            switch flag {
+            case "i": options.insert(.caseInsensitive)
+            case "s": options.insert(.dotMatchesLineSeparators)
+            case "m": options.insert(.anchorsMatchLines)
+            default: break
+            }
+        }
+        return (rawPattern, options)
+    }
+
+    private func matchNumeric(actual: Int?) -> Bool {
+        switch value {
+        case .number(let n):
+            guard let a = actual else { return false }
+            switch `operator` {
+            case .isEqualTo:       return a == n
+            case .isNotEqualTo:    return a != n
+            case .isGreaterThan:   return a > n
+            case .isLessThan:      return a < n
+            case .isGreaterOrEqual: return a >= n
+            case .isLessOrEqual: return a <= n
+            default: return true
+            }
+        case .range(let lo, let hi):
+            guard `operator` == .isBetween, let a = actual else { return false }
+            return a >= lo && a <= hi
+        default:
+            return true
+        }
+    }
+}
+
+// MARK: - Field Sets
+
+extension FilterField {
+    static let songFields: [FilterField] = [
+        // Text
+        .title, .artist, .albumTitle, .genre, .label, .suffix, .contentType, .comment,
+        // Numeric
+        .year, .duration, .size, .channels, .bitRate, .bitDepth, .sampleRate, .bpm,
+        .playCount, .rating, .averageRating, .albumRating, .albumPlayCount,
+        .artistRating, .artistPlayCount, .trackNumber, .discNumber,
+        // Date-relative
+        .lastPlayed, .dateLoved, .dateRated, .dateAdded, .dateModified,
+        .albumLastPlayed, .albumDateLoved, .albumDateRated,
+        .artistLastPlayed, .artistDateLoved, .artistDateRated,
+        // Boolean
+        .isFavorited, .albumFavorited, .artistFavorited,
+        .hasCoverArt, .isCompilation, .isMissing, .isDownloaded,
+    ]
+    static let albumFields: [FilterField] = [
+        .albumTitle, .artist, .genre, .label,
+        .year, .duration, .rating, .albumRating,
+        .isFavorited, .isDownloaded,
+    ]
+    static let artistFields: [FilterField] = [
+        .artist, .genre,
+        .isFavorited,
+    ]
+
+    /// Fields available in the smart playlist editor (server-evaluated; excludes local-only fields).
+    static let smartPlaylistFields: [FilterField] = [
+        // Text
+        .title, .artist, .albumTitle, .genre, .label, .suffix, .contentType, .comment,
+        .explicitStatus,
+        .mbzRecordingId, .mbzAlbumId, .mbzArtistId, .mbzAlbumArtistId,
+        .mbzReleaseTrackId, .mbzReleaseGroupId,
+        // Numeric
+        .year, .duration, .size, .channels, .bitRate, .bitDepth, .sampleRate, .bpm,
+        .playCount, .rating, .averageRating, .albumRating, .albumPlayCount,
+        .artistRating, .artistPlayCount, .trackNumber, .discNumber,
+        // Date-relative
+        .lastPlayed, .dateLoved, .dateRated, .dateAdded, .dateModified,
+        .albumLastPlayed, .albumDateLoved, .albumDateRated,
+        .artistLastPlayed, .artistDateLoved, .artistDateRated,
+        // Boolean
+        .isFavorited, .albumFavorited, .artistFavorited,
+        .hasCoverArt, .isCompilation, .isMissing,
+        // Playlist membership
+        .inPlaylist, .notInPlaylist,
+    ]
+}
+
+// MARK: - Rule Set
+
+struct FilterRuleSet: Codable, Sendable, Equatable {
+    enum Combinator: String, Codable, Sendable { case all, any }
+
+    var combinator: Combinator = .all
+    var rules: [FilterRule] = []
+
+    var isEmpty: Bool { rules.allSatisfy(\.isEffectivelyEmpty) }
+
+    /// True when any active rule targets a field that requires CachedSong lookup
+    /// (fields not carried on the Song value type — stored in CachedSong or its album relationship).
+    var needsCachedSong: Bool {
+        let cachedFields: Set<FilterField> = [
+            .playCount, .rating, .albumRating, .albumFavorited, .albumPlayCount,
+            .artistRating, .artistPlayCount, .artistFavorited,
+            .bitDepth, .sampleRate, .size, .channels, .comment,
+            .hasCoverArt, .isCompilation, .dateAdded,
+        ]
+        return rules.contains { !$0.isEffectivelyEmpty && cachedFields.contains($0.field) }
+    }
+
+    private var activeRules: [FilterRule] { rules.filter { !$0.isEffectivelyEmpty } }
+
+    func matches(song: SongMeta) -> Bool {
+        let active = activeRules
+        guard !active.isEmpty else { return true }
+        switch combinator {
+        case .all: return active.allSatisfy { $0.matches(song: song) }
+        case .any: return active.contains { $0.matches(song: song) }
+        }
+    }
+
+    func matches(album: AlbumMeta) -> Bool {
+        let active = activeRules
+        guard !active.isEmpty else { return true }
+        switch combinator {
+        case .all: return active.allSatisfy { $0.matches(album: album) }
+        case .any: return active.contains { $0.matches(album: album) }
+        }
+    }
+
+    func matches(artist: ArtistMeta) -> Bool {
+        let active = activeRules
+        guard !active.isEmpty else { return true }
+        switch combinator {
+        case .all: return active.allSatisfy { $0.matches(artist: artist) }
+        case .any: return active.contains { $0.matches(artist: artist) }
+        }
+    }
+
+    // MARK: Metadata structs
+
+    struct SongMeta {
+        let title: String
+        let artist: String?
+        let albumTitle: String?
+        let genre: String?
+        let label: String?
+        let suffix: String?
+        let contentType: String?
+        let comment: String?
+        let year: Int?
+        let duration: Int?
+        let bitRate: Int?
+        let bitDepth: Int?
+        let samplingRate: Int?
+        let bpm: Int?
+        let playCount: Int
+        let rating: Int
+        let albumRating: Int
+        let trackNumber: Int?
+        let discNumber: Int?
+        let isFavorited: Bool
+        let albumFavorited: Bool
+        let isDownloaded: Bool
+        let hasCoverArt: Bool
+        let isCompilation: Bool
+        let size: Int?
+        let channels: Int?
+        let mbzRecordingId: String?
+        let dateAdded: Date?
+    }
+
+    struct AlbumMeta {
+        let title: String
+        let artist: String?
+        let genre: String?
+        let label: String?
+        let year: Int?
+        let duration: Int?
+        let rating: Int
+        let isFavorited: Bool
+        let isDownloaded: Bool = false
+    }
+
+    struct ArtistMeta {
+        let name: String
+        let genre: String?
+        let isFavorited: Bool
+        let isDownloaded: Bool = false
+    }
+}
+
+// MARK: - FilterTarget protocol (private)
+
+private protocol FilterTarget {
+    func textValue(for field: FilterField) -> String?
+    func numericValue(for field: FilterField) -> Int?
+    func boolValue(for field: FilterField) -> Bool
+}
+
+extension FilterRuleSet.SongMeta: FilterTarget {
+    func textValue(for field: FilterField) -> String? {
+        switch field {
+        case .title:       return title
+        case .artist:      return artist
+        case .albumTitle:  return albumTitle
+        case .genre:       return genre
+        case .label:       return label
+        case .suffix:      return suffix
+        case .contentType: return contentType
+        case .comment:         return comment
+        case .mbzRecordingId:  return mbzRecordingId
+        default:               return nil
+        }
+    }
+    func numericValue(for field: FilterField) -> Int? {
+        switch field {
+        case .year:        return year
+        case .duration:    return duration
+        case .bitRate:     return bitRate
+        case .bitDepth:    return bitDepth
+        case .sampleRate:  return samplingRate
+        case .bpm:         return bpm
+        case .playCount:   return playCount
+        case .rating:      return rating
+        case .albumRating: return albumRating
+        case .trackNumber: return trackNumber
+        case .discNumber:  return discNumber
+        case .size:        return size
+        case .channels:    return channels
+        default:           return nil
+        }
+    }
+    func boolValue(for field: FilterField) -> Bool {
+        switch field {
+        case .isFavorited:    return isFavorited
+        case .albumFavorited: return albumFavorited
+        case .isDownloaded:   return isDownloaded
+        case .hasCoverArt:    return hasCoverArt
+        case .isCompilation:  return isCompilation
+        default:              return false
+        }
+    }
+}
+
+extension FilterRuleSet.AlbumMeta: FilterTarget {
+    func textValue(for field: FilterField) -> String? {
+        switch field {
+        case .title, .albumTitle: return title
+        case .artist:             return artist
+        case .genre:              return genre
+        case .label:              return label
+        default:                  return nil
+        }
+    }
+    func numericValue(for field: FilterField) -> Int? {
+        switch field {
+        case .year:               return year
+        case .duration:           return duration
+        case .rating, .albumRating: return rating
+        default:                  return nil
+        }
+    }
+    func boolValue(for field: FilterField) -> Bool {
+        switch field {
+        case .isFavorited:  return isFavorited
+        case .isDownloaded: return isDownloaded
+        default:            return false
+        }
+    }
+}
+
+extension FilterRuleSet.ArtistMeta: FilterTarget {
+    func textValue(for field: FilterField) -> String? {
+        switch field {
+        case .artist, .title: return name
+        case .genre:          return genre
+        default:              return nil
+        }
+    }
+    func numericValue(for field: FilterField) -> Int? { nil }
+    func boolValue(for field: FilterField) -> Bool {
+        switch field {
+        case .isFavorited:  return isFavorited
+        case .isDownloaded: return isDownloaded
+        default:            return false
+        }
+    }
+}

--- a/Vibrdrome/Core/Models/LibraryFilter.swift
+++ b/Vibrdrome/Core/Models/LibraryFilter.swift
@@ -28,6 +28,17 @@ final class LibraryFilter {
     var selectedLabels: Set<String> = []
     var year: Int?
 
+    /// Advanced rule-set filter (regex / operator-based, persisted separately).
+    var ruleSet: FilterRuleSet = .init() {
+        didSet { persistRuleSet() }
+    }
+
+    /// Live result count written back by the library view after each filter pass. Nil when filter is inactive.
+    var matchCount: Int?
+
+    /// UserDefaults key used to persist this filter's rule set. Set once after init.
+    var ruleSetPersistenceKey: String?
+
     var isActive: Bool {
         isFavorited != .none ||
         isRated != .none ||
@@ -35,7 +46,8 @@ final class LibraryFilter {
         !selectedArtistIds.isEmpty ||
         !selectedGenres.isEmpty ||
         !selectedLabels.isEmpty ||
-        year != nil
+        year != nil ||
+        !ruleSet.isEmpty
     }
 
     var activeFilterCount: Int {
@@ -47,6 +59,7 @@ final class LibraryFilter {
         if !selectedGenres.isEmpty { count += 1 }
         if !selectedLabels.isEmpty { count += 1 }
         if year != nil { count += 1 }
+        if !ruleSet.isEmpty { count += 1 }
         return count
     }
 
@@ -58,5 +71,22 @@ final class LibraryFilter {
         selectedGenres = []
         selectedLabels = []
         year = nil
+        ruleSet = .init()
+        matchCount = nil
+    }
+
+    // MARK: Persistence
+
+    func loadRuleSet(from key: String) {
+        ruleSetPersistenceKey = key
+        guard let data = UserDefaults.standard.data(forKey: key),
+              let decoded = try? JSONDecoder().decode(FilterRuleSet.self, from: data) else { return }
+        ruleSet = decoded
+    }
+
+    private func persistRuleSet() {
+        guard let key = ruleSetPersistenceKey,
+              let data = try? JSONEncoder().encode(ruleSet) else { return }
+        UserDefaults.standard.set(data, forKey: key)
     }
 }

--- a/Vibrdrome/Core/Models/NSPCriteria.swift
+++ b/Vibrdrome/Core/Models/NSPCriteria.swift
@@ -1,0 +1,379 @@
+import Foundation
+
+// MARK: - NSP Criteria
+
+/// Navidrome Smart Playlist criteria, matching the .nsp JSON format.
+/// Sent as the `rules` field in the Navidrome native REST API.
+///
+/// Format mirrors the Navidrome `model/criteria` package:
+///   { "all": [ { "contains": { "title": "love" } }, … ], "sort": "rating", "order": "desc", "limit": 100 }
+struct NSPCriteria: Codable, Sendable {
+    enum Combinator: String, Codable, Sendable { case all, any }
+
+    var combinator: Combinator
+    var expressions: [NSPExpression]
+    var sort: String?
+    var order: String?
+    var limit: Int?
+    var limitPercent: Int?
+
+    // MARK: Codable
+
+    enum CodingKeys: String, CodingKey { case all, any, sort, order, limit, limitPercent }
+
+    init(combinator: Combinator = .all, expressions: [NSPExpression] = [],
+         sort: String? = nil, order: String? = nil, limit: Int? = nil, limitPercent: Int? = nil) {
+        self.combinator = combinator
+        self.expressions = expressions
+        self.sort = sort
+        self.order = order
+        self.limit = limit
+        self.limitPercent = limitPercent
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        sort = try c.decodeIfPresent(String.self, forKey: .sort)
+        order = try c.decodeIfPresent(String.self, forKey: .order)
+        limit = try c.decodeIfPresent(Int.self, forKey: .limit)
+        limitPercent = try c.decodeIfPresent(Int.self, forKey: .limitPercent)
+        if let all = try c.decodeIfPresent([NSPExpression].self, forKey: .all) {
+            combinator = .all; expressions = all
+        } else if let any = try c.decodeIfPresent([NSPExpression].self, forKey: .any) {
+            combinator = .any; expressions = any
+        } else {
+            // Mirror Navidrome: criteria must have an 'all' or 'any' key.
+            throw DecodingError.dataCorruptedError(
+                forKey: .all,
+                in: c,
+                debugDescription: "NSPCriteria missing required 'all' or 'any' key"
+            )
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encodeIfPresent(sort, forKey: .sort)
+        try c.encodeIfPresent(order, forKey: .order)
+        try c.encodeIfPresent(limit, forKey: .limit)
+        try c.encodeIfPresent(limitPercent, forKey: .limitPercent)
+        switch combinator {
+        case .all: try c.encode(expressions, forKey: .all)
+        case .any: try c.encode(expressions, forKey: .any)
+        }
+    }
+
+    /// Serialize to a plain `[String: Any]` dictionary for embedding in an API request body.
+    func toJSON() -> [String: Any]? {
+        guard let data = try? JSONEncoder().encode(self) else { return nil }
+        return try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+    }
+}
+
+// MARK: - NSP Expression
+
+/// One rule node in the NSP format: `{ "<operator>": { "<field>": <value> } }`.
+/// Also handles nested `all`/`any` conjunctions.
+indirect enum NSPExpression: Codable, Sendable {
+    case leaf(operator: String, field: String, value: NSPValue)
+    case conjunction(NSPCriteria)
+
+    // Operator names recognised by Navidrome (lowercased for comparison).
+    private static let leafOperators: Set<String> = [
+        "is", "isnot", "gt", "lt", "contains", "notcontains",
+        "startswith", "endswith", "intherange",
+        "before", "after", "inthelast", "notinthelast",
+        "inplaylist", "notinplaylist", "ismissing", "ispresent",
+    ]
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        // Decode as a raw single-key dict to inspect the operator name first,
+        // mirroring Navidrome's unmarshalConjunctionType logic exactly:
+        // known leaf operators → leaf; "all"/"any" → nested conjunction.
+        let raw = try container.decode([String: NSPRawValue].self)
+        guard let (key, rawValue) = raw.first else {
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "Empty NSP expression")
+        }
+        let lowerKey = key.lowercased()
+        if NSPExpression.leafOperators.contains(lowerKey) {
+            // Leaf: { "<op>": { "<field>": <value> } }
+            guard case .object(let fieldMap) = rawValue,
+                  let (field, nspVal) = fieldMap.first else {
+                throw DecodingError.dataCorruptedError(in: container, debugDescription: "Invalid leaf expression for op '\(key)'")
+            }
+            self = .leaf(operator: key, field: field, value: nspVal)
+        } else if lowerKey == "all" || lowerKey == "any" {
+            // Nested conjunction: { "all": [...] } or { "any": [...] }
+            let nested = try container.decode(NSPCriteria.self)
+            self = .conjunction(nested)
+        } else {
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "Unknown NSP expression key '\(key)'")
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .conjunction(let crit):
+            try container.encode(crit)
+        case .leaf(let op, let field, let value):
+            try container.encode([op: [field: value]])
+        }
+    }
+}
+
+// MARK: - NSP Raw Value (expression decoding helper)
+
+/// Intermediate decoded shape for one side of an NSP expression dict.
+/// Used by `NSPExpression.init(from:)` to inspect the key before committing to a type.
+private enum NSPRawValue: Decodable {
+    case object([String: NSPValue])
+    case array([NSPExpression])
+    case other
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.singleValueContainer()
+        if let obj = try? c.decode([String: NSPValue].self) { self = .object(obj); return }
+        if let arr = try? c.decode([NSPExpression].self)    { self = .array(arr);  return }
+        self = .other
+    }
+}
+
+// MARK: - NSP Value
+
+/// A value in an NSP expression. Can be a string, int, bool, float, or a two-element range array.
+indirect enum NSPValue: Codable, Sendable {
+    case string(String)
+    case int(Int)
+    case bool(Bool)
+    case double(Double)
+    case range(NSPValue, NSPValue)
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.singleValueContainer()
+        if let b = try? c.decode(Bool.self)   { self = .bool(b);   return }
+        if let i = try? c.decode(Int.self)    { self = .int(i);    return }
+        if let d = try? c.decode(Double.self) { self = .double(d); return }
+        if let s = try? c.decode(String.self) { self = .string(s); return }
+        if let arr = try? c.decode([NSPValue].self), arr.count == 2 {
+            self = .range(arr[0], arr[1]); return
+        }
+        throw DecodingError.dataCorruptedError(in: c, debugDescription: "Unsupported NSPValue")
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.singleValueContainer()
+        switch self {
+        case .string(let s): try c.encode(s)
+        case .int(let i):    try c.encode(i)
+        case .bool(let b):   try c.encode(b)
+        case .double(let d): try c.encode(d)
+        case .range(let lo, let hi): try c.encode([lo, hi])
+        }
+    }
+}
+
+// MARK: - FilterRuleSet → NSPCriteria mapping
+
+extension NSPCriteria {
+
+    /// Convert a `FilterRuleSet` (local filter model) to an `NSPCriteria` (Navidrome native format).
+    init(from ruleSet: FilterRuleSet, sort: String? = nil, order: String? = nil, limit: Int? = nil) {
+        let expressions = ruleSet.rules
+            .filter { !$0.isEffectivelyEmpty }
+            .compactMap { NSPExpression(from: $0) }
+
+        self.init(
+            combinator: ruleSet.combinator == .all ? .all : .any,
+            expressions: expressions,
+            sort: sort,
+            order: order,
+            limit: limit
+        )
+    }
+}
+
+extension NSPExpression {
+
+    /// Map a single `FilterRule` to an `NSPExpression`.
+    /// Returns nil for rules that have no valid NSP mapping.
+    init?(from rule: FilterRule) {
+        guard !rule.isEffectivelyEmpty else { return nil }
+        guard let (op, field, value) = rule.toNSP() else { return nil }
+        self = .leaf(operator: op, field: field, value: value)
+    }
+}
+
+// MARK: - FilterRule → (operator, field, value)
+
+private extension FilterRule {
+
+    func toNSP() -> (op: String, field: String, value: NSPValue)? {
+        switch self.field.kind {
+        case .playlist: return playlistNSP()
+        default:
+            guard let field = self.field.nspField else { return nil }
+            switch self.field.kind {
+            case .text:    return textNSP(field: field)
+            case .numeric: return numericNSP(field: field)
+            case .days:    return daysNSP(field: field)
+            case .boolean: return booleanNSP(field: field)
+            case .playlist: return nil  // handled above
+            }
+        }
+    }
+
+    // MARK: Text
+
+    private func textNSP(field: String) -> (String, String, NSPValue)? {
+        guard case .text(let pattern) = value else { return nil }
+        switch `operator` {
+        case .contains:     return ("contains", field, .string(pattern))
+        case .notContains:  return ("notContains", field, .string(pattern))
+        case .equals:       return ("is", field, .string(pattern))
+        case .notEquals:    return ("isNot", field, .string(pattern))
+        case .startsWith:   return ("startsWith", field, .string(pattern))
+        case .endsWith:     return ("endsWith", field, .string(pattern))
+        case .matchesRegex:
+            // NSP doesn't have a regex operator; skip silently.
+            return nil
+        default:            return nil
+        }
+    }
+
+    // MARK: Numeric
+
+    private func numericNSP(field: String) -> (String, String, NSPValue)? {
+        switch value {
+        case .number(let n):
+            switch `operator` {
+            case .isEqualTo:       return ("is", field, .int(n))
+            case .isNotEqualTo:    return ("isNot", field, .int(n))
+            case .isGreaterThan:   return ("gt", field, .int(n))
+            case .isLessThan:      return ("lt", field, .int(n))
+            case .isGreaterOrEqual:
+                // NSP has no ≥; emulate with gt(n-1) for integer fields.
+                return ("gt", field, .int(n - 1))
+            case .isLessOrEqual:
+                // NSP has no ≤; emulate with lt(n+1) for integer fields.
+                return ("lt", field, .int(n + 1))
+            default: return nil
+            }
+        case .range(let lo, let hi):
+            guard `operator` == .isBetween else { return nil }
+            return ("inTheRange", field, .range(.int(lo), .int(hi)))
+        default:
+            return nil
+        }
+    }
+
+    // MARK: Days (inTheLast / notInTheLast / before / after)
+
+    private func daysNSP(field: String) -> (String, String, NSPValue)? {
+        switch `operator` {
+        case .inTheLast:
+            guard case .number(let n) = value else { return nil }
+            return ("inTheLast", field, .int(n))
+        case .notInTheLast:
+            guard case .number(let n) = value else { return nil }
+            return ("notInTheLast", field, .int(n))
+        case .before:
+            guard case .text(let date) = value, !date.isEmpty else { return nil }
+            return ("before", field, .string(date))
+        case .after:
+            guard case .text(let date) = value, !date.isEmpty else { return nil }
+            return ("after", field, .string(date))
+        default: return nil
+        }
+    }
+
+    // MARK: Boolean
+
+    private func booleanNSP(field: String) -> (String, String, NSPValue)? {
+        guard case .boolean(let flag) = value else { return nil }
+        // NSP uses `is` for booleans: { "is": { "loved": true } }
+        return ("is", field, .bool(flag))
+    }
+
+    // MARK: Playlist membership
+    // NSP format: { "inPlaylist": { "id": "<playlistId>" } }
+    // The "field" key inside inPlaylist/notInPlaylist is always "id".
+
+    private func playlistNSP() -> (String, String, NSPValue)? {
+        guard case .text(let playlistId) = value, !playlistId.isEmpty else { return nil }
+        switch self.field {
+        case .inPlaylist:    return ("inPlaylist", "id", .string(playlistId))
+        case .notInPlaylist: return ("notInPlaylist", "id", .string(playlistId))
+        default:             return nil
+        }
+    }
+}
+
+// MARK: - FilterField → NSP field name
+
+private extension FilterField {
+    /// Maps a Vibrdrome filter field to the corresponding Navidrome NSP field name.
+    /// Returns nil for fields that have no valid NSP mapping (local-only fields).
+    var nspField: String? {
+        switch self {
+        // Text
+        case .title:              return "title"
+        case .artist:             return "artist"
+        case .albumTitle:         return "album"
+        case .genre:              return "genre"
+        case .label:              return "recordlabel"
+        case .suffix:             return "filetype"
+        case .contentType:        return "codec"
+        case .comment:            return "comment"
+        case .explicitStatus:     return "explicitstatus"
+        case .mbzRecordingId:     return "mbz_recording_id"
+        case .mbzAlbumId:         return "mbz_album_id"
+        case .mbzArtistId:        return "mbz_artist_id"
+        case .mbzAlbumArtistId:   return "mbz_album_artist_id"
+        case .mbzReleaseTrackId:  return "mbz_release_track_id"
+        case .mbzReleaseGroupId:  return "mbz_release_group_id"
+        // Numeric
+        case .year:               return "year"
+        case .duration:           return "duration"
+        case .size:               return "size"
+        case .channels:           return "channels"
+        case .bitRate:            return "bitrate"
+        case .bitDepth:           return "bitdepth"
+        case .sampleRate:         return "samplerate"
+        case .bpm:                return "bpm"
+        case .playCount:          return "playcount"
+        case .rating:             return "rating"
+        case .averageRating:      return "averagerating"
+        case .albumRating:        return "albumrating"
+        case .albumPlayCount:     return "albumplaycount"
+        case .artistRating:       return "artistrating"
+        case .artistPlayCount:    return "artistplaycount"
+        case .trackNumber:        return "tracknumber"
+        case .discNumber:         return "discnumber"
+        // Date-relative
+        case .lastPlayed:         return "lastplayed"
+        case .dateLoved:          return "dateloved"
+        case .dateRated:          return "daterated"
+        case .dateAdded:          return "dateadded"
+        case .dateModified:       return "datemodified"
+        case .albumLastPlayed:    return "albumlastplayed"
+        case .albumDateLoved:     return "albumdateloved"
+        case .albumDateRated:     return "albumdaterated"
+        case .artistLastPlayed:   return "artistlastplayed"
+        case .artistDateLoved:    return "artistdateloved"
+        case .artistDateRated:    return "artistdaterated"
+        // Boolean
+        case .isFavorited:        return "loved"
+        case .albumFavorited:     return "albumloved"
+        case .artistFavorited:    return "artistloved"
+        case .hasCoverArt:        return "hascoverart"
+        case .isCompilation:      return "compilation"
+        case .isMissing:          return "missing"
+        // Local-only — no server mapping
+        case .isDownloaded:       return nil
+        // Playlist membership — handled specially in playlistNSP(), not via nspField
+        case .inPlaylist, .notInPlaylist: return nil
+        }
+    }
+}

--- a/Vibrdrome/Core/Networking/NavidromeNativeClient.swift
+++ b/Vibrdrome/Core/Networking/NavidromeNativeClient.swift
@@ -1,0 +1,348 @@
+import Foundation
+import os.log
+
+private let ndLog = Logger(subsystem: "com.vibrdrome.app", category: "NavidromeNative")
+
+// MARK: - Errors
+
+enum NavidromeNativeError: LocalizedError {
+    case notNavidrome
+    case authFailed(String)
+    case httpError(Int)
+    case decodingError(Error)
+    case invalidURL
+
+    var errorDescription: String? {
+        switch self {
+        case .notNavidrome:       return "Server does not appear to be Navidrome"
+        case .authFailed(let m):  return "Navidrome authentication failed: \(m)"
+        case .httpError(let c):   return "HTTP \(c)"
+        case .decodingError(let e): return "Decode error: \(e.localizedDescription)"
+        case .invalidURL:         return "Invalid URL"
+        }
+    }
+}
+
+// MARK: - Response models
+
+private struct NDLoginResponse: Decodable {
+    let token: String
+    let id: String?
+}
+
+struct NDSmartPlaylist: Decodable, Sendable {
+    let id: String
+    let name: String
+    let comment: String?
+    let rules: NSPCriteria?
+    let sync: Bool?
+}
+
+// MARK: - Song / Album response models
+
+struct NDSong: Decodable, Sendable {
+    let id: String
+    let title: String
+    let album: String?
+    let albumId: String?
+    let artist: String?
+    let albumArtist: String?
+    let artistId: String?
+    let albumArtistId: String?
+    let trackNumber: Int?
+    let discNumber: Int?
+    let year: Int?
+    let genre: String?
+    let size: Int?
+    let suffix: String?
+    let contentType: String?          // maps to `suffix` mime — not present, use `suffix`
+    let duration: Double?
+    let bitRate: Int?
+    let bitDepth: Int?
+    let sampleRate: Int?
+    let channels: Int?
+    let bpm: Int?
+    let comment: String?
+    let path: String?
+    let compilation: Bool?
+    let hasCoverArt: Bool?
+    let starred: Bool?
+    let starredAt: String?
+    let rating: Int?
+    let playCount: Int?
+    let playDate: String?
+    let createdAt: String?
+    let mbzRecordingId: String?       // not in ND API directly — use mbzReleaseTrackId
+    let mbzReleaseTrackId: String?
+    let mbzAlbumId: String?
+    let mbzArtistId: String?
+    let mbzAlbumArtistId: String?
+    let rgTrackGain: Double?
+    let rgTrackPeak: Double?
+    let rgAlbumGain: Double?
+    let rgAlbumPeak: Double?
+    let smallImageUrl: String?
+    let largeImageUrl: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id, title, album, albumId, artist, albumArtist, artistId, albumArtistId
+        case trackNumber, discNumber, year, genre, size, suffix, duration
+        case bitRate, bitDepth, sampleRate, channels, bpm, comment, path
+        case compilation, hasCoverArt, starred, starredAt, rating, playCount, playDate, createdAt
+        case mbzReleaseTrackId, mbzAlbumId, mbzArtistId, mbzAlbumArtistId
+        case rgTrackGain, rgTrackPeak, rgAlbumGain, rgAlbumPeak
+        case smallImageUrl, largeImageUrl
+        case contentType
+        case mbzRecordingId
+    }
+}
+
+struct NDAlbum: Decodable, Sendable {
+    let id: String
+    let name: String
+    let artist: String?
+    let artistId: String?
+    let albumArtistId: String?
+    let genre: String?
+    let year: Int?
+    let songCount: Int?
+    let duration: Double?
+    let size: Int?
+    let starred: Bool?
+    let starredAt: String?
+    let rating: Int?
+    let playCount: Int?
+    let playDate: String?
+    let createdAt: String?
+    let compilation: Bool?
+    let mbzAlbumId: String?
+    let mbzAlbumArtistId: String?
+    let mbzReleaseGroupId: String?
+    let smallImageUrl: String?
+    let largeImageUrl: String?
+    let comment: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id, name, artist, artistId, albumArtistId, genre, year, songCount, duration, size
+        case starred, starredAt, rating, playCount, playDate, createdAt, compilation
+        case mbzAlbumId, mbzAlbumArtistId, mbzReleaseGroupId
+        case smallImageUrl, largeImageUrl, comment
+    }
+}
+
+// MARK: - NavidromeNativeClient
+
+/// Thin client for Navidrome's own REST API (`/api/…`), used for smart-playlist
+/// create/update/delete with embedded NSP criteria rules.
+///
+/// Auth flow: POST /auth/login → JWT → X-ND-Authorization: Bearer <token>
+/// The JWT is cached in memory until invalidated.
+@Observable
+@MainActor
+final class NavidromeNativeClient {
+
+    private let baseURL: URL
+    private let username: String
+    private let password: String
+    private let session: URLSession
+
+    /// Cached JWT token. Nil until first login; cleared on 401.
+    private var token: String?
+
+    var isAvailable: Bool = false
+
+    init(baseURL: URL, username: String, password: String) {
+        self.baseURL = baseURL
+        self.username = username
+        self.password = password
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = 30
+        config.httpShouldSetCookies = false
+        config.httpCookieAcceptPolicy = .never
+        config.httpCookieStorage = nil
+        config.urlCredentialStorage = nil
+        self.session = URLSession(configuration: config)
+    }
+
+    // MARK: - Auth
+
+    /// Authenticate and cache the JWT. Throws NavidromeNativeError.authFailed on bad credentials.
+    func login() async throws {
+        let url = baseURL.appendingPathComponent("auth/login")
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        let body = ["username": username, "password": password]
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        let (data, response) = try await session.data(for: request)
+        let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
+        guard statusCode == 200 else {
+            throw NavidromeNativeError.authFailed("HTTP \(statusCode)")
+        }
+
+        do {
+            let decoded = try JSONDecoder().decode(NDLoginResponse.self, from: data)
+            token = decoded.token
+            isAvailable = true
+            ndLog.info("Navidrome native auth OK (user: \(self.username))")
+        } catch {
+            throw NavidromeNativeError.authFailed("Could not decode login response")
+        }
+    }
+
+    /// Probe the server to confirm it is Navidrome, and authenticate.
+    /// Safe to call repeatedly — returns quickly if already available.
+    func probe() async {
+        guard !isAvailable else { return }
+        do {
+            try await login()
+        } catch {
+            isAvailable = false
+            ndLog.info("Navidrome native API not available: \(error.localizedDescription)")
+        }
+    }
+
+    // MARK: - Playlist CRUD
+
+    /// Create a new smart playlist on the server. Returns the new playlist ID.
+    @discardableResult
+    func createSmartPlaylist(name: String, comment: String = "", rules: NSPCriteria) async throws -> String {
+        let body = buildPlaylistBody(name: name, comment: comment, rules: rules)
+        let data = try await nativeRequest(method: "POST", path: "api/playlist", body: body)
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let id = json["id"] as? String else {
+            throw NavidromeNativeError.decodingError(
+                NSError(domain: "NavidromeNative", code: -1,
+                        userInfo: [NSLocalizedDescriptionKey: "Missing id in createPlaylist response"])
+            )
+        }
+        ndLog.info("Created smart playlist '\(name)' (id: \(id))")
+        return id
+    }
+
+    /// Update rules (and optionally name/comment) of an existing playlist.
+    func updateSmartPlaylist(id: String, name: String, comment: String = "", rules: NSPCriteria) async throws {
+        let body = buildPlaylistBody(name: name, comment: comment, rules: rules)
+        _ = try await nativeRequest(method: "PUT", path: "api/playlist/\(id)", body: body)
+        ndLog.info("Updated smart playlist '\(name)' (id: \(id))")
+    }
+
+    /// Delete a playlist.
+    func deletePlaylist(id: String) async throws {
+        _ = try await nativeRequest(method: "DELETE", path: "api/playlist/\(id)", body: nil)
+        ndLog.info("Deleted playlist id: \(id)")
+    }
+
+    /// Fetch all playlists (both smart and regular).
+    func getPlaylists() async throws -> [NDSmartPlaylist] {
+        let data = try await nativeRequest(method: "GET", path: "api/playlist?_end=500&_start=0", body: nil)
+        do {
+            return try JSONDecoder().decode([NDSmartPlaylist].self, from: data)
+        } catch {
+            throw NavidromeNativeError.decodingError(error)
+        }
+    }
+
+    // MARK: - Song / Album fetch
+
+    /// Fetch a page of songs from the Navidrome native API.
+    /// Returns `(items, totalCount)` where totalCount comes from the `x-total-count` header.
+    func getSongs(start: Int, end: Int) async throws -> (items: [NDSong], total: Int) {
+        let path = "api/song?_start=\(start)&_end=\(end)&_sort=title&_order=ASC"
+        let (data, response) = try await nativeRequestWithResponse(method: "GET", path: path, body: nil)
+        let total = (response as? HTTPURLResponse)
+            .flatMap { $0.value(forHTTPHeaderField: "x-total-count") }
+            .flatMap { Int($0) } ?? 0
+        do {
+            let items = try JSONDecoder().decode([NDSong].self, from: data)
+            return (items, total)
+        } catch {
+            throw NavidromeNativeError.decodingError(error)
+        }
+    }
+
+    /// Fetch a page of albums from the Navidrome native API.
+    func getAlbums(start: Int, end: Int) async throws -> (items: [NDAlbum], total: Int) {
+        let path = "api/album?_start=\(start)&_end=\(end)&_sort=name&_order=ASC"
+        let (data, response) = try await nativeRequestWithResponse(method: "GET", path: path, body: nil)
+        let total = (response as? HTTPURLResponse)
+            .flatMap { $0.value(forHTTPHeaderField: "x-total-count") }
+            .flatMap { Int($0) } ?? 0
+        do {
+            let items = try JSONDecoder().decode([NDAlbum].self, from: data)
+            return (items, total)
+        } catch {
+            throw NavidromeNativeError.decodingError(error)
+        }
+    }
+
+    // MARK: - Private helpers
+
+    private func buildPlaylistBody(name: String, comment: String, rules: NSPCriteria) -> [String: Any] {
+        var body: [String: Any] = [
+            "name": name,
+            "comment": comment,
+            "sync": true,
+        ]
+        if let rulesJSON = rules.toJSON() {
+            body["rules"] = rulesJSON
+        }
+        return body
+    }
+
+    private func nativeRequest(method: String, path: String, body: [String: Any]?) async throws -> Data {
+        let (data, _) = try await nativeRequestWithResponse(method: method, path: path, body: body)
+        return data
+    }
+
+    private func nativeRequestWithResponse(method: String, path: String, body: [String: Any]?) async throws -> (Data, URLResponse) {
+        // Ensure we have a token
+        if token == nil {
+            try await login()
+        }
+
+        guard let tok = token else {
+            throw NavidromeNativeError.authFailed("No token after login")
+        }
+
+        guard let url = URL(string: path, relativeTo: baseURL) else {
+            throw NavidromeNativeError.invalidURL
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        request.setValue("Bearer \(tok)", forHTTPHeaderField: "X-ND-Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        if let body {
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        }
+
+        let (data, response) = try await session.data(for: request)
+        let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
+
+        if statusCode == 401 {
+            // Token expired — clear and retry once
+            token = nil
+            isAvailable = false
+            try await login()
+            guard let newTok = token else {
+                throw NavidromeNativeError.authFailed("Re-login failed")
+            }
+            request.setValue("Bearer \(newTok)", forHTTPHeaderField: "X-ND-Authorization")
+            let (retryData, retryResponse) = try await session.data(for: request)
+            let retryStatus = (retryResponse as? HTTPURLResponse)?.statusCode ?? 0
+            guard (200...299).contains(retryStatus) else {
+                throw NavidromeNativeError.httpError(retryStatus)
+            }
+            return (retryData, retryResponse)
+        }
+
+        guard (200...299).contains(statusCode) else {
+            throw NavidromeNativeError.httpError(statusCode)
+        }
+
+        return (data, response)
+    }
+}

--- a/Vibrdrome/Core/Networking/SubsonicModels.swift
+++ b/Vibrdrome/Core/Networking/SubsonicModels.swift
@@ -199,6 +199,9 @@ struct Song: Decodable, Identifiable, Sendable, Equatable {
     let suffix: String?
     let duration: Int?
     let bitRate: Int?
+    let bitDepth: Int?
+    let samplingRate: Int?
+    let comment: String?
     let path: String?
     let discNumber: Int?
     let created: String?
@@ -215,8 +218,9 @@ struct Song: Decodable, Identifiable, Sendable, Equatable {
         track: Int? = nil, year: Int? = nil, genre: String? = nil,
         coverArt: String? = nil, size: Int? = nil,
         contentType: String? = nil, suffix: String? = nil,
-        duration: Int? = nil, bitRate: Int? = nil, path: String? = nil,
-        discNumber: Int? = nil, created: String? = nil,
+        duration: Int? = nil, bitRate: Int? = nil,
+        bitDepth: Int? = nil, samplingRate: Int? = nil, comment: String? = nil,
+        path: String? = nil, discNumber: Int? = nil, created: String? = nil,
         starred: String? = nil, userRating: Int? = nil,
         bpm: Int? = nil, replayGain: ReplayGain? = nil, musicBrainzId: String? = nil
     ) {
@@ -226,8 +230,9 @@ struct Song: Decodable, Identifiable, Sendable, Equatable {
         self.track = track; self.year = year; self.genre = genre
         self.coverArt = coverArt; self.size = size
         self.contentType = contentType; self.suffix = suffix
-        self.duration = duration; self.bitRate = bitRate; self.path = path
-        self.discNumber = discNumber; self.created = created
+        self.duration = duration; self.bitRate = bitRate
+        self.bitDepth = bitDepth; self.samplingRate = samplingRate; self.comment = comment
+        self.path = path; self.discNumber = discNumber; self.created = created
         self.starred = starred; self.userRating = userRating
         self.bpm = bpm; self.replayGain = replayGain; self.musicBrainzId = musicBrainzId
     }

--- a/Vibrdrome/Core/Persistence/BackgroundSyncScheduler.swift
+++ b/Vibrdrome/Core/Persistence/BackgroundSyncScheduler.swift
@@ -121,6 +121,7 @@ final class BackgroundSyncScheduler {
         let syncTask = Task {
             await appState.librarySyncManager.incrementalSync(
                 client: appState.subsonicClient,
+                ndClient: appState.navidromeClient,
                 container: PersistenceController.shared.container
             )
         }
@@ -150,6 +151,7 @@ final class BackgroundSyncScheduler {
         let syncTask = Task {
             await appState.librarySyncManager.sync(
                 client: appState.subsonicClient,
+                ndClient: appState.navidromeClient,
                 container: PersistenceController.shared.container
             )
         }

--- a/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
+++ b/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
@@ -83,13 +83,13 @@ final class LibrarySyncManager {
     // MARK: - Public API
 
     /// Run a full library sync: albums, artists, songs, then playlists.
-    func sync(client: SubsonicClient, container: ModelContainer) async {
-        await performSync(mode: .full, client: client, container: container)
+    func sync(client: SubsonicClient, ndClient: NavidromeNativeClient? = nil, container: ModelContainer) async {
+        await performSync(mode: .full, client: client, ndClient: ndClient, container: container)
     }
 
     /// Run an incremental sync — only fetches changes since last sync.
-    func incrementalSync(client: SubsonicClient, container: ModelContainer) async {
-        await performSync(mode: .incremental, client: client, container: container)
+    func incrementalSync(client: SubsonicClient, ndClient: NavidromeNativeClient? = nil, container: ModelContainer) async {
+        await performSync(mode: .incremental, client: client, ndClient: ndClient, container: container)
     }
 
     /// Convenience: sync using the configured client and container.
@@ -99,25 +99,22 @@ final class LibrarySyncManager {
     }
 
     /// Check if sync is stale and trigger the appropriate sync mode.
-    func syncIfStale(client: SubsonicClient, container: ModelContainer) async {
+    func syncIfStale(client: SubsonicClient, ndClient: NavidromeNativeClient? = nil, container: ModelContainer) async {
         guard let last = lastSyncDate else {
-            await performSync(mode: .full, client: client, container: container)
+            await performSync(mode: .full, client: client, ndClient: ndClient, container: container)
             return
         }
         let elapsed = Date().timeIntervalSince(last)
         guard elapsed > staleInterval else { return }
 
-        // Check if server data actually changed before doing work
         let serverChanged = await hasServerChanged(client: client)
 
         if serverChanged {
-            // Use full sync if it's been over a week, otherwise incremental
             let lastFull = UserDefaults.standard.object(forKey: UserDefaultsKeys.lastFullSyncDate) as? Date
             let needsFullSync = lastFull == nil || Date().timeIntervalSince(lastFull!) > fullSyncInterval
             let mode: SyncMode = needsFullSync ? .full : .incremental
-            await performSync(mode: mode, client: client, container: container)
+            await performSync(mode: mode, client: client, ndClient: ndClient, container: container)
         } else {
-            // Server unchanged — just update the stale check timestamp
             lastSyncDate = Date()
             syncLog.info("Server data unchanged, skipping sync (trigger: auto-stale-check)")
         }
@@ -126,7 +123,7 @@ final class LibrarySyncManager {
     // MARK: - Change Detection Polling
 
     /// Start periodic polling for server changes while the app is active.
-    func startPolling(client: SubsonicClient, container: ModelContainer) {
+    func startPolling(client: SubsonicClient, ndClient: NavidromeNativeClient? = nil, container: ModelContainer) {
         stopPolling()
         let intervalMinutes = UserDefaults.standard.integer(forKey: UserDefaultsKeys.syncPollingInterval)
         let interval = max(TimeInterval(intervalMinutes > 0 ? intervalMinutes : 15) * 60, 300)
@@ -139,7 +136,7 @@ final class LibrarySyncManager {
                 let changed = await self.hasServerChanged(client: client)
                 if changed {
                     syncLog.info("Polling detected server changes, triggering incremental sync (trigger: auto-poll)")
-                    await self.performSync(mode: .incremental, client: client, container: container)
+                    await self.performSync(mode: .incremental, client: client, ndClient: ndClient, container: container)
                 }
             }
         }
@@ -155,7 +152,7 @@ final class LibrarySyncManager {
     // MARK: - Core Sync Engine
 
     // swiftlint:disable:next function_body_length
-    private func performSync(mode: SyncMode, client: SubsonicClient, container: ModelContainer) async {
+    private func performSync(mode: SyncMode, client: SubsonicClient, ndClient: NavidromeNativeClient? = nil, container: ModelContainer) async {
         guard !isSyncing else { return }
         isSyncing = true
         syncError = nil
@@ -192,7 +189,7 @@ final class LibrarySyncManager {
                 var working = SyncStats()
 
                 try await Self.syncAlbumsOffMain(
-                    client: client, container: container,
+                    client: client, ndClient: ndClient, container: container,
                     stats: &working, incremental: incremental,
                     progress: updateProgress, publishStats: publishPartialStats
                 )
@@ -202,7 +199,7 @@ final class LibrarySyncManager {
                     progress: updateProgress, publishStats: publishPartialStats
                 )
                 try await Self.syncSongsOffMain(
-                    client: client, container: container,
+                    client: client, ndClient: ndClient, container: container,
                     stats: &working, incremental: incremental,
                     progress: updateProgress, publishStats: publishPartialStats
                 )
@@ -274,9 +271,10 @@ final class LibrarySyncManager {
 
     // MARK: - Albums
 
-    // swiftlint:disable:next function_body_length function_parameter_count
+    // swiftlint:disable:next function_parameter_count
     nonisolated static func syncAlbumsOffMain(
         client: SubsonicClient,
+        ndClient: NavidromeNativeClient?,
         container: ModelContainer,
         stats: inout SyncStats,
         incremental: Bool,
@@ -288,67 +286,26 @@ final class LibrarySyncManager {
         let context = ModelContext(container)
         context.autosaveEnabled = false
 
-        // Build lookup dictionary of existing albums for O(1) access
         let allLocal = try context.fetch(FetchDescriptor<CachedAlbum>())
         var localMap = Dictionary(uniqueKeysWithValues: allLocal.map { ($0.id, $0) })
-
-        var offset = 0
         var serverAlbumIds = Set<String>()
         var totalFetched = 0
 
-        if incremental {
-            // Fetch only newest albums (added/modified recently)
-            let newestAlbums = try await client.getAlbumList(type: .newest, size: albumPageSize)
-            for album in newestAlbums {
-                serverAlbumIds.insert(album.id)
-                if let existing = localMap[album.id] {
-                    if hasAlbumChanged(existing, album) {
-                        existing.update(from: album)
-                        stats.albumsUpdated += 1
-                    }
-                } else {
-                    let cached = CachedAlbum(from: album)
-                    context.insert(cached)
-                    localMap[album.id] = cached
-                    stats.albumsAdded += 1
-                }
-            }
-            totalFetched = newestAlbums.count
+        if let ndClient, await ndClient.isAvailable {
+            totalFetched = try await syncAlbumsND(
+                ndClient: ndClient, context: context, allLocal: allLocal,
+                localMap: &localMap, serverIds: &serverAlbumIds, stats: &stats, progress: progress
+            )
+        } else if incremental {
+            totalFetched = try await syncAlbumsIncremental(
+                client: client, context: context,
+                localMap: &localMap, serverIds: &serverAlbumIds, stats: &stats
+            )
         } else {
-            // Full sync: fetch all albums
-            while true {
-                let page = try await client.getAlbumList(
-                    type: .alphabeticalByName, size: albumPageSize, offset: offset
-                )
-                if page.isEmpty { break }
-
-                for album in page {
-                    serverAlbumIds.insert(album.id)
-                    if let existing = localMap[album.id] {
-                        if hasAlbumChanged(existing, album) {
-                            existing.update(from: album)
-                            stats.albumsUpdated += 1
-                        }
-                    } else {
-                        let cached = CachedAlbum(from: album)
-                        context.insert(cached)
-                        localMap[album.id] = cached
-                        stats.albumsAdded += 1
-                    }
-                }
-
-                totalFetched += page.count
-                progress("Syncing albums… \(totalFetched)")
-                offset += page.count
-
-                if page.count < albumPageSize { break }
-            }
-
-            // Remove albums no longer on server
-            for local in allLocal where !serverAlbumIds.contains(local.id) {
-                context.delete(local)
-                stats.albumsRemoved += 1
-            }
+            totalFetched = try await syncAlbumsSubsonic(
+                client: client, context: context, allLocal: allLocal,
+                localMap: &localMap, serverIds: &serverAlbumIds, stats: &stats, progress: progress
+            )
         }
 
         try context.save()
@@ -357,6 +314,82 @@ final class LibrarySyncManager {
         let updated = stats.albumsUpdated
         let removed = stats.albumsRemoved
         syncLog.info("Synced \(totalFetched) albums (+\(added) ~\(updated) -\(removed))")
+    }
+
+    nonisolated private static func syncAlbumsIncremental(
+        client: SubsonicClient, context: ModelContext,
+        localMap: inout [String: CachedAlbum], serverIds: inout Set<String>,
+        stats: inout SyncStats
+    ) async throws -> Int {
+        let newestAlbums = try await client.getAlbumList(type: .newest, size: albumPageSize)
+        for album in newestAlbums {
+            serverIds.insert(album.id)
+            if let existing = localMap[album.id] {
+                if hasAlbumChanged(existing, album) { existing.update(from: album); stats.albumsUpdated += 1 }
+            } else {
+                let cached = CachedAlbum(from: album)
+                context.insert(cached); localMap[album.id] = cached; stats.albumsAdded += 1
+            }
+        }
+        return newestAlbums.count
+    }
+
+    // swiftlint:disable:next function_parameter_count
+    nonisolated private static func syncAlbumsND(
+        ndClient: NavidromeNativeClient, context: ModelContext, allLocal: [CachedAlbum],
+        localMap: inout [String: CachedAlbum], serverIds: inout Set<String>,
+        stats: inout SyncStats, progress: @Sendable (String) -> Void
+    ) async throws -> Int {
+        var start = 0
+        var totalFetched = 0
+        while true {
+            let (page, total) = try await ndClient.getAlbums(start: start, end: start + albumPageSize)
+            if page.isEmpty { break }
+            for ndAlbum in page {
+                serverIds.insert(ndAlbum.id)
+                if let existing = localMap[ndAlbum.id] {
+                    if hasNDAlbumChanged(existing, ndAlbum) { existing.update(from: ndAlbum); stats.albumsUpdated += 1 }
+                } else {
+                    let cached = CachedAlbum(from: ndAlbum)
+                    context.insert(cached); localMap[ndAlbum.id] = cached; stats.albumsAdded += 1
+                }
+            }
+            totalFetched += page.count
+            progress("Syncing albums… \(totalFetched)/\(total)")
+            start += page.count
+            if totalFetched >= total || page.count < albumPageSize { break }
+        }
+        for local in allLocal where !serverIds.contains(local.id) { context.delete(local); stats.albumsRemoved += 1 }
+        return totalFetched
+    }
+
+    // swiftlint:disable:next function_parameter_count
+    nonisolated private static func syncAlbumsSubsonic(
+        client: SubsonicClient, context: ModelContext, allLocal: [CachedAlbum],
+        localMap: inout [String: CachedAlbum], serverIds: inout Set<String>,
+        stats: inout SyncStats, progress: @Sendable (String) -> Void
+    ) async throws -> Int {
+        var offset = 0
+        var totalFetched = 0
+        while true {
+            let page = try await client.getAlbumList(type: .alphabeticalByName, size: albumPageSize, offset: offset)
+            if page.isEmpty { break }
+            for album in page {
+                serverIds.insert(album.id)
+                if let existing = localMap[album.id] {
+                    if hasAlbumChanged(existing, album) { existing.update(from: album); stats.albumsUpdated += 1 }
+                } else {
+                    let cached = CachedAlbum(from: album)
+                    context.insert(cached); localMap[album.id] = cached; stats.albumsAdded += 1
+                }
+            }
+            totalFetched += page.count
+            progress("Syncing albums… \(totalFetched)")
+            offset += page.count
+            if page.count < albumPageSize { break }
+        }
+        for local in allLocal where !serverIds.contains(local.id) { context.delete(local); stats.albumsRemoved += 1 }
+        return totalFetched
     }
 
     nonisolated static func hasAlbumChanged(_ cached: CachedAlbum, _ server: Album) -> Bool {
@@ -371,7 +404,24 @@ final class LibrarySyncManager {
         cached.coverArtId != server.coverArt ||
         cached.created != server.created ||
         cached.userRating != (server.userRating ?? 0) ||
-        cached.label != server.label
+        cached.label != server.label ||
+        cached.mbzAlbumId != server.musicBrainzId
+    }
+
+    nonisolated static func hasNDAlbumChanged(_ cached: CachedAlbum, _ server: NDAlbum) -> Bool {
+        cached.name != server.name ||
+        cached.artistId != server.artistId ||
+        cached.year != server.year ||
+        cached.genre != server.genre ||
+        cached.songCount != server.songCount ||
+        cached.duration != server.duration.map({ Int($0) }) ||
+        cached.isStarred != (server.starred ?? false) ||
+        cached.userRating != (server.rating ?? 0) ||
+        cached.mbzAlbumId != server.mbzAlbumId ||
+        cached.mbzAlbumArtistId != server.mbzAlbumArtistId ||
+        cached.mbzReleaseGroupId != server.mbzReleaseGroupId ||
+        cached.playCount != (server.playCount ?? 0) ||
+        cached.isCompilation != (server.compilation ?? false)
     }
 
     // MARK: - Artists
@@ -443,6 +493,7 @@ final class LibrarySyncManager {
     // swiftlint:disable:next function_parameter_count
     nonisolated static func syncSongsOffMain(
         client: SubsonicClient,
+        ndClient: NavidromeNativeClient?,
         container: ModelContainer,
         stats: inout SyncStats,
         incremental: Bool,
@@ -454,62 +505,26 @@ final class LibrarySyncManager {
         let context = ModelContext(container)
         context.autosaveEnabled = false
 
-        // Build lookup dictionary for O(1) access
         let allLocal = try context.fetch(FetchDescriptor<CachedSong>())
         var localMap = Dictionary(uniqueKeysWithValues: allLocal.map { ($0.id, $0) })
-
-        // Pre-fetch album map for linking
-        let allAlbums = try context.fetch(FetchDescriptor<CachedAlbum>())
-        let albumMap = Dictionary(uniqueKeysWithValues: allAlbums.map { ($0.id, $0) })
-
-        var offset = 0
+        let albumMap = Dictionary(
+            uniqueKeysWithValues: (try context.fetch(FetchDescriptor<CachedAlbum>())).map { ($0.id, $0) }
+        )
         var serverSongIds = Set<String>()
-        var totalFetched = 0
 
-        while true {
-            let result = try await client.search(
-                query: "", artistCount: 0, albumCount: 0,
-                songCount: songPageSize, songOffset: offset
+        let totalFetched: Int
+        if let ndClient, await ndClient.isAvailable {
+            totalFetched = try await syncSongsND(
+                ndClient: ndClient, context: context, allLocal: allLocal, albumMap: albumMap,
+                localMap: &localMap, serverIds: &serverSongIds, stats: &stats,
+                progress: progress, publishStats: publishStats
             )
-            let songs = result.song ?? []
-            if songs.isEmpty { break }
-
-            for song in songs {
-                serverSongIds.insert(song.id)
-                if let existing = localMap[song.id] {
-                    if hasSongChanged(existing, song) {
-                        updateSongFields(existing, from: song)
-                        stats.songsUpdated += 1
-                    }
-                } else {
-                    let cached = CachedSong(from: song)
-                    if let albumId = song.albumId {
-                        cached.album = albumMap[albumId]
-                    }
-                    context.insert(cached)
-                    localMap[song.id] = cached
-                    stats.songsAdded += 1
-                }
-            }
-
-            totalFetched += songs.count
-            progress("Syncing songs… \(totalFetched)")
-            offset += songs.count
-
-            if totalFetched % 2000 == 0 {
-                try context.save()
-                publishStats(stats)
-            }
-
-            if songs.count < songPageSize { break }
-        }
-
-        // Remove songs no longer on server (only on full sync, preserve downloads)
-        if !incremental {
-            for local in allLocal where !serverSongIds.contains(local.id) && local.download == nil {
-                context.delete(local)
-                stats.songsRemoved += 1
-            }
+        } else {
+            totalFetched = try await syncSongsSubsonic(
+                client: client, context: context, allLocal: allLocal, albumMap: albumMap,
+                localMap: &localMap, serverIds: &serverSongIds, stats: &stats,
+                incremental: incremental, progress: progress, publishStats: publishStats
+            )
         }
 
         try context.save()
@@ -519,6 +534,87 @@ final class LibrarySyncManager {
         let songUpdated = stats.songsUpdated
         let songRemoved = stats.songsRemoved
         syncLog.info("Synced \(totalFetched) songs (+\(songAdded) ~\(songUpdated) -\(songRemoved))")
+    }
+
+    // swiftlint:disable:next function_parameter_count
+    nonisolated private static func syncSongsND(
+        ndClient: NavidromeNativeClient, context: ModelContext,
+        allLocal: [CachedSong], albumMap: [String: CachedAlbum],
+        localMap: inout [String: CachedSong], serverIds: inout Set<String>,
+        stats: inout SyncStats,
+        progress: @Sendable (String) -> Void,
+        publishStats: @Sendable (SyncStats) -> Void
+    ) async throws -> Int {
+        var start = 0
+        var totalFetched = 0
+        while true {
+            let (page, total) = try await ndClient.getSongs(start: start, end: start + songPageSize)
+            if page.isEmpty { break }
+            for ndSong in page {
+                serverIds.insert(ndSong.id)
+                if let existing = localMap[ndSong.id] {
+                    if hasNDSongChanged(existing, ndSong) {
+                        existing.update(from: ndSong)
+                        if let albumId = ndSong.albumId { existing.album = albumMap[albumId] }
+                        stats.songsUpdated += 1
+                    }
+                } else {
+                    let cached = CachedSong(from: ndSong)
+                    if let albumId = ndSong.albumId { cached.album = albumMap[albumId] }
+                    context.insert(cached); localMap[ndSong.id] = cached; stats.songsAdded += 1
+                }
+            }
+            totalFetched += page.count
+            progress("Syncing songs… \(totalFetched)/\(total)")
+            start += page.count
+            if totalFetched % 2000 == 0 { try context.save(); publishStats(stats) }
+            if totalFetched >= total || page.count < songPageSize { break }
+        }
+        for local in allLocal where !serverIds.contains(local.id) && local.download == nil {
+            context.delete(local); stats.songsRemoved += 1
+        }
+        return totalFetched
+    }
+
+    // swiftlint:disable:next function_parameter_count
+    nonisolated private static func syncSongsSubsonic(
+        client: SubsonicClient, context: ModelContext,
+        allLocal: [CachedSong], albumMap: [String: CachedAlbum],
+        localMap: inout [String: CachedSong], serverIds: inout Set<String>,
+        stats: inout SyncStats, incremental: Bool,
+        progress: @Sendable (String) -> Void,
+        publishStats: @Sendable (SyncStats) -> Void
+    ) async throws -> Int {
+        var offset = 0
+        var totalFetched = 0
+        while true {
+            let result = try await client.search(
+                query: "", artistCount: 0, albumCount: 0, songCount: songPageSize, songOffset: offset
+            )
+            let songs = result.song ?? []
+            if songs.isEmpty { break }
+            for song in songs {
+                serverIds.insert(song.id)
+                if let existing = localMap[song.id] {
+                    if hasSongChanged(existing, song) { updateSongFields(existing, from: song); stats.songsUpdated += 1 }
+                } else {
+                    let cached = CachedSong(from: song)
+                    if let albumId = song.albumId { cached.album = albumMap[albumId] }
+                    context.insert(cached); localMap[song.id] = cached; stats.songsAdded += 1
+                }
+            }
+            totalFetched += songs.count
+            progress("Syncing songs… \(totalFetched)")
+            offset += songs.count
+            if totalFetched % 2000 == 0 { try context.save(); publishStats(stats) }
+            if songs.count < songPageSize { break }
+        }
+        if !incremental {
+            for local in allLocal where !serverIds.contains(local.id) && local.download == nil {
+                context.delete(local); stats.songsRemoved += 1
+            }
+        }
+        return totalFetched
     }
 
     /// Nonisolated so songs sync (off MainActor) can call it directly.
@@ -543,7 +639,12 @@ final class LibrarySyncManager {
         cached.duration != server.duration ||
         cached.isStarred != (server.starred != nil) ||
         cached.coverArtId != server.coverArt ||
-        cached.bitRate != server.bitRate
+        cached.bitRate != server.bitRate ||
+        cached.bitDepth != server.bitDepth ||
+        cached.samplingRate != server.samplingRate ||
+        cached.comment != server.comment ||
+        cached.bpm != server.bpm ||
+        cached.mbzRecordingId != server.musicBrainzId
     }
 
     nonisolated static func updateSongFields(_ cached: CachedSong, from song: Song) {
@@ -560,12 +661,40 @@ final class LibrarySyncManager {
         cached.genre = song.genre
         cached.duration = song.duration
         cached.bitRate = song.bitRate
+        cached.bitDepth = song.bitDepth
+        cached.samplingRate = song.samplingRate
+        cached.comment = song.comment
         cached.suffix = song.suffix
         cached.contentType = song.contentType
         cached.size = song.size
+        cached.bpm = song.bpm
+        cached.dateAdded = song.created.flatMap { ISO8601DateFormatter().date(from: $0) }
+        cached.mbzRecordingId = song.musicBrainzId
         cached.isStarred = song.starred != nil
         cached.rating = song.userRating ?? 0
         cached.cachedAt = Date()
+    }
+
+    nonisolated static func hasNDSongChanged(_ cached: CachedSong, _ server: NDSong) -> Bool {
+        cached.title != server.title ||
+        cached.artist != server.artist ||
+        cached.albumName != server.album ||
+        cached.track != server.trackNumber ||
+        cached.year != server.year ||
+        cached.genre != server.genre ||
+        cached.duration != server.duration.map({ Int($0) }) ||
+        cached.isStarred != (server.starred ?? false) ||
+        cached.bitRate != server.bitRate ||
+        cached.bitDepth != server.bitDepth ||
+        cached.samplingRate != server.sampleRate ||
+        cached.channels != server.channels ||
+        cached.comment != server.comment ||
+        cached.bpm != server.bpm ||
+        cached.mbzRecordingId != server.mbzReleaseTrackId ||
+        cached.rating != (server.rating ?? 0) ||
+        cached.playCount != (server.playCount ?? 0) ||
+        cached.isCompilation != (server.compilation ?? false) ||
+        cached.hasCoverArt != (server.hasCoverArt ?? false)
     }
 
     // MARK: - Playlists

--- a/Vibrdrome/Core/Persistence/Models/CachedAlbum.swift
+++ b/Vibrdrome/Core/Persistence/Models/CachedAlbum.swift
@@ -16,6 +16,11 @@ final class CachedAlbum {
     var created: String?
     var userRating: Int = 0
     var label: String?
+    var mbzAlbumId: String?
+    var mbzAlbumArtistId: String?
+    var mbzReleaseGroupId: String?
+    var playCount: Int = 0
+    var isCompilation: Bool = false
     var cachedAt: Date = Date()
 
     var songs: [CachedSong] = []
@@ -34,6 +39,43 @@ final class CachedAlbum {
         self.created = album.created
         self.userRating = album.userRating ?? 0
         self.label = album.label
+        self.mbzAlbumId = album.musicBrainzId
+    }
+
+    init(from ndAlbum: NDAlbum) {
+        self.id = ndAlbum.id
+        self.name = ndAlbum.name
+        self.artistName = ndAlbum.artist
+        self.artistId = ndAlbum.artistId
+        self.coverArtId = ndAlbum.id        // ND albums use the album id as coverArt id
+        self.year = ndAlbum.year
+        self.genre = ndAlbum.genre
+        self.songCount = ndAlbum.songCount
+        self.duration = ndAlbum.duration.map { Int($0) }
+        self.isStarred = ndAlbum.starred ?? false
+        self.userRating = ndAlbum.rating ?? 0
+        self.mbzAlbumId = ndAlbum.mbzAlbumId
+        self.mbzAlbumArtistId = ndAlbum.mbzAlbumArtistId
+        self.mbzReleaseGroupId = ndAlbum.mbzReleaseGroupId
+        self.playCount = ndAlbum.playCount ?? 0
+        self.isCompilation = ndAlbum.compilation ?? false
+    }
+
+    func update(from ndAlbum: NDAlbum) {
+        name = ndAlbum.name
+        artistId = ndAlbum.artistId
+        year = ndAlbum.year
+        genre = ndAlbum.genre
+        songCount = ndAlbum.songCount
+        duration = ndAlbum.duration.map { Int($0) }
+        isStarred = ndAlbum.starred ?? false
+        userRating = ndAlbum.rating ?? 0
+        mbzAlbumId = ndAlbum.mbzAlbumId
+        mbzAlbumArtistId = ndAlbum.mbzAlbumArtistId
+        mbzReleaseGroupId = ndAlbum.mbzReleaseGroupId
+        playCount = ndAlbum.playCount ?? 0
+        isCompilation = ndAlbum.compilation ?? false
+        cachedAt = Date()
     }
 
     /// Update existing record with fresh server data.
@@ -50,6 +92,7 @@ final class CachedAlbum {
         created = album.created
         userRating = album.userRating ?? 0
         label = album.label
+        mbzAlbumId = album.musicBrainzId
         cachedAt = Date()
     }
 
@@ -70,7 +113,7 @@ final class CachedAlbum {
             userRating: userRating > 0 ? userRating : nil,
             song: nil,
             replayGain: nil,
-            musicBrainzId: nil,
+            musicBrainzId: mbzAlbumId,
             recordLabels: label.map { [RecordLabel(name: $0)] }
         )
     }

--- a/Vibrdrome/Core/Persistence/Models/CachedSong.swift
+++ b/Vibrdrome/Core/Persistence/Models/CachedSong.swift
@@ -17,9 +17,20 @@ final class CachedSong {
     var genre: String?
     var duration: Int?
     var bitRate: Int?
+    var bitDepth: Int?
+    var samplingRate: Int?
+    var comment: String?
     var suffix: String?
     var contentType: String?
     var size: Int?
+    var bpm: Int?
+    var channels: Int?
+    var hasCoverArt: Bool = false
+    var isCompilation: Bool = false
+    var dateAdded: Date?
+    var mbzRecordingId: String?
+    var mbzArtistId: String?
+    var mbzAlbumArtistId: String?
     var isStarred: Bool = false
     var rating: Int = 0
     var lastPlayed: Date?
@@ -44,10 +55,76 @@ final class CachedSong {
         self.genre = song.genre
         self.duration = song.duration
         self.bitRate = song.bitRate
+        self.bitDepth = song.bitDepth
+        self.samplingRate = song.samplingRate
+        self.comment = song.comment
         self.suffix = song.suffix
         self.contentType = song.contentType
         self.size = song.size
+        self.bpm = song.bpm
+        self.dateAdded = song.created.flatMap { ISO8601DateFormatter().date(from: $0) }
+        self.mbzRecordingId = song.musicBrainzId
         self.isStarred = song.starred != nil
+    }
+
+    convenience init(from ndSong: NDSong) {
+        self.init(from: Song(
+            id: ndSong.id, title: ndSong.title, album: ndSong.album,
+            artist: ndSong.artist, albumArtist: ndSong.albumArtist,
+            albumId: ndSong.albumId, artistId: ndSong.artistId,
+            track: ndSong.trackNumber, year: ndSong.year, genre: ndSong.genre,
+            size: ndSong.size, suffix: ndSong.suffix,
+            duration: ndSong.duration.map { Int($0) }, bitRate: ndSong.bitRate,
+            bitDepth: ndSong.bitDepth, samplingRate: ndSong.sampleRate, comment: ndSong.comment,
+            discNumber: ndSong.discNumber, created: ndSong.createdAt,
+            starred: ndSong.starred == true ? "true" : nil,
+            userRating: ndSong.rating, bpm: ndSong.bpm,
+            musicBrainzId: ndSong.mbzReleaseTrackId
+        ))
+        self.channels = ndSong.channels
+        self.hasCoverArt = ndSong.hasCoverArt ?? false
+        self.isCompilation = ndSong.compilation ?? false
+        self.mbzArtistId = ndSong.mbzArtistId
+        self.mbzAlbumArtistId = ndSong.mbzAlbumArtistId
+        self.playCount = ndSong.playCount ?? 0
+        if let playDate = ndSong.playDate {
+            self.lastPlayed = ISO8601DateFormatter().date(from: playDate)
+        }
+    }
+
+    func update(from ndSong: NDSong) {
+        title = ndSong.title
+        artist = ndSong.artist
+        albumArtist = ndSong.albumArtist
+        albumName = ndSong.album
+        albumId = ndSong.albumId
+        artistId = ndSong.artistId
+        track = ndSong.trackNumber
+        discNumber = ndSong.discNumber
+        year = ndSong.year
+        genre = ndSong.genre
+        duration = ndSong.duration.map { Int($0) }
+        bitRate = ndSong.bitRate
+        bitDepth = ndSong.bitDepth
+        samplingRate = ndSong.sampleRate
+        channels = ndSong.channels
+        comment = ndSong.comment
+        suffix = ndSong.suffix
+        size = ndSong.size
+        bpm = ndSong.bpm
+        hasCoverArt = ndSong.hasCoverArt ?? false
+        isCompilation = ndSong.compilation ?? false
+        dateAdded = ndSong.createdAt.flatMap { ISO8601DateFormatter().date(from: $0) }
+        mbzRecordingId = ndSong.mbzReleaseTrackId
+        mbzArtistId = ndSong.mbzArtistId
+        mbzAlbumArtistId = ndSong.mbzAlbumArtistId
+        isStarred = ndSong.starred ?? false
+        rating = ndSong.rating ?? 0
+        playCount = ndSong.playCount ?? 0
+        if let playDate = ndSong.playDate {
+            lastPlayed = ISO8601DateFormatter().date(from: playDate)
+        }
+        cachedAt = Date()
     }
 
     /// Convert back to a Song value type for playback queue reconstruction.
@@ -70,14 +147,17 @@ final class CachedSong {
             suffix: suffix,
             duration: duration,
             bitRate: bitRate,
+            bitDepth: bitDepth,
+            samplingRate: samplingRate,
+            comment: comment,
             path: nil,
             discNumber: discNumber,
             created: nil,
             starred: isStarred ? "true" : nil,
             userRating: rating,
-            bpm: nil,
+            bpm: bpm,
             replayGain: nil,
-            musicBrainzId: nil
+            musicBrainzId: mbzRecordingId
         )
     }
 }

--- a/Vibrdrome/Features/Library/AlbumsView.swift
+++ b/Vibrdrome/Features/Library/AlbumsView.swift
@@ -360,6 +360,11 @@ struct AlbumsView: View {
         .onChange(of: appState.albumFilter.selectedGenres) { debouncedApplyLocalFilters() }
         .onChange(of: appState.albumFilter.selectedLabels) { debouncedApplyLocalFilters() }
         .onChange(of: appState.albumFilter.year) { debouncedApplyLocalFilters() }
+        .onChange(of: appState.albumFilter.ruleSet) { debouncedApplyLocalFilters() }
+        .onChange(of: appState.libraryCache.generation) { _, _ in
+            if appState.albumFilter.isActive { debouncedApplyLocalFilters() }
+        }
+        .onAppear { appState.activeFilterWindowContext = .album }
         #endif
     }
 
@@ -696,6 +701,7 @@ struct AlbumsView: View {
         let filter = appState.albumFilter
         guard filter.isActive else {
             localFilteredAlbums = nil
+            appState.albumFilter.matchCount = nil
             recomputeFilteredAlbums()
             return
         }
@@ -705,19 +711,19 @@ struct AlbumsView: View {
         let selectedArtistNames = selectedArtistNames(for: filter)
         let snapshot = FilterSnapshot(filter: filter)
         let allAlbums: [Album]
-        if let cachedAlbums = appState.libraryCache.albums {
-            allAlbums = cachedAlbums
-        } else {
-            do {
+        do {
+            if let cachedAlbums = appState.libraryCache.albums {
+                allAlbums = cachedAlbums
+            } else {
                 var descriptor = FetchDescriptor<CachedAlbum>()
                 descriptor.sortBy = [SortDescriptor(\.name)]
                 allAlbums = try modelContext.fetch(descriptor).map { $0.toAlbum() }
-            } catch {
-                Logger(subsystem: "com.vibrdrome.app", category: "Albums")
-                    .error("Failed to fetch albums for filter: \(error)")
-                localFilteredAlbums = nil
-                return
             }
+        } catch {
+            Logger(subsystem: "com.vibrdrome.app", category: "Albums")
+                .error("Failed to fetch albums for filter: \(error)")
+            localFilteredAlbums = nil
+            return
         }
 
         // Heavy array filtering runs off the MainActor.
@@ -734,6 +740,7 @@ struct AlbumsView: View {
 
         guard !Task.isCancelled else { return }
         localFilteredAlbums = filtered
+        appState.albumFilter.matchCount = filtered.count
         recomputeFilteredAlbums()
     }
 
@@ -759,19 +766,23 @@ struct AlbumsView: View {
     struct FilterSnapshot: Sendable {
         let isFavorited: TriState
         let isRated: TriState
+        let isRecentlyPlayed: Bool
         let selectedArtistIds: Set<String>
         let selectedGenres: Set<String>
         let selectedLabels: Set<String>
         let year: Int?
+        let ruleSet: FilterRuleSet
 
         @MainActor
         init(filter: LibraryFilter) {
             isFavorited = filter.isFavorited
             isRated = filter.isRated
+            isRecentlyPlayed = filter.isRecentlyPlayed
             selectedArtistIds = filter.selectedArtistIds
             selectedGenres = filter.selectedGenres
             selectedLabels = filter.selectedLabels
             year = filter.year
+            ruleSet = filter.ruleSet
         }
     }
 
@@ -787,22 +798,29 @@ struct AlbumsView: View {
         if !snapshot.selectedArtistIds.isEmpty {
             let matchesById = album.artistId.map { snapshot.selectedArtistIds.contains($0) } ?? false
             let matchesByName = album.artist.map { selectedArtistNames.contains($0) } ?? false
-            guard matchesById || matchesByName else {
-                return false
-            }
+            guard matchesById || matchesByName else { return false }
         }
         if !snapshot.selectedGenres.isEmpty {
-            guard let genre = album.genre, snapshot.selectedGenres.contains(genre) else {
-                return false
-            }
+            guard let genre = album.genre, snapshot.selectedGenres.contains(genre) else { return false }
         }
         if !snapshot.selectedLabels.isEmpty {
-            guard let albumLabel = album.label, snapshot.selectedLabels.contains(albumLabel) else {
-                return false
-            }
+            guard let albumLabel = album.label, snapshot.selectedLabels.contains(albumLabel) else { return false }
         }
         if let yearFilter = snapshot.year {
             guard album.year == yearFilter else { return false }
+        }
+        if !snapshot.ruleSet.isEmpty {
+            let meta = FilterRuleSet.AlbumMeta(
+                title: album.name,
+                artist: album.artist,
+                genre: album.genre,
+                label: album.label,
+                year: album.year,
+                duration: album.duration,
+                rating: album.userRating ?? 0,
+                isFavorited: album.starred != nil
+            )
+            guard snapshot.ruleSet.matches(album: meta) else { return false }
         }
         return true
     }

--- a/Vibrdrome/Features/Library/ArtistsView.swift
+++ b/Vibrdrome/Features/Library/ArtistsView.swift
@@ -235,7 +235,7 @@ struct ArtistsView: View {
             await loadArtists()
             await loadFavorites()
             #if os(macOS)
-            applyLocalFilters()
+            await applyLocalFilters()
             #endif
             recomputeFilteredIndexes()
         }
@@ -245,6 +245,11 @@ struct ArtistsView: View {
         #if os(macOS)
         .onChange(of: appState.artistFilter.isFavorited) { debouncedApplyLocalFilters() }
         .onChange(of: appState.artistFilter.selectedGenres) { debouncedApplyLocalFilters() }
+        .onChange(of: appState.artistFilter.ruleSet) { debouncedApplyLocalFilters() }
+        .onChange(of: appState.libraryCache.generation) { _, _ in
+            if appState.artistFilter.isActive { debouncedApplyLocalFilters() }
+        }
+        .onAppear { appState.activeFilterWindowContext = .artist }
         #endif
     }
 
@@ -402,71 +407,94 @@ struct ArtistsView: View {
         filterTask = Task {
             try? await Task.sleep(for: .milliseconds(150))
             guard !Task.isCancelled else { return }
-            applyLocalFilters()
+            await applyLocalFilters()
         }
     }
 
-    private func applyLocalFilters() {
+    private func applyLocalFilters() async {
         let filter = appState.artistFilter
         guard filter.isActive else {
             localFilteredArtists = nil
+            appState.artistFilter.matchCount = nil
             recomputeFilteredIndexes()
             return
         }
 
+        // Snapshot MainActor state before leaving the main thread.
+        let snapshot = ArtistFilterSnapshot(filter: filter)
+        let allArtists: [Artist]
+        let artistIdsWithMatchingGenres: Set<String>?
         do {
-            let allArtists: [Artist]
-            if let cachedArtists = appState.libraryCache.artists {
-                allArtists = cachedArtists
+            if let cached = appState.libraryCache.artists {
+                allArtists = cached
             } else {
                 var descriptor = FetchDescriptor<CachedArtist>()
                 descriptor.sortBy = [SortDescriptor(\.name)]
                 allArtists = try modelContext.fetch(descriptor).map { $0.toArtist() }
             }
-
-            // Pre-compute artist IDs that have albums matching selected genres
-            var artistIdsWithMatchingGenres: Set<String>?
+            // Pre-compute artist IDs that have albums matching selected genres.
             if !filter.selectedGenres.isEmpty {
                 let allAlbums: [Album]
-                if let cachedAlbums = appState.libraryCache.albums {
-                    allAlbums = cachedAlbums
+                if let cached = appState.libraryCache.albums {
+                    allAlbums = cached
                 } else {
-                    let albumDescriptor = FetchDescriptor<CachedAlbum>()
-                    allAlbums = try modelContext.fetch(albumDescriptor).map { $0.toAlbum() }
+                    allAlbums = try modelContext.fetch(FetchDescriptor<CachedAlbum>()).map { $0.toAlbum() }
                 }
                 var ids = Set<String>()
                 for album in allAlbums {
                     if let genre = album.genre, filter.selectedGenres.contains(genre),
-                       let artistId = album.artistId {
-                        ids.insert(artistId)
-                    }
+                       let artistId = album.artistId { ids.insert(artistId) }
                 }
                 artistIdsWithMatchingGenres = ids
+            } else {
+                artistIdsWithMatchingGenres = nil
             }
-
-            let filtered = allArtists.filter { artist in
-                // Favorited filter
-                switch filter.isFavorited {
-                case .yes: if artist.starred == nil { return false }
-                case .no: if artist.starred != nil { return false }
-                case .none: break
-                }
-
-                // Genre filter (via album lookup)
-                if let matchIds = artistIdsWithMatchingGenres {
-                    if !matchIds.contains(artist.id) { return false }
-                }
-
-                return true
-            }
-
-            localFilteredArtists = filtered
-            recomputeFilteredIndexes()
         } catch {
             Logger(subsystem: "com.vibrdrome.app", category: "Artists")
-                .error("Failed to apply local filters: \(error)")
+                .error("Failed to fetch artists for filter: \(error)")
             localFilteredArtists = nil
+            return
         }
+
+        let filtered = await Task.detached(priority: .userInitiated) {
+            allArtists.filter {
+                ArtistsView.artistMatchesFilter($0, snapshot: snapshot, genreIds: artistIdsWithMatchingGenres)
+            }
+        }.value
+
+        guard !Task.isCancelled else { return }
+        localFilteredArtists = filtered
+        appState.artistFilter.matchCount = filtered.count
+        recomputeFilteredIndexes()
+    }
+
+    struct ArtistFilterSnapshot: Sendable {
+        let isFavorited: TriState
+        let selectedGenres: Set<String>
+        let ruleSet: FilterRuleSet
+
+        @MainActor
+        init(filter: LibraryFilter) {
+            isFavorited = filter.isFavorited
+            selectedGenres = filter.selectedGenres
+            ruleSet = filter.ruleSet
+        }
+    }
+
+    nonisolated static func artistMatchesFilter(
+        _ artist: Artist, snapshot: ArtistFilterSnapshot, genreIds: Set<String>?
+    ) -> Bool {
+        switch snapshot.isFavorited {
+        case .yes: if artist.starred == nil { return false }
+        case .no: if artist.starred != nil { return false }
+        case .none: break
+        }
+        if let matchIds = genreIds, !matchIds.contains(artist.id) { return false }
+        if !snapshot.ruleSet.isEmpty {
+            let meta = FilterRuleSet.ArtistMeta(name: artist.name, genre: nil, isFavorited: artist.starred != nil)
+            if !snapshot.ruleSet.matches(artist: meta) { return false }
+        }
+        return true
     }
     #endif
 }

--- a/Vibrdrome/Features/Library/FilterContext.swift
+++ b/Vibrdrome/Features/Library/FilterContext.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// Which entity type the filter sidebar / filter window is controlling.
+enum FilterContext: String, Codable, Hashable, CaseIterable {
+    case album, artist, song
+
+    var windowTitle: String {
+        switch self {
+        case .album:  "Album Filters"
+        case .artist: "Artist Filters"
+        case .song:   "Song Filters"
+        }
+    }
+}

--- a/Vibrdrome/Features/Library/FilterRuleBuilderView.swift
+++ b/Vibrdrome/Features/Library/FilterRuleBuilderView.swift
@@ -1,0 +1,500 @@
+#if os(macOS)
+import SwiftUI
+
+/// Expandable "Advanced Filters" section rendered inside LibraryFilterSidebarView.
+/// Lets the user compose operator-based rules (including regex) targeting diverse metadata fields.
+struct FilterRuleBuilderView: View {
+    @Binding var ruleSet: FilterRuleSet
+    let allowedFields: [FilterField]
+    /// AppStorage key for persisting the expanded state across sessions.
+    let expandedKey: String
+
+    @AppStorage private var isExpanded: Bool
+    @State private var showSaveSheet = false
+
+    init(ruleSet: Binding<FilterRuleSet>, allowedFields: [FilterField], expandedKey: String) {
+        self._ruleSet = ruleSet
+        self.allowedFields = allowedFields
+        self.expandedKey = expandedKey
+        self._isExpanded = AppStorage(wrappedValue: false, expandedKey)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            expanderHeader
+            if isExpanded {
+                builderContent
+                    .padding(.top, 8)
+            }
+        }
+        .onChange(of: ruleSet.rules.count) { oldCount, newCount in
+            if oldCount == 0 && newCount == 1 {
+                withAnimation(.easeInOut(duration: 0.15)) { isExpanded = true }
+            } else if newCount == 0 {
+                withAnimation(.easeInOut(duration: 0.15)) { isExpanded = false }
+            }
+        }
+    }
+
+    // MARK: - Expander Header
+
+    private var expanderHeader: some View {
+        Button {
+            withAnimation(.easeInOut(duration: 0.15)) { isExpanded.toggle() }
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                Text("Advanced Filters")
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                Spacer()
+                let activeCount = ruleSet.rules.filter { !$0.isEffectivelyEmpty }.count
+                if activeCount > 0 {
+                    Text("\(activeCount)")
+                        .font(.caption2)
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 2)
+                        .background(Color.accentColor.opacity(0.2))
+                        .clipShape(Capsule())
+                        .foregroundStyle(Color.accentColor)
+                }
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Builder Content
+
+    private var builderContent: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            if ruleSet.rules.count > 1 {
+                combinatorPicker
+            }
+
+            if ruleSet.rules.isEmpty {
+                Text("No rules yet — click + to add one.")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding(.vertical, 6)
+            } else {
+                ForEach($ruleSet.rules) { $rule in
+                    RuleRowView(rule: $rule, allowedFields: allowedFields) {
+                        ruleSet.rules.removeAll { $0.id == rule.id }
+                    }
+                }
+            }
+
+            addRuleButton
+
+            if !ruleSet.isEmpty {
+                Divider().padding(.vertical, 4)
+                saveAsSmartPlaylistButton
+            }
+        }
+        .padding(.horizontal, 2)
+        .sheet(isPresented: $showSaveSheet) {
+            SaveSmartPlaylistSheet(ruleSet: ruleSet)
+        }
+    }
+
+    // MARK: - Combinator Picker
+
+    private var combinatorPicker: some View {
+        HStack(spacing: 4) {
+            Text("Match")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Picker("", selection: $ruleSet.combinator) {
+                Text("ALL rules").tag(FilterRuleSet.Combinator.all)
+                Text("ANY rule").tag(FilterRuleSet.Combinator.any)
+            }
+            .pickerStyle(.menu)
+            .controlSize(.mini)
+            .labelsHidden()
+            .frame(maxWidth: 110)
+        }
+    }
+
+    // MARK: - Save as Smart Playlist
+
+    private var saveAsSmartPlaylistButton: some View {
+        Button {
+            showSaveSheet = true
+        } label: {
+            Label("Save as Smart Playlist…", systemImage: "sparkles")
+                .font(.caption)
+                .foregroundStyle(Color.accentColor)
+        }
+        .buttonStyle(.plain)
+        .help("Save these filter rules as a Navidrome Smart Playlist")
+    }
+
+    // MARK: - Add Rule Button
+
+    private var addRuleButton: some View {
+        Button {
+            let defaultField = allowedFields.first ?? .title
+            let defaultOp = FilterOperator.allowed(for: defaultField.kind).first ?? .contains
+            ruleSet.rules.append(
+                FilterRule(field: defaultField, operator: defaultOp, value: .defaultValue(for: defaultField.kind))
+            )
+        } label: {
+            Label("Add Rule", systemImage: "plus.circle")
+                .font(.caption)
+                .foregroundStyle(Color.accentColor)
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Individual Rule Row
+
+private struct RuleRowView: View {
+    @Binding var rule: FilterRule
+    let allowedFields: [FilterField]
+    let onRemove: () -> Void
+
+    /// Local draft buffers — updated every keystroke, committed to rule.value after debounce.
+    @State private var draftText: String = ""
+    @State private var draftNumber: Int = 0
+    @State private var draftRangeLo: Int = 0
+    @State private var draftRangeHi: Int = 0
+    @State private var debounceTask: Task<Void, Never>?
+    /// Non-nil means the regex pattern is currently invalid.
+    @State private var regexError: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 4) {
+                fieldPicker
+                operatorPicker
+                Spacer()
+                removeButton
+            }
+            valuePicker
+            if let err = regexError {
+                Text(err)
+                    .font(.caption2)
+                    .foregroundStyle(.red)
+                    .lineLimit(2)
+            }
+        }
+        .padding(6)
+        .background(Color(nsColor: .controlBackgroundColor).opacity(0.6))
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+    }
+
+    // MARK: Pickers
+
+    private var fieldPicker: some View {
+        Picker("", selection: $rule.field) {
+            ForEach(allowedFields, id: \.self) { field in
+                Text(field.displayName).tag(field)
+            }
+        }
+        .pickerStyle(.menu)
+        .controlSize(.mini)
+        .labelsHidden()
+        .onChange(of: rule.field) { _, newField in
+            debounceTask?.cancel()
+            let allowedOps = FilterOperator.allowed(for: newField.kind)
+            if !allowedOps.contains(rule.operator) {
+                rule.operator = allowedOps[0]
+            }
+            rule.value = .defaultValue(for: newField.kind)
+            regexError = nil
+            syncDraftsFromRule()
+        }
+    }
+
+    private var operatorPicker: some View {
+        let ops = FilterOperator.allowed(for: rule.field.kind)
+        return Picker("", selection: $rule.operator) {
+            ForEach(ops, id: \.self) { op in
+                Text(op.displayName).tag(op)
+            }
+        }
+        .pickerStyle(.menu)
+        .controlSize(.mini)
+        .labelsHidden()
+        .onChange(of: rule.operator) { _, newOp in
+            if newOp == .isBetween, case .number(let n) = rule.value {
+                rule.value = .range(n, n)
+                draftRangeLo = n; draftRangeHi = n
+            } else if newOp != .isBetween, case .range(let lo, _) = rule.value {
+                rule.value = .number(lo)
+                draftNumber = lo
+            }
+            if newOp != .matchesRegex { regexError = nil }
+        }
+    }
+
+    private var removeButton: some View {
+        Button(action: onRemove) {
+            Image(systemName: "minus.circle")
+                .foregroundStyle(.secondary)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Remove rule")
+    }
+
+    // MARK: Value Input
+
+    @ViewBuilder
+    private var valuePicker: some View {
+        switch rule.field.kind {
+        case .text:    textValueInput
+        case .numeric: numericValueInput
+        case .days:    daysValueInput
+        case .boolean: booleanValueInput
+        case .playlist: textValueInput
+        }
+    }
+
+    // MARK: Text Input
+
+    @ViewBuilder
+    private var textValueInput: some View {
+        HStack(spacing: 4) {
+            TextField(rule.operator == .matchesRegex ? "/pattern/flags or pattern…" : "value…", text: $draftText)
+                .textFieldStyle(.roundedBorder)
+                .font(.caption)
+                .onChange(of: draftText) { _, newText in scheduleCommit { .text(newText) }
+                    if rule.operator == .matchesRegex { scheduleRegexValidation(newText) }
+                }
+                .onAppear { syncDraftsFromRule() }
+            if rule.operator == .matchesRegex {
+                Image(systemName: regexError == nil ? "checkmark.circle" : "exclamationmark.circle")
+                    .font(.caption)
+                    .foregroundStyle(regexError == nil ? Color.green : Color.red)
+                    .opacity(draftText.isEmpty ? 0 : 1)
+            }
+        }
+    }
+
+    // MARK: Numeric Inputs
+
+    @ViewBuilder
+    private var numericValueInput: some View {
+        if rule.operator == .isBetween {
+            rangeInput
+        } else {
+            singleNumberInput
+        }
+    }
+
+    private var singleNumberInput: some View {
+        TextField("0", value: $draftNumber, format: .number.grouping(.never))
+            .textFieldStyle(.roundedBorder)
+            .font(.caption)
+            .frame(maxWidth: 90)
+            .onAppear { syncDraftsFromRule() }
+            .onChange(of: draftNumber) { _, n in scheduleCommit { .number(n) } }
+    }
+
+    private var rangeInput: some View {
+        HStack(alignment: .center, spacing: 4) {
+            TextField("from", value: $draftRangeLo, format: .number.grouping(.never))
+                .textFieldStyle(.roundedBorder).font(.caption).frame(maxWidth: 60)
+                .onAppear { syncDraftsFromRule() }
+                .onChange(of: draftRangeLo) { _, lo in scheduleCommit { .range(lo, self.draftRangeHi) } }
+            Text("–").font(.caption).foregroundStyle(.secondary)
+            TextField("to", value: $draftRangeHi, format: .number.grouping(.never))
+                .textFieldStyle(.roundedBorder).font(.caption).frame(maxWidth: 60)
+                .onChange(of: draftRangeHi) { _, hi in scheduleCommit { .range(self.draftRangeLo, hi) } }
+        }
+    }
+
+    // MARK: Days Input
+
+    private var daysValueInput: some View {
+        HStack(spacing: 4) {
+            TextField("30", value: $draftNumber, format: .number.grouping(.never))
+                .textFieldStyle(.roundedBorder)
+                .font(.caption)
+                .frame(maxWidth: 70)
+                .onAppear { syncDraftsFromRule() }
+                .onChange(of: draftNumber) { _, n in scheduleCommit { .number(n) } }
+            Text("days").font(.caption).foregroundStyle(.secondary)
+        }
+    }
+
+    // MARK: Boolean Input
+
+    private var booleanValueInput: some View {
+        let binding = Binding<Bool>(
+            get: { if case .boolean(let b) = rule.value { return b }; return true },
+            set: { rule.value = .boolean($0) }
+        )
+        return Picker("", selection: binding) {
+            Text("Yes").tag(true)
+            Text("No").tag(false)
+        }
+        .pickerStyle(.segmented)
+        .controlSize(.mini)
+        .labelsHidden()
+        .frame(maxWidth: 100)
+    }
+
+    // MARK: Debounce Helpers
+
+    private func scheduleCommit(_ makeValue: @escaping @Sendable () -> FilterValue) {
+        debounceTask?.cancel()
+        debounceTask = Task {
+            try? await Task.sleep(for: .milliseconds(300))
+            guard !Task.isCancelled else { return }
+            rule.value = makeValue()
+        }
+    }
+
+    private func scheduleRegexValidation(_ pattern: String) {
+        guard !pattern.isEmpty else { regexError = nil; return }
+        debounceTask?.cancel()
+        debounceTask = Task {
+            try? await Task.sleep(for: .milliseconds(300))
+            guard !Task.isCancelled else { return }
+            rule.value = .text(pattern)
+            let (rawPattern, options) = FilterRule.parseRegexLiteral(pattern)
+            do {
+                _ = try NSRegularExpression(pattern: rawPattern, options: options)
+                regexError = nil
+            } catch {
+                regexError = "⚠ \(error.localizedDescription)"
+            }
+        }
+    }
+
+    private func syncDraftsFromRule() {
+        switch rule.value {
+        case .text(let s):       draftText = s
+        case .number(let n):     draftNumber = n
+        case .range(let lo, let hi): draftRangeLo = lo; draftRangeHi = hi
+        case .boolean:           break
+        }
+        regexError = nil
+    }
+}
+
+// MARK: - Save Smart Playlist Sheet
+
+private struct SaveSmartPlaylistSheet: View {
+    @Environment(AppState.self) private var appState
+    @Environment(\.dismiss) private var dismiss
+
+    let ruleSet: FilterRuleSet
+
+    @State private var name = ""
+    @State private var comment = ""
+    @State private var isSaving = false
+    @State private var errorMessage: String?
+    @State private var didSave = false
+
+    private var activeRuleCount: Int { ruleSet.rules.filter { !$0.isEffectivelyEmpty }.count }
+    private var canSave: Bool { !name.trimmingCharacters(in: .whitespaces).isEmpty && !isSaving }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Save as Smart Playlist")
+                .font(.headline)
+
+            if let ndClient = appState.navidromeClient {
+                if ndClient.isAvailable {
+                    formContent
+                } else {
+                    unavailableView
+                }
+            } else {
+                unavailableView
+            }
+
+            Spacer(minLength: 0)
+
+            if let error = errorMessage {
+                Text(error)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+            }
+
+            HStack {
+                Button("Cancel") { dismiss() }
+                    .keyboardShortcut(.cancelAction)
+                Spacer()
+                if !didSave {
+                    Button("Save") { save() }
+                        .keyboardShortcut(.defaultAction)
+                        .disabled(!canSave)
+                } else {
+                    Label("Saved", systemImage: "checkmark.circle.fill")
+                        .foregroundStyle(.green)
+                        .font(.callout)
+                }
+            }
+        }
+        .padding(24)
+        .frame(minWidth: 340, minHeight: 200)
+    }
+
+    private var formContent: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Name").font(.caption).foregroundStyle(.secondary)
+                TextField("Smart Playlist Name", text: $name)
+                    .textFieldStyle(.roundedBorder)
+            }
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Description (optional)").font(.caption).foregroundStyle(.secondary)
+                TextField("", text: $comment)
+                    .textFieldStyle(.roundedBorder)
+            }
+            Text("\(activeRuleCount) rule\(activeRuleCount == 1 ? "" : "s") will be saved")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var unavailableView: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.title2)
+                .foregroundStyle(.orange)
+            Text("Navidrome Smart Playlists are not available.")
+                .font(.callout)
+            Text("Connect to a Navidrome server to use this feature.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 8)
+    }
+
+    private func save() {
+        guard let ndClient = appState.navidromeClient, canSave else { return }
+        let trimmedName = name.trimmingCharacters(in: .whitespaces)
+        let criteria = NSPCriteria(from: ruleSet)
+        isSaving = true
+        errorMessage = nil
+
+        Task {
+            do {
+                try await ndClient.createSmartPlaylist(name: trimmedName, comment: comment, rules: criteria)
+                await MainActor.run {
+                    isSaving = false
+                    didSave = true
+                }
+                try? await Task.sleep(for: .seconds(1.2))
+                await MainActor.run { dismiss() }
+            } catch {
+                await MainActor.run {
+                    isSaving = false
+                    errorMessage = error.localizedDescription
+                }
+            }
+        }
+    }
+}
+#endif

--- a/Vibrdrome/Features/Library/LibraryFilterSidebarView.swift
+++ b/Vibrdrome/Features/Library/LibraryFilterSidebarView.swift
@@ -2,18 +2,16 @@
 import SwiftUI
 import SwiftData
 
-/// Which entity type the filter sidebar is controlling.
-enum FilterContext {
-    case album, artist, song
-}
-
-/// Feishin-style filter sidebar shown as a macOS side panel.
+/// Feishin-style filter sidebar shown as a macOS side panel or a standalone window.
 /// Adapts its controls based on the entity type being filtered.
 struct LibraryFilterSidebarView: View {
     let context: FilterContext
+    /// True when rendered in a standalone window; hides the SidePanelContainer chrome.
+    var isWindow: Bool = false
 
     @Environment(AppState.self) private var appState
     @Environment(\.modelContext) private var modelContext
+    @Environment(\.openWindow) private var openWindow
     @Query(sort: \CachedArtist.name) private var artists: [CachedArtist]
     @State private var genres: [String] = []
     @State private var labels: [String] = []
@@ -26,32 +24,52 @@ struct LibraryFilterSidebarView: View {
         }
     }
 
-    private var panelTitle: String {
-        switch context {
-        case .album: "Album Filters"
-        case .artist: "Artist Filters"
-        case .song: "Song Filters"
+    var body: some View {
+        if isWindow {
+            VStack(spacing: 0) {
+                stickyHeader
+                Divider()
+                scrollableContent
+            }
+            .navigationTitle(context.windowTitle)
+            .task { loadCachedMetadata() }
+        } else {
+            SidePanelContainer(
+                title: context.windowTitle,
+                onClose: { appState.activeSidePanel = nil },
+                onPopOut: {
+                    appState.activeFilterWindowContext = context
+                    openWindow(id: "library-filter", value: context)
+                    appState.activeSidePanel = nil
+                }
+            ) {
+                VStack(spacing: 0) {
+                    stickyHeader
+                    Divider()
+                    scrollableContent
+                }
+            }
+            .task { loadCachedMetadata() }
         }
     }
 
-    var body: some View {
-        SidePanelContainer(title: panelTitle, onClose: {
-            appState.activeSidePanel = nil
-        }) {
-            ScrollView {
-                VStack(alignment: .leading, spacing: 16) {
-                    headerButtons
+    private var stickyHeader: some View {
+        headerButtons
+            .padding(.horizontal, 14)
+            .padding(.vertical, 8)
+    }
 
-                    if appState.librarySyncManager.lastSyncDate == nil {
-                        syncRequiredView
-                    } else {
-                        filterControls
-                    }
+    private var scrollableContent: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                if appState.librarySyncManager.lastSyncDate == nil {
+                    syncRequiredView
+                } else {
+                    filterControls
                 }
-                .padding(14)
             }
+            .padding(14)
         }
-        .task { loadCachedMetadata() }
     }
 
     // MARK: - Header
@@ -60,9 +78,17 @@ struct LibraryFilterSidebarView: View {
     private var headerButtons: some View {
         HStack {
             if filter.isActive {
-                Text("\(filter.activeFilterCount) active")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                if let count = filter.matchCount {
+                    Text("\(count) result\(count == 1 ? "" : "s")")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .contentTransition(.numericText())
+                        .animation(.easeInOut(duration: 0.2), value: count)
+                } else {
+                    Text("\(filter.activeFilterCount) filter\(filter.activeFilterCount == 1 ? "" : "s") active")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
             }
             Spacer()
             Button("Reset") {
@@ -94,6 +120,7 @@ struct LibraryFilterSidebarView: View {
                 Task {
                     await appState.librarySyncManager.sync(
                         client: appState.subsonicClient,
+                        ndClient: appState.navidromeClient,
                         container: PersistenceController.shared.container
                     )
                     loadCachedMetadata()
@@ -156,6 +183,36 @@ struct LibraryFilterSidebarView: View {
         if context == .album || context == .song {
             Divider()
             yearFilter
+        }
+
+        Divider()
+        advancedFilterSection
+    }
+
+    // MARK: - Advanced Filter Builder
+
+    @ViewBuilder
+    private var advancedFilterSection: some View {
+        @Bindable var state = appState
+        switch context {
+        case .album:
+            FilterRuleBuilderView(
+                ruleSet: $state.albumFilter.ruleSet,
+                allowedFields: FilterField.albumFields,
+                expandedKey: UserDefaultsKeys.albumFilterRuleBuilderExpanded
+            )
+        case .song:
+            FilterRuleBuilderView(
+                ruleSet: $state.songFilter.ruleSet,
+                allowedFields: FilterField.songFields,
+                expandedKey: UserDefaultsKeys.songFilterRuleBuilderExpanded
+            )
+        case .artist:
+            FilterRuleBuilderView(
+                ruleSet: $state.artistFilter.ruleSet,
+                allowedFields: FilterField.artistFields,
+                expandedKey: UserDefaultsKeys.artistFilterRuleBuilderExpanded
+            )
         }
     }
 

--- a/Vibrdrome/Features/Library/SongsView.swift
+++ b/Vibrdrome/Features/Library/SongsView.swift
@@ -108,12 +108,17 @@ struct SongsView: View {
             refreshTitleSongCount()
         }
         #if os(macOS)
+        .onChange(of: appState.libraryCache.generation) { _, _ in
+            if appState.songFilter.isActive { debouncedApplyLocalFilters() }
+        }
         .onChange(of: appState.songFilter.isFavorited) { debouncedApplyLocalFilters() }
         .onChange(of: appState.songFilter.isRated) { debouncedApplyLocalFilters() }
         .onChange(of: appState.songFilter.isRecentlyPlayed) { debouncedApplyLocalFilters() }
         .onChange(of: appState.songFilter.selectedArtistIds) { debouncedApplyLocalFilters() }
         .onChange(of: appState.songFilter.selectedGenres) { debouncedApplyLocalFilters() }
         .onChange(of: appState.songFilter.year) { debouncedApplyLocalFilters() }
+        .onChange(of: appState.songFilter.ruleSet) { debouncedApplyLocalFilters() }
+        .onAppear { appState.activeFilterWindowContext = .song }
         #endif
     }
 
@@ -535,7 +540,7 @@ struct SongsView: View {
         await loadGenres()
         refreshTitleSongCount()
         #if os(macOS)
-        applyLocalFilters()
+        await applyLocalFilters()
         #endif
         recomputeDisplayedSongs()
     }
@@ -682,36 +687,66 @@ struct SongsView: View {
         filterTask = Task {
             try? await Task.sleep(for: .milliseconds(150))
             guard !Task.isCancelled else { return }
-            applyLocalFilters()
+            await applyLocalFilters()
         }
     }
 
-    private func applyLocalFilters() {
+    private func applyLocalFilters() async {
         let filter = appState.songFilter
         guard filter.isActive else {
             localFilteredSongs = nil
+            appState.songFilter.matchCount = nil
             recomputeDisplayedSongs()
             return
         }
 
+        // Snapshot MainActor state before leaving the main thread.
+        let snapshot = SongFilterSnapshot(filter: filter)
+        let allSongs: [Song]
+        let cachedExtras: [String: CachedSongExtras]
+        let recentSongIds: Set<String>?
         do {
-            let allSongs: [Song]
-            if let cachedSongs = appState.libraryCache.songs {
-                allSongs = cachedSongs
+            if let cached = appState.libraryCache.songs {
+                allSongs = cached
             } else {
                 var descriptor = FetchDescriptor<CachedSong>()
                 descriptor.sortBy = [SortDescriptor(\.title)]
                 allSongs = try modelContext.fetch(descriptor).map { $0.toSong() }
             }
-
-            let recentSongIds = recentlyPlayedSongIds(for: filter)
-            localFilteredSongs = allSongs.filter { songMatchesFilter($0, filter: filter, recentIds: recentSongIds) }
-            recomputeDisplayedSongs()
+            // Build extras lookup only when rule-set fields require SwiftData fields
+            // (playCount, albumRating, albumFavorited, dateAdded, isDownloaded).
+            if filter.ruleSet.needsCachedSong {
+                let all = try modelContext.fetch(FetchDescriptor<CachedSong>())
+                cachedExtras = Dictionary(uniqueKeysWithValues: all.map {
+                    ($0.id, CachedSongExtras(
+                        playCount: $0.playCount,
+                        albumRating: $0.album?.userRating ?? 0,
+                        albumFavorited: $0.album?.isStarred ?? false,
+                        isDownloaded: $0.download != nil,
+                        dateAdded: $0.dateAdded
+                    ))
+                })
+            } else {
+                cachedExtras = [:]
+            }
+            recentSongIds = recentlyPlayedSongIds(for: filter)
         } catch {
             Logger(subsystem: "com.vibrdrome.app", category: "Songs")
-                .error("Failed to apply local filters: \(error)")
+                .error("Failed to fetch songs for filter: \(error)")
             localFilteredSongs = nil
+            return
         }
+
+        let filtered = await Task.detached(priority: .userInitiated) {
+            allSongs.filter {
+                SongsView.songMatchesFilter($0, snapshot: snapshot, recentIds: recentSongIds, extras: cachedExtras)
+            }
+        }.value
+
+        guard !Task.isCancelled else { return }
+        localFilteredSongs = filtered
+        appState.songFilter.matchCount = filtered.count
+        recomputeDisplayedSongs()
     }
 
     private func recentlyPlayedSongIds(for filter: LibraryFilter) -> Set<String>? {
@@ -720,28 +755,87 @@ struct SongsView: View {
         let descriptor = FetchDescriptor<CachedSong>(
             predicate: #Predicate { $0.lastPlayed != nil && $0.lastPlayed! > cutoff }
         )
-        let recentSongs = (try? modelContext.fetch(descriptor)) ?? []
-        return Set(recentSongs.map(\.id))
+        return Set((try? modelContext.fetch(descriptor))?.map(\.id) ?? [])
     }
 
-    private func songMatchesFilter(
-        _ song: Song, filter: LibraryFilter, recentIds: Set<String>?
+    struct CachedSongExtras: Sendable {
+        let playCount: Int
+        let albumRating: Int
+        let albumFavorited: Bool
+        let isDownloaded: Bool
+        let dateAdded: Date?
+    }
+
+    struct SongFilterSnapshot: Sendable {
+        let isFavorited: TriState
+        let isRated: TriState
+        let isRecentlyPlayed: Bool
+        let selectedArtistIds: Set<String>
+        let selectedGenres: Set<String>
+        let year: Int?
+        let ruleSet: FilterRuleSet
+
+        @MainActor
+        init(filter: LibraryFilter) {
+            isFavorited = filter.isFavorited
+            isRated = filter.isRated
+            isRecentlyPlayed = filter.isRecentlyPlayed
+            selectedArtistIds = filter.selectedArtistIds
+            selectedGenres = filter.selectedGenres
+            year = filter.year
+            ruleSet = filter.ruleSet
+        }
+    }
+
+    nonisolated static func songMatchesFilter(
+        _ song: Song, snapshot: SongFilterSnapshot,
+        recentIds: Set<String>?, extras: [String: CachedSongExtras]
     ) -> Bool {
-        guard filter.isFavorited.matches(song.starred != nil) else { return false }
-        guard filter.isRated.matches((song.userRating ?? 0) != 0) else { return false }
+        guard snapshot.isFavorited.matches(song.starred != nil) else { return false }
+        guard snapshot.isRated.matches((song.userRating ?? 0) != 0) else { return false }
         if let recentIds, !recentIds.contains(song.id) { return false }
-        if !filter.selectedArtistIds.isEmpty {
-            guard let artistId = song.artistId, filter.selectedArtistIds.contains(artistId) else {
-                return false
-            }
+        if !snapshot.selectedArtistIds.isEmpty {
+            guard let artistId = song.artistId, snapshot.selectedArtistIds.contains(artistId) else { return false }
         }
-        if !filter.selectedGenres.isEmpty {
-            guard let genre = song.genre, filter.selectedGenres.contains(genre) else {
-                return false
-            }
+        if !snapshot.selectedGenres.isEmpty {
+            guard let genre = song.genre, snapshot.selectedGenres.contains(genre) else { return false }
         }
-        if let yearFilter = filter.year {
+        if let yearFilter = snapshot.year {
             guard song.year == yearFilter else { return false }
+        }
+        if !snapshot.ruleSet.isEmpty {
+            let extra = extras[song.id]
+            let meta = FilterRuleSet.SongMeta(
+                title: song.title,
+                artist: song.artist,
+                albumTitle: song.album,
+                genre: song.genre,
+                label: nil,
+                suffix: song.suffix,
+                contentType: song.contentType,
+                comment: song.comment,
+                year: song.year,
+                duration: song.duration,
+                bitRate: song.bitRate,
+                bitDepth: song.bitDepth,
+                samplingRate: song.samplingRate,
+                bpm: song.bpm,
+                playCount: extra?.playCount ?? 0,
+                rating: song.userRating ?? 0,
+                albumRating: extra?.albumRating ?? 0,
+                trackNumber: song.track,
+                discNumber: song.discNumber,
+                isFavorited: song.starred != nil,
+                albumFavorited: extra?.albumFavorited ?? false,
+                isDownloaded: extra?.isDownloaded ?? false,
+                hasCoverArt: song.coverArt != nil,
+                isCompilation: false,
+                size: song.size,
+                channels: nil,
+                mbzRecordingId: song.musicBrainzId,
+                dateAdded: extra?.dateAdded
+            )
+            guard snapshot.ruleSet.matches(song: meta) else { return false }
         }
         return true
     }

--- a/Vibrdrome/Features/Player/SidePanels.swift
+++ b/Vibrdrome/Features/Player/SidePanels.swift
@@ -8,6 +8,7 @@ import os.log
 struct SidePanelContainer<Content: View>: View {
     let title: String
     let onClose: () -> Void
+    var onPopOut: (() -> Void)?
     @ViewBuilder let content: () -> Content
 
     var body: some View {
@@ -16,6 +17,15 @@ struct SidePanelContainer<Content: View>: View {
                 Text(title)
                     .font(.headline)
                 Spacer()
+                if let onPopOut {
+                    Button(action: onPopOut) {
+                        Image(systemName: "arrow.up.forward.app")
+                            .font(.title3)
+                            .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Pop out \(title)")
+                }
                 Button {
                     onClose()
                 } label: {

--- a/Vibrdrome/Features/Playlists/PlaylistDetailView.swift
+++ b/Vibrdrome/Features/Playlists/PlaylistDetailView.swift
@@ -11,6 +11,10 @@ struct PlaylistDetailView: View {
     @State private var error: String?
     @State private var showEditSheet = false
     @State private var isDownloading = false
+    @State private var smartPlaylistRules: NSPCriteria?
+    @State private var isSmartPlaylist = false
+    @State private var isLoadingSmartRules = false
+    @State private var didDetectSmartPlaylist = false
     @State private var searchText = ""
     @State private var m3uFileURL: URL?
     @State private var showShareSheet = false
@@ -18,10 +22,17 @@ struct PlaylistDetailView: View {
     @State private var isSelecting = false
     @State private var showBatchAddToPlaylist = false
     @State private var showRemoveOfflineConfirmation = false
+    /// Active view mode for smart playlists: songs list or album grid.
+    @State private var smartViewMode: SmartPlaylistViewMode = .songs
     @Query private var downloadedSongs: [DownloadedSong]
     #if os(macOS)
     @State private var columnSettings = TrackTableColumnSettings(viewKey: "playlist")
     #endif
+
+    enum SmartPlaylistViewMode: String, CaseIterable {
+        case songs = "Songs"
+        case albums = "Albums"
+    }
 
     private var filteredSongs: [Song] {
         guard let songs = playlist?.entry else { return [] }
@@ -30,6 +41,22 @@ struct PlaylistDetailView: View {
             $0.title.localizedCaseInsensitiveContains(searchText) ||
             ($0.artist ?? "").localizedCaseInsensitiveContains(searchText)
         }
+    }
+
+    /// Songs grouped by album for the Albums view. Preserves playlist order within each album.
+    private var songsByAlbum: [(albumName: String, albumId: String?, songs: [Song])] {
+        var seen: [String: Int] = [:]
+        var groups: [(albumName: String, albumId: String?, songs: [Song])] = []
+        for song in filteredSongs {
+            let key = song.album ?? "Unknown Album"
+            if let idx = seen[key] {
+                groups[idx].songs.append(song)
+            } else {
+                seen[key] = groups.count
+                groups.append((albumName: key, albumId: song.albumId, songs: [song]))
+            }
+        }
+        return groups
     }
 
     var body: some View {
@@ -46,6 +73,14 @@ struct PlaylistDetailView: View {
                             .bold()
 
                         HStack(spacing: 8) {
+                            if isSmartPlaylist {
+                                Label("Smart Playlist", systemImage: "sparkles")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                Text("·")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
                             Text(verbatim: "\(playlist.songCount ?? 0) songs")
                             if let duration = playlist.duration {
                                 Text("·")
@@ -54,6 +89,16 @@ struct PlaylistDetailView: View {
                         }
                         .font(.caption)
                         .foregroundStyle(.secondary)
+
+                        if isSmartPlaylist {
+                            Picker("View", selection: $smartViewMode) {
+                                ForEach(SmartPlaylistViewMode.allCases, id: \.self) {
+                                    Text($0.rawValue).tag($0)
+                                }
+                            }
+                            .pickerStyle(.segmented)
+                            .frame(maxWidth: 200)
+                        }
 
                         // Action buttons
                         HStack(spacing: 16) {
@@ -111,55 +156,56 @@ struct PlaylistDetailView: View {
                     .padding(.vertical, 12)
                 }
 
-                // Songs
-                Section {
-                    #if os(macOS)
-                    MacTrackTableView(songs: filteredSongs, settings: columnSettings)
-                        .listRowInsets(EdgeInsets())
-                        .listRowSeparator(.hidden)
-                    #else
-                    ForEach(Array(filteredSongs.enumerated()), id: \.element.id) { index, song in
-                        HStack(spacing: 0) {
-                            if isSelecting {
-                                Button {
-                                    toggleSelection(song.id)
-                                } label: {
-                                    Image(systemName: selectedSongs.contains(song.id)
-                                          ? "checkmark.circle.fill" : "circle")
-                                        .foregroundStyle(selectedSongs.contains(song.id)
-                                                         ? Color.accentColor : .secondary)
-                                        .font(.title3)
-                                }
-                                .buttonStyle(.plain)
-                                .padding(.trailing, 8)
-                            }
-
-                            TrackRow(song: song, showTrackNumber: false)
-                                .contentShape(Rectangle())
-                                .onTapGesture {
-                                    if isSelecting {
+                // Songs or Albums view
+                if isSmartPlaylist && smartViewMode == .albums {
+                    smartAlbumsSection
+                } else {
+                    Section {
+                        #if os(macOS)
+                        MacTrackTableView(songs: filteredSongs, settings: columnSettings)
+                            .listRowInsets(EdgeInsets())
+                            .listRowSeparator(.hidden)
+                        #else
+                        ForEach(Array(filteredSongs.enumerated()), id: \.element.id) { index, song in
+                            HStack(spacing: 0) {
+                                if isSelecting {
+                                    Button {
                                         toggleSelection(song.id)
-                                    } else {
-                                        playFromPlaylist(song: song, songs: filteredSongs, index: index)
+                                    } label: {
+                                        Image(systemName: selectedSongs.contains(song.id)
+                                              ? "checkmark.circle.fill" : "circle")
+                                            .foregroundStyle(selectedSongs.contains(song.id)
+                                                             ? Color.accentColor : .secondary)
+                                            .font(.title3)
                                     }
+                                    .buttonStyle(.plain)
+                                    .padding(.trailing, 8)
                                 }
-                                .trackContextMenu(song: song, queue: filteredSongs, index: index)
+
+                                TrackRow(song: song, showTrackNumber: false)
+                                    .contentShape(Rectangle())
+                                    .onTapGesture {
+                                        if isSelecting {
+                                            toggleSelection(song.id)
+                                        } else {
+                                            playFromPlaylist(song: song, songs: filteredSongs, index: index)
+                                        }
+                                    }
+                                    .trackContextMenu(song: song, queue: filteredSongs, index: index)
+                            }
                         }
+                        .onDelete(perform: isSmartPlaylist ? nil : { offsets in
+                            let allSongs = playlist.entry ?? []
+                            let filtered = filteredSongs
+                            let originalIndices = offsets.compactMap { offset -> Int? in
+                                guard offset < filtered.count else { return nil }
+                                let songId = filtered[offset].id
+                                return allSongs.firstIndex(where: { $0.id == songId })
+                            }
+                            removeFromPlaylist(at: IndexSet(originalIndices), songs: allSongs)
+                        })
+                        #endif
                     }
-                    .onDelete { offsets in
-                        // Map filtered indices to original playlist indices
-                        let allSongs = playlist.entry ?? []
-                        let filtered = filteredSongs
-                        let originalIndices = offsets.compactMap { offset -> Int? in
-                            guard offset < filtered.count else { return nil }
-                            let songId = filtered[offset].id
-                            return allSongs.firstIndex(where: { $0.id == songId })
-                        }
-                        removeFromPlaylist(
-                            at: IndexSet(originalIndices), songs: allSongs
-                        )
-                    }
-                    #endif
                 }
 
                 // Batch action bar
@@ -196,10 +242,16 @@ struct PlaylistDetailView: View {
                 ToolbarItem(placement: .primaryAction) {
                     Menu {
                         Button {
-                            showEditSheet = true
+                            openEditSheet()
                         } label: {
-                            Label("Edit Playlist", systemImage: "pencil")
+                            if isLoadingSmartRules {
+                                Label("Loading…", systemImage: "arrow.clockwise")
+                            } else {
+                                Label(isSmartPlaylist ? "Edit Smart Playlist" : "Edit Playlist",
+                                      systemImage: isSmartPlaylist ? "sparkles" : "pencil")
+                            }
                         }
+                        .disabled(isLoadingSmartRules)
 
                         Button {
                             if let songs = playlist?.entry, !songs.isEmpty {
@@ -299,7 +351,11 @@ struct PlaylistDetailView: View {
         .sheet(isPresented: $showEditSheet) {
             if let playlist {
                 PlaylistEditorView(
-                    mode: .edit(playlistId: playlist.id, currentName: playlist.name)
+                    mode: isSmartPlaylist
+                        ? .smartPlaylist(playlistId: playlist.id,
+                                         currentName: playlist.name,
+                                         existingRules: smartPlaylistRules)
+                        : .edit(playlistId: playlist.id, currentName: playlist.name)
                 ) {
                     await loadPlaylist()
                 }
@@ -331,6 +387,68 @@ struct PlaylistDetailView: View {
         .refreshable { await loadPlaylist() }
     }
 
+    @ViewBuilder
+    private var smartAlbumsSection: some View {
+        ForEach(songsByAlbum, id: \.albumName) { group in
+            Section {
+                ForEach(Array(group.songs.enumerated()), id: \.element.id) { index, song in
+                    TrackRow(song: song, showTrackNumber: true)
+                        .contentShape(Rectangle())
+                        .onTapGesture {
+                            playFromPlaylist(song: song, songs: group.songs, index: index)
+                        }
+                        .trackContextMenu(song: song, queue: group.songs, index: index)
+                }
+            } header: {
+                HStack(spacing: 10) {
+                    AlbumArtView(coverArtId: group.songs.first?.coverArt, size: 40, cornerRadius: 4)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(group.albumName)
+                            .font(.subheadline)
+                            .bold()
+                        if let artist = group.songs.first?.albumArtist ?? group.songs.first?.artist {
+                            Text(artist)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    Spacer()
+                    Text("\(group.songs.count)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.vertical, 4)
+            }
+        }
+    }
+
+    private func openEditSheet() {
+        if isLoadingSmartRules {
+            // Detection still in flight — wait for it
+            return
+        }
+        showEditSheet = true
+    }
+
+    /// Detect smart playlist status eagerly when the playlist loads. Runs once per view lifetime.
+    private func detectSmartPlaylist() async {
+        guard let ndClient = appState.navidromeClient, ndClient.isAvailable else {
+            didDetectSmartPlaylist = true
+            return
+        }
+        isLoadingSmartRules = true
+        defer { isLoadingSmartRules = false; didDetectSmartPlaylist = true }
+        do {
+            let playlists = try await ndClient.getPlaylists()
+            if let match = playlists.first(where: { $0.id == playlistId }) {
+                isSmartPlaylist = match.rules != nil
+                smartPlaylistRules = match.rules
+            }
+        } catch {
+            // Detection failed — treat as regular playlist
+        }
+    }
+
     private func loadPlaylist() async {
         // Show cached playlist data instantly while fetching fresh
         if playlist == nil {
@@ -345,6 +463,10 @@ struct PlaylistDetailView: View {
             if playlist == nil {
                 self.error = ErrorPresenter.userMessage(for: error)
             }
+        }
+        // Run smart playlist detection once (not on every refresh)
+        if playlist != nil && !didDetectSmartPlaylist {
+            await detectSmartPlaylist()
         }
     }
 

--- a/Vibrdrome/Features/Playlists/PlaylistEditorView.swift
+++ b/Vibrdrome/Features/Playlists/PlaylistEditorView.swift
@@ -4,6 +4,8 @@ struct PlaylistEditorView: View {
     enum Mode {
         case create
         case edit(playlistId: String, currentName: String)
+        /// Edit an existing Navidrome smart playlist — pre-loads its rules.
+        case smartPlaylist(playlistId: String, currentName: String, existingRules: NSPCriteria?)
     }
 
     let mode: Mode
@@ -17,6 +19,13 @@ struct PlaylistEditorView: View {
     @State private var selectedSongs: [Song] = []
     @State private var isSaving = false
     @State private var searchTask: Task<Void, Never>?
+    @State private var errorMessage: String?
+
+    // Smart playlist state
+    @State private var ruleSet: FilterRuleSet = .init()
+    @State private var sortEntries: [SortEntry] = []
+    @State private var limitEnabled: Bool = false
+    @State private var limit: Int = 25
 
     init(mode: Mode, onSave: (() async -> Void)? = nil) {
         self.mode = mode
@@ -26,6 +35,33 @@ struct PlaylistEditorView: View {
             self._name = State(initialValue: "")
         case .edit(_, let currentName):
             self._name = State(initialValue: currentName)
+        case .smartPlaylist(_, let currentName, let existing):
+            self._name = State(initialValue: currentName)
+            if let existing {
+                self._ruleSet = State(initialValue: FilterRuleSet(from: existing))
+                // Parse comma-separated sort string into SortEntry list.
+                // Each component is optionally prefixed with "-" (desc) or "+" (asc).
+                // A bare global `order: "desc"` with no per-field prefix flips all entries.
+                let globalDesc = (existing.order == "desc")
+                let entries: [SortEntry] = (existing.sort ?? "")
+                    .split(separator: ",")
+                    .compactMap { token -> SortEntry? in
+                        let s = token.trimmingCharacters(in: .whitespaces)
+                        guard !s.isEmpty else { return nil }
+                        if s.hasPrefix("-") {
+                            return SortEntry(field: String(s.dropFirst()), descending: true)
+                        } else if s.hasPrefix("+") {
+                            return SortEntry(field: String(s.dropFirst()), descending: false)
+                        } else {
+                            return SortEntry(field: s, descending: globalDesc)
+                        }
+                    }
+                self._sortEntries = State(initialValue: entries)
+                if let l = existing.limit, l > 0 {
+                    self._limitEnabled = State(initialValue: true)
+                    self._limit = State(initialValue: l)
+                }
+            }
         }
     }
 
@@ -36,86 +72,29 @@ struct PlaylistEditorView: View {
                     TextField("Name", text: $name, prompt: Text("My Playlist"))
                 }
 
-                if case .create = mode {
-                    Section("Add Songs") {
-                        TextField("Search songs...", text: $searchQuery)
-                            .autocorrectionDisabled()
-                            #if os(iOS)
-                            .textInputAutocapitalization(.never)
-                            #endif
-                            .onChange(of: searchQuery) { _, newValue in
-                                searchTask?.cancel()
-                                guard newValue.count >= 2 else {
-                                    searchResults = []
-                                    return
-                                }
-                                searchTask = Task {
-                                    try? await Task.sleep(for: .milliseconds(300))
-                                    guard !Task.isCancelled else { return }
-                                    let results = try? await appState.subsonicClient.search(
-                                        query: newValue, artistCount: 0, albumCount: 0, songCount: 30)
-                                    searchResults = results?.song ?? []
-                                }
-                            }
+                if isCreating {
+                    addSongsSection
+                }
 
-                        ForEach(searchResults) { song in
-                            Button {
-                                if !selectedSongs.contains(where: { $0.id == song.id }) {
-                                    selectedSongs.append(song)
-                                }
-                            } label: {
-                                HStack {
-                                    VStack(alignment: .leading, spacing: 2) {
-                                        Text(song.title)
-                                            .font(.body)
-                                            .lineLimit(1)
-                                        Text(song.artist ?? "")
-                                            .font(.caption)
-                                            .foregroundStyle(.secondary)
-                                            .lineLimit(1)
-                                    }
-                                    Spacer()
-                                    if selectedSongs.contains(where: { $0.id == song.id }) {
-                                        Image(systemName: "checkmark.circle.fill")
-                                            .foregroundStyle(.green)
-                                    } else {
-                                        Image(systemName: "plus.circle")
-                                            .foregroundStyle(.secondary)
-                                    }
-                                }
-                            }
-                            .tint(.primary)
-                        }
-                    }
+                if isSmart {
+                    smartRulesSection
+                }
 
-                    if !selectedSongs.isEmpty {
-                        Section("Selected (\(selectedSongs.count))") {
-                            ForEach(selectedSongs) { song in
-                                HStack {
-                                    VStack(alignment: .leading, spacing: 2) {
-                                        Text(song.title)
-                                            .font(.body)
-                                            .lineLimit(1)
-                                        Text(song.artist ?? "")
-                                            .font(.caption)
-                                            .foregroundStyle(.secondary)
-                                    }
-                                    Spacer()
-                                }
-                            }
-                            .onDelete { offsets in
-                                selectedSongs.remove(atOffsets: offsets)
-                            }
-                            .onMove { source, destination in
-                                selectedSongs.move(fromOffsets: source, toOffset: destination)
-                            }
-                        }
+                if let error = errorMessage {
+                    Section {
+                        Text(error)
+                            .foregroundStyle(.red)
+                            .font(.caption)
                     }
                 }
             }
-            .navigationTitle(isCreating ? "New Playlist" : "Edit Playlist")
+            .navigationTitle(navigationTitle)
             #if os(iOS)
             .navigationBarTitleDisplayMode(.inline)
+            #endif
+            #if os(macOS)
+            .formStyle(.grouped)
+            .frame(minWidth: 580, minHeight: isSmart ? 420 : 160)
             #endif
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
@@ -123,7 +102,7 @@ struct PlaylistEditorView: View {
                         .accessibilityIdentifier("playlistEditorCancelButton")
                 }
                 ToolbarItem(placement: .confirmationAction) {
-                    Button(isCreating ? "Create" : "Save") {
+                    Button(isSmart ? "Update" : (isCreating ? "Create" : "Save")) {
                         save()
                     }
                     .bold()
@@ -134,13 +113,229 @@ struct PlaylistEditorView: View {
         }
     }
 
+    // MARK: - Regular playlist song search
+
+    private var addSongsSection: some View {
+        Group {
+            Section("Add Songs") {
+                TextField("Search songs...", text: $searchQuery)
+                    .autocorrectionDisabled()
+                    #if os(iOS)
+                    .textInputAutocapitalization(.never)
+                    #endif
+                    .onChange(of: searchQuery) { _, newValue in
+                        searchTask?.cancel()
+                        guard newValue.count >= 2 else { searchResults = []; return }
+                        searchTask = Task {
+                            try? await Task.sleep(for: .milliseconds(300))
+                            guard !Task.isCancelled else { return }
+                            let results = try? await appState.subsonicClient.search(
+                                query: newValue, artistCount: 0, albumCount: 0, songCount: 30)
+                            searchResults = results?.song ?? []
+                        }
+                    }
+
+                ForEach(searchResults) { song in
+                    Button {
+                        if !selectedSongs.contains(where: { $0.id == song.id }) {
+                            selectedSongs.append(song)
+                        }
+                    } label: {
+                        HStack {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(song.title).font(.body).lineLimit(1)
+                                Text(song.artist ?? "").font(.caption).foregroundStyle(.secondary).lineLimit(1)
+                            }
+                            Spacer()
+                            Image(systemName: selectedSongs.contains(where: { $0.id == song.id })
+                                  ? "checkmark.circle.fill" : "plus.circle")
+                            .foregroundStyle(selectedSongs.contains(where: { $0.id == song.id }) ? Color.green : .secondary)
+                        }
+                    }
+                    .tint(.primary)
+                }
+            }
+
+            if !selectedSongs.isEmpty {
+                Section("Selected (\(selectedSongs.count))") {
+                    ForEach(selectedSongs) { song in
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(song.title).font(.body).lineLimit(1)
+                            Text(song.artist ?? "").font(.caption).foregroundStyle(.secondary)
+                        }
+                    }
+                    .onDelete { offsets in selectedSongs.remove(atOffsets: offsets) }
+                    .onMove { source, destination in selectedSongs.move(fromOffsets: source, toOffset: destination) }
+                }
+            }
+        }
+    }
+
+    // MARK: - Smart playlist rule builder
+
+    private var smartRulesSection: some View {
+        Section {
+            VStack(alignment: .leading, spacing: 10) {
+                HStack {
+                    Text("Match")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                    Picker("", selection: $ruleSet.combinator) {
+                        Text("ALL rules").tag(FilterRuleSet.Combinator.all)
+                        Text("ANY rule").tag(FilterRuleSet.Combinator.any)
+                    }
+                    .pickerStyle(.segmented)
+                    .labelsHidden()
+                    .frame(maxWidth: 200)
+                }
+
+                if !ruleSet.rules.isEmpty {
+                    Divider()
+                }
+
+                ForEach($ruleSet.rules) { $rule in
+                    InlineRuleRowView(rule: $rule, allowedFields: FilterField.smartPlaylistFields) {
+                        ruleSet.rules.removeAll { $0.id == rule.id }
+                    }
+                    Divider()
+                }
+
+                Button {
+                    let field = FilterField.smartPlaylistFields.first ?? .title
+                    let op = FilterOperator.allowed(for: field.kind).first ?? .contains
+                    ruleSet.rules.append(FilterRule(field: field, operator: op,
+                                                    value: .defaultValue(for: field.kind)))
+                } label: {
+                    Label("Add Rule", systemImage: "plus.circle")
+                        .font(.subheadline)
+                        .foregroundStyle(Color.accentColor)
+                }
+                .buttonStyle(.plain)
+
+                let activeCount = ruleSet.rules.filter { !$0.isEffectivelyEmpty }.count
+                if activeCount > 0 {
+                    Text("\(activeCount) active rule\(activeCount == 1 ? "" : "s")")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Divider()
+
+                // Sort — supports multiple fields, each with independent direction
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack {
+                        Text("Sort by")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        Button {
+                            sortEntries.append(SortEntry(field: NSPSortField.title.rawValue, descending: false))
+                        } label: {
+                            Label("Add Sort Field", systemImage: "plus.circle")
+                                .font(.caption)
+                                .foregroundStyle(Color.accentColor)
+                                .labelStyle(.titleAndIcon)
+                        }
+                        .buttonStyle(.plain)
+                        .disabled(sortEntries.count >= NSPSortField.allCases.count)
+                    }
+
+                    ForEach($sortEntries) { $entry in
+                        HStack(spacing: 6) {
+                            Picker("", selection: $entry.field) {
+                                ForEach(NSPSortField.allCases, id: \.rawValue) {
+                                    Text($0.displayName).tag($0.rawValue)
+                                }
+                            }
+                            .pickerStyle(.menu)
+                            .labelsHidden()
+                            .frame(width: 140)
+
+                            Picker("", selection: $entry.descending) {
+                                Text("Ascending").tag(false)
+                                Text("Descending").tag(true)
+                            }
+                            .pickerStyle(.menu)
+                            .labelsHidden()
+                            .frame(width: 130)
+                            .disabled(entry.field == NSPSortField.random.rawValue)
+
+                            Button {
+                                sortEntries.removeAll { $0.id == entry.id }
+                            } label: {
+                                Image(systemName: "minus.circle")
+                                    .foregroundStyle(.secondary)
+                            }
+                            .buttonStyle(.plain)
+
+                            Spacer()
+                        }
+                    }
+
+                    if sortEntries.isEmpty {
+                        Text("None")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                // Limit
+                HStack(spacing: 8) {
+                    Toggle(isOn: $limitEnabled) {
+                        Text("Limit to")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                    #if os(macOS)
+                    .toggleStyle(.checkbox)
+                    #endif
+
+                    if limitEnabled {
+                        TextField("", value: $limit, format: .number.grouping(.never))
+                            .textFieldStyle(.roundedBorder)
+                            .frame(width: 60)
+                        Text("songs")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    Spacer()
+                }
+            }
+            .padding(.vertical, 6)
+        } header: {
+            Label("Smart Rules", systemImage: "sparkles")
+        } footer: {
+            Text("Rules run on the server. Changes take effect on next playlist refresh.")
+                .font(.caption)
+        }
+    }
+
+    // MARK: - Helpers
+
     private var isCreating: Bool {
         if case .create = mode { return true }
         return false
     }
 
+    private var isSmart: Bool {
+        if case .smartPlaylist = mode { return true }
+        return false
+    }
+
+    private var navigationTitle: String {
+        switch mode {
+        case .create:           return "New Playlist"
+        case .edit:             return "Edit Playlist"
+        case .smartPlaylist:    return "Edit Smart Playlist"
+        }
+    }
+
+    // MARK: - Save
+
     private func save() {
         isSaving = true
+        errorMessage = nil
         Task {
             defer { isSaving = false }
             do {
@@ -156,13 +351,390 @@ struct PlaylistEditorView: View {
                         id: playlistId,
                         name: name.trimmingCharacters(in: .whitespaces)
                     )
+                case .smartPlaylist(let playlistId, _, _):
+                    guard let ndClient = appState.navidromeClient else {
+                        errorMessage = "Navidrome native API not available"
+                        return
+                    }
+                    // Navidrome supports comma-separated sort with per-field direction prefix.
+                    // "-field" = descending, "field" = ascending (no prefix).
+                    let sortValue: String? = sortEntries.isEmpty ? nil
+                        : sortEntries.map { $0.descending ? "-\($0.field)" : $0.field }.joined(separator: ",")
+                    let criteria = NSPCriteria(
+                        from: ruleSet,
+                        sort: sortValue,
+                        order: nil,
+                        limit: limitEnabled ? limit : nil
+                    )
+                    try await ndClient.updateSmartPlaylist(
+                        id: playlistId,
+                        name: name.trimmingCharacters(in: .whitespaces),
+                        rules: criteria
+                    )
                 }
                 await onSave?()
                 dismiss()
             } catch {
-                // Show error - for now just print
-                print("Failed to save playlist: \(error)")
+                errorMessage = error.localizedDescription
             }
+        }
+    }
+}
+
+// MARK: - NSPCriteria → FilterRuleSet (reverse mapping for pre-population)
+
+extension FilterRuleSet {
+    /// Reconstruct a `FilterRuleSet` from an `NSPCriteria` so existing smart playlist
+    /// rules can be displayed in the UI for editing.
+    init(from criteria: NSPCriteria) {
+        self.combinator = criteria.combinator == .all ? .all : .any
+        self.rules = criteria.expressions.compactMap { FilterRule(from: $0) }
+    }
+}
+
+private extension FilterRule {
+    /// Reconstruct a `FilterRule` from an `NSPExpression` leaf.
+    /// Returns nil for conjunctions (nested groups) — we don't support nested editing yet.
+    init?(from expression: NSPExpression) {
+        guard case .leaf(let op, let field, let value) = expression else { return nil }
+
+        // inPlaylist / notInPlaylist: the "field" key is "id", not a regular field name.
+        // Detect by the operator name and treat the value as the playlist ID.
+        let opLower = op.lowercased()
+        if opLower == "inplaylist" || opLower == "notinplaylist" {
+            guard case .string(let playlistId) = value else { return nil }
+            let filterField: FilterField = opLower == "inplaylist" ? .inPlaylist : .notInPlaylist
+            self.init(field: filterField, operator: .isInPlaylist, value: .text(playlistId))
+            return
+        }
+
+        guard let filterField = FilterField(nspField: field) else { return nil }
+        guard let (filterOp, filterValue) = FilterRule.fromNSP(op: opLower, value: value, field: filterField) else { return nil }
+        self.init(field: filterField, operator: filterOp, value: filterValue)
+    }
+
+    static func fromNSP(op: String, value: NSPValue, field: FilterField) -> (FilterOperator, FilterValue)? {
+        switch field.kind {
+        case .text:     return textFromNSP(op: op, value: value)
+        case .numeric:  return numericFromNSP(op: op, value: value)
+        case .days:     return daysFromNSP(op: op, value: value)
+        case .boolean:  return booleanFromNSP(value: value)
+        case .playlist: return nil  // handled in init?(from:) above
+        }
+    }
+
+    private static func textFromNSP(op: String, value: NSPValue) -> (FilterOperator, FilterValue)? {
+        guard case .string(let s) = value else { return nil }
+        switch op {
+        case "contains":    return (.contains, .text(s))
+        case "notcontains": return (.notContains, .text(s))
+        case "is":          return (.equals, .text(s))
+        case "isnot":       return (.notEquals, .text(s))
+        case "startswith":  return (.startsWith, .text(s))
+        case "endswith":    return (.endsWith, .text(s))
+        default:            return nil
+        }
+    }
+
+    private static func numericFromNSP(op: String, value: NSPValue) -> (FilterOperator, FilterValue)? {
+        func intFrom(_ v: NSPValue) -> Int? {
+            switch v {
+            case .int(let n):    return n
+            case .double(let d): return Int(d)
+            default:             return nil
+            }
+        }
+        switch op {
+        case "is":
+            if let n = intFrom(value) { return (.isEqualTo, .number(n)) }
+        case "isnot":
+            if let n = intFrom(value) { return (.isNotEqualTo, .number(n)) }
+        case "gt":
+            if let n = intFrom(value) { return (.isGreaterThan, .number(n)) }
+        case "lt":
+            if let n = intFrom(value) { return (.isLessThan, .number(n)) }
+        case "intherange":
+            if case .range(let lo, let hi) = value,
+               let loN = intFrom(lo), let hiN = intFrom(hi) {
+                return (.isBetween, .range(loN, hiN))
+            }
+        default: break
+        }
+        return nil
+    }
+
+    private static func daysFromNSP(op: String, value: NSPValue) -> (FilterOperator, FilterValue)? {
+        func intFrom(_ v: NSPValue) -> Int? {
+            switch v {
+            case .int(let n):    return n
+            case .double(let d): return Int(d)
+            default:             return nil
+            }
+        }
+        switch op {
+        case "inthelast":
+            if let n = intFrom(value) { return (.inTheLast, .number(n)) }
+        case "notinthelast":
+            if let n = intFrom(value) { return (.notInTheLast, .number(n)) }
+        case "before":
+            if case .string(let date) = value { return (.before, .text(date)) }
+        case "after":
+            if case .string(let date) = value { return (.after, .text(date)) }
+        default: break
+        }
+        return nil
+    }
+
+    private static func booleanFromNSP(value: NSPValue) -> (FilterOperator, FilterValue)? {
+        guard case .bool(let b) = value else { return nil }
+        return (.isTrue, .boolean(b))
+    }
+}
+
+private extension FilterField {
+    /// Reverse lookup: NSP field name → FilterField.
+    init?(nspField: String) {
+        let table: [String: FilterField] = [
+            // Text
+            "title": .title, "artist": .artist, "album": .albumTitle,
+            "genre": .genre, "recordlabel": .label, "filetype": .suffix,
+            "codec": .contentType, "comment": .comment,
+            "explicitstatus": .explicitStatus,
+            "mbz_recording_id": .mbzRecordingId, "mbz_album_id": .mbzAlbumId,
+            "mbz_artist_id": .mbzArtistId, "mbz_album_artist_id": .mbzAlbumArtistId,
+            "mbz_release_track_id": .mbzReleaseTrackId, "mbz_release_group_id": .mbzReleaseGroupId,
+            // Numeric
+            "year": .year, "duration": .duration, "size": .size, "channels": .channels,
+            "bitrate": .bitRate, "bitdepth": .bitDepth, "samplerate": .sampleRate,
+            "bpm": .bpm, "playcount": .playCount, "rating": .rating,
+            "averagerating": .averageRating,
+            "albumrating": .albumRating, "albumplaycount": .albumPlayCount,
+            "artistrating": .artistRating, "artistplaycount": .artistPlayCount,
+            "tracknumber": .trackNumber, "discnumber": .discNumber,
+            // Date-relative
+            "lastplayed": .lastPlayed, "dateloved": .dateLoved, "daterated": .dateRated,
+            "dateadded": .dateAdded, "datemodified": .dateModified,
+            "albumlastplayed": .albumLastPlayed, "albumdateloved": .albumDateLoved,
+            "albumdaterated": .albumDateRated,
+            "artistlastplayed": .artistLastPlayed, "artistdateloved": .artistDateLoved,
+            "artistdaterated": .artistDateRated,
+            // Boolean
+            "loved": .isFavorited, "albumloved": .albumFavorited, "artistloved": .artistFavorited,
+            "hascoverart": .hasCoverArt, "compilation": .isCompilation, "missing": .isMissing,
+        ]
+        guard let match = table[nspField] else { return nil }
+        self = match
+    }
+}
+
+// MARK: - Sort entry
+
+private struct SortEntry: Identifiable {
+    let id = UUID()
+    var field: String
+    var descending: Bool
+}
+
+// MARK: - Sort fields
+
+private enum NSPSortField: String, CaseIterable {
+    case title, artist, album, genre, year, duration
+    case size
+    case channels
+    case bitRate = "bitrate"
+    case bitDepth = "bitdepth"
+    case sampleRate = "samplerate"
+    case bpm
+    case playCount = "playcount"
+    case rating
+    case averageRating = "averagerating"
+    case albumRating = "albumrating"
+    case albumPlayCount = "albumplaycount"
+    case artistRating = "artistrating"
+    case artistPlayCount = "artistplaycount"
+    case trackNumber = "tracknumber"
+    case discNumber = "discnumber"
+    case lastPlayed = "lastplayed"
+    case dateLoved = "dateloved"
+    case dateRated = "daterated"
+    case dateAdded = "dateadded"
+    case dateModified = "datemodified"
+    case albumLastPlayed = "albumlastplayed"
+    case artistLastPlayed = "artistlastplayed"
+    case random
+
+    var displayName: String {
+        switch self {
+        case .title:           "Title"
+        case .artist:          "Artist"
+        case .album:           "Album"
+        case .genre:           "Genre"
+        case .year:            "Year"
+        case .duration:        "Duration"
+        case .size:            "File Size"
+        case .channels:        "Channels"
+        case .bitRate:         "Bit Rate"
+        case .bitDepth:        "Bit Depth"
+        case .sampleRate:      "Sample Rate"
+        case .bpm:             "BPM"
+        case .playCount:       "Play Count"
+        case .rating:          "Rating"
+        case .averageRating:   "Avg Rating"
+        case .albumRating:     "Album Rating"
+        case .albumPlayCount:  "Album Play Count"
+        case .artistRating:    "Artist Rating"
+        case .artistPlayCount: "Artist Play Count"
+        case .trackNumber:     "Track #"
+        case .discNumber:      "Disc #"
+        case .lastPlayed:      "Last Played"
+        case .dateLoved:       "Date Loved"
+        case .dateRated:       "Date Rated"
+        case .dateAdded:       "Date Added"
+        case .dateModified:    "Date Modified"
+        case .albumLastPlayed: "Album Last Played"
+        case .artistLastPlayed: "Artist Last Played"
+        case .random:          "Random"
+        }
+    }
+}
+
+// MARK: - Inline rule row (iOS/macOS shared, no NSColor dependency)
+
+private struct InlineRuleRowView: View {
+    @Binding var rule: FilterRule
+    let allowedFields: [FilterField]
+    let onRemove: () -> Void
+
+    @State private var draftText: String = ""
+    @State private var draftNumber: Int = 0
+    @State private var draftRangeLo: Int = 0
+    @State private var draftRangeHi: Int = 0
+    @State private var debounceTask: Task<Void, Never>?
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Picker("", selection: $rule.field) {
+                ForEach(allowedFields, id: \.self) { Text($0.displayName).tag($0) }
+            }
+            .pickerStyle(.menu)
+            .labelsHidden()
+            .frame(width: 120)
+            .onChange(of: rule.field) { _, newField in
+                let ops = FilterOperator.allowed(for: newField.kind)
+                if !ops.contains(rule.operator) { rule.operator = ops[0] }
+                rule.value = .defaultValue(for: newField.kind)
+                syncDrafts()
+            }
+
+            Picker("", selection: $rule.operator) {
+                ForEach(FilterOperator.allowed(for: rule.field.kind), id: \.self) {
+                    Text($0.displayName).tag($0)
+                }
+            }
+            .pickerStyle(.menu)
+            .labelsHidden()
+            .frame(width: 120)
+            .onChange(of: rule.operator) { _, newOp in
+                if newOp == .isBetween, case .number(let n) = rule.value {
+                    rule.value = .range(n, n); draftRangeLo = n; draftRangeHi = n
+                } else if newOp != .isBetween, case .range(let lo, _) = rule.value {
+                    rule.value = .number(lo); draftNumber = lo
+                } else if newOp == .before || newOp == .after, case .number = rule.value {
+                    rule.value = .text(""); draftText = ""
+                } else if newOp == .inTheLast || newOp == .notInTheLast, case .text = rule.value {
+                    rule.value = .number(30); draftNumber = 30
+                }
+            }
+
+            valueInput
+
+            Button(action: onRemove) {
+                Image(systemName: "minus.circle").foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+        }
+        .onAppear { syncDrafts() }
+    }
+
+    @ViewBuilder
+    private var valueInput: some View {
+        switch rule.field.kind {
+        case .text:
+            TextField("value…", text: $draftText)
+                .textFieldStyle(.roundedBorder)
+                .frame(maxWidth: .infinity)
+                .onChange(of: draftText) { _, v in commit { .text(v) } }
+        case .numeric:
+            if rule.operator == .isBetween {
+                HStack(spacing: 4) {
+                    TextField("", value: $draftRangeLo, format: .number.grouping(.never))
+                        .textFieldStyle(.roundedBorder)
+                        .frame(maxWidth: .infinity)
+                        .onChange(of: draftRangeLo) { _, lo in commit { .range(lo, self.draftRangeHi) } }
+                    Text("–").foregroundStyle(.secondary)
+                    TextField("", value: $draftRangeHi, format: .number.grouping(.never))
+                        .textFieldStyle(.roundedBorder)
+                        .frame(maxWidth: .infinity)
+                        .onChange(of: draftRangeHi) { _, hi in commit { .range(self.draftRangeLo, hi) } }
+                }
+                .frame(maxWidth: .infinity)
+            } else {
+                TextField("", value: $draftNumber, format: .number.grouping(.never))
+                    .textFieldStyle(.roundedBorder)
+                    .frame(maxWidth: .infinity)
+                    .onChange(of: draftNumber) { _, n in commit { .number(n) } }
+            }
+        case .days:
+            if rule.operator == .before || rule.operator == .after {
+                // Absolute date input: "YYYY-MM-DD"
+                TextField("YYYY-MM-DD", text: $draftText)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(maxWidth: .infinity)
+                    .onChange(of: draftText) { _, v in commit { .text(v) } }
+            } else {
+                HStack(spacing: 6) {
+                    TextField("", value: $draftNumber, format: .number.grouping(.never))
+                        .textFieldStyle(.roundedBorder)
+                        .frame(maxWidth: .infinity)
+                        .onChange(of: draftNumber) { _, n in commit { .number(n) } }
+                    Text("days").foregroundStyle(.secondary)
+                }
+                .frame(maxWidth: .infinity)
+            }
+        case .boolean:
+            Picker("", selection: Binding(
+                get: { if case .boolean(let b) = rule.value { return b }; return true },
+                set: { rule.value = .boolean($0) }
+            )) {
+                Text("Yes").tag(true)
+                Text("No").tag(false)
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+            .frame(maxWidth: .infinity)
+        case .playlist:
+            TextField("Playlist ID…", text: $draftText)
+                .textFieldStyle(.roundedBorder)
+                .frame(maxWidth: .infinity)
+                .onChange(of: draftText) { _, v in commit { .text(v) } }
+        }
+    }
+
+    private func commit(_ make: @escaping @Sendable () -> FilterValue) {
+        debounceTask?.cancel()
+        debounceTask = Task {
+            try? await Task.sleep(for: .milliseconds(300))
+            guard !Task.isCancelled else { return }
+            rule.value = make()
+        }
+    }
+
+    private func syncDrafts() {
+        switch rule.value {
+        case .text(let s):          draftText = s
+        case .number(let n):        draftNumber = n
+        case .range(let lo, let hi): draftRangeLo = lo; draftRangeHi = hi
+        case .boolean:              break
         }
     }
 }

--- a/Vibrdrome/Features/Settings/SettingsView.swift
+++ b/Vibrdrome/Features/Settings/SettingsView.swift
@@ -380,6 +380,7 @@ struct SettingsView: View {
                     Task {
                         await appState.librarySyncManager.sync(
                             client: appState.subsonicClient,
+                            ndClient: appState.navidromeClient,
                             container: PersistenceController.shared.container
                         )
                     }
@@ -398,6 +399,7 @@ struct SettingsView: View {
                     Task {
                         await appState.librarySyncManager.incrementalSync(
                             client: appState.subsonicClient,
+                            ndClient: appState.navidromeClient,
                             container: PersistenceController.shared.container
                         )
                     }
@@ -443,6 +445,7 @@ struct SettingsView: View {
                     // rather than waiting until the next launch.
                     appState.librarySyncManager.startPolling(
                         client: appState.subsonicClient,
+                        ndClient: appState.navidromeClient,
                         container: PersistenceController.shared.container
                     )
                 }

--- a/Vibrdrome/Vibrdrome.swift
+++ b/Vibrdrome/Vibrdrome.swift
@@ -149,11 +149,13 @@ struct VibrdromeApp: App {
                         appState.libraryCache.rebuild(container: persistenceController.container)
                         await appState.librarySyncManager.syncIfStale(
                             client: appState.subsonicClient,
+                            ndClient: appState.navidromeClient,
                             container: persistenceController.container
                         )
                         appState.libraryCache.rebuild(container: persistenceController.container)
                         appState.librarySyncManager.startPolling(
                             client: appState.subsonicClient,
+                            ndClient: appState.navidromeClient,
                             container: persistenceController.container
                         )
                         await appState.librarySyncManager.warmImageCache(
@@ -185,11 +187,13 @@ struct VibrdromeApp: App {
                         appState.libraryCache.rebuild(container: persistenceController.container)
                         await appState.librarySyncManager.syncIfStale(
                             client: appState.subsonicClient,
+                            ndClient: appState.navidromeClient,
                             container: persistenceController.container
                         )
                         appState.libraryCache.rebuild(container: persistenceController.container)
                         appState.librarySyncManager.startPolling(
                             client: appState.subsonicClient,
+                            ndClient: appState.navidromeClient,
                             container: persistenceController.container
                         )
                         await appState.librarySyncManager.warmImageCache(
@@ -254,6 +258,17 @@ struct VibrdromeApp: App {
             }
         }
         .defaultSize(width: 560, height: 700)
+
+        WindowGroup("Filters", id: "library-filter", for: FilterContext.self) { _ in
+            if let context = appState.activeFilterWindowContext {
+                LibraryFilterSidebarView(context: context, isWindow: true)
+                    .environment(appState)
+                    .modelContainer(persistenceController.container)
+                    .preferredColorScheme(colorScheme)
+                    .tint(accentColor)
+            }
+        }
+        .defaultSize(width: 280, height: 600)
 
         Window("Mini Player", id: "mini-player") {
             PopOutPlayerView()

--- a/VibrdromeTests/Features/NSPCriteriaTests.swift
+++ b/VibrdromeTests/Features/NSPCriteriaTests.swift
@@ -1,0 +1,255 @@
+import Foundation
+import Testing
+@testable import Vibrdrome
+
+struct NSPCriteriaTests {
+
+    // MARK: - FilterField → NSP field name
+
+    @Test func textFieldsMappedCorrectly() {
+        let pairs: [(FilterField, String)] = [
+            (.title, "title"),
+            (.artist, "artist"),
+            (.albumTitle, "album"),
+            (.genre, "genre"),
+            (.label, "recordlabel"),
+            (.suffix, "filetype"),
+            (.contentType, "codec"),
+        ]
+        for (field, expected) in pairs {
+            let rule = FilterRule(field: field, operator: .contains, value: .text("x"))
+            let criteria = NSPCriteria(from: FilterRuleSet(combinator: .all, rules: [rule]))
+            #expect(criteria.expressions.count == 1)
+            if case .leaf(let op, let f, _) = criteria.expressions[0] {
+                #expect(f == expected, "Field \(field) should map to '\(expected)', got '\(f)'")
+                #expect(op == "contains")
+            }
+        }
+    }
+
+    @Test func numericFieldsMappedCorrectly() {
+        let pairs: [(FilterField, String)] = [
+            (.year, "year"),
+            (.duration, "duration"),
+            (.bitRate, "bitrate"),
+            (.playCount, "playcount"),
+            (.rating, "rating"),
+            (.trackNumber, "tracknumber"),
+            (.discNumber, "discnumber"),
+        ]
+        for (field, expected) in pairs {
+            let rule = FilterRule(field: field, operator: .isGreaterThan, value: .number(0))
+            let criteria = NSPCriteria(from: FilterRuleSet(combinator: .all, rules: [rule]))
+            #expect(criteria.expressions.count == 1)
+            if case .leaf(_, let f, _) = criteria.expressions[0] {
+                #expect(f == expected)
+            }
+        }
+    }
+
+    @Test func isFavoritedMapsToLoved() {
+        let rule = FilterRule(field: .isFavorited, operator: .isTrue, value: .boolean(true))
+        let criteria = NSPCriteria(from: FilterRuleSet(combinator: .all, rules: [rule]))
+        #expect(criteria.expressions.count == 1)
+        if case .leaf(let op, let field, let value) = criteria.expressions[0] {
+            #expect(field == "loved")
+            #expect(op == "is")
+            if case .bool(let b) = value { #expect(b == true) }
+        }
+    }
+
+    @Test func isDownloadedIsDropped() {
+        let rule = FilterRule(field: .isDownloaded, operator: .isTrue, value: .boolean(true))
+        let criteria = NSPCriteria(from: FilterRuleSet(combinator: .all, rules: [rule]))
+        #expect(criteria.expressions.isEmpty, "isDownloaded has no NSP mapping and should be dropped")
+    }
+
+    // MARK: - Operator mapping
+
+    @Test func textOperators() {
+        let cases: [(FilterOperator, String)] = [
+            (.contains, "contains"),
+            (.notContains, "notContains"),
+            (.equals, "is"),
+            (.notEquals, "isNot"),
+            (.startsWith, "startsWith"),
+            (.endsWith, "endsWith"),
+        ]
+        for (op, expected) in cases {
+            let rule = FilterRule(field: .title, operator: op, value: .text("test"))
+            let criteria = NSPCriteria(from: FilterRuleSet(combinator: .all, rules: [rule]))
+            if case .leaf(let nspOp, _, _) = criteria.expressions.first {
+                #expect(nspOp == expected, "Operator \(op) should map to '\(expected)', got '\(nspOp)'")
+            } else {
+                #expect(Bool(false), "Missing expression for operator \(op)")
+            }
+        }
+    }
+
+    @Test func regexOperatorIsDropped() {
+        let rule = FilterRule(field: .title, operator: .matchesRegex, value: .text(".*love.*"))
+        let criteria = NSPCriteria(from: FilterRuleSet(combinator: .all, rules: [rule]))
+        #expect(criteria.expressions.isEmpty, "matchesRegex has no NSP mapping and should be dropped")
+    }
+
+    @Test func numericEqualTo() {
+        let rule = FilterRule(field: .rating, operator: .isEqualTo, value: .number(4))
+        let criteria = NSPCriteria(from: FilterRuleSet(combinator: .all, rules: [rule]))
+        if case .leaf(let op, _, let val) = criteria.expressions.first {
+            #expect(op == "is")
+            if case .int(let n) = val { #expect(n == 4) }
+        }
+    }
+
+    @Test func numericGreaterThan() {
+        let rule = FilterRule(field: .rating, operator: .isGreaterThan, value: .number(3))
+        let criteria = NSPCriteria(from: FilterRuleSet(combinator: .all, rules: [rule]))
+        if case .leaf(let op, _, let val) = criteria.expressions.first {
+            #expect(op == "gt")
+            if case .int(let n) = val { #expect(n == 3) }
+        }
+    }
+
+    @Test func numericGreaterOrEqualEmulatedWithGtMinusOne() {
+        // ≥ n is emulated as gt(n-1)
+        let rule = FilterRule(field: .rating, operator: .isGreaterOrEqual, value: .number(3))
+        let criteria = NSPCriteria(from: FilterRuleSet(combinator: .all, rules: [rule]))
+        if case .leaf(let op, _, let val) = criteria.expressions.first {
+            #expect(op == "gt")
+            if case .int(let n) = val { #expect(n == 2) }
+        }
+    }
+
+    @Test func numericLessOrEqualEmulatedWithLtPlusOne() {
+        // ≤ n is emulated as lt(n+1)
+        let rule = FilterRule(field: .year, operator: .isLessOrEqual, value: .number(2000))
+        let criteria = NSPCriteria(from: FilterRuleSet(combinator: .all, rules: [rule]))
+        if case .leaf(let op, _, let val) = criteria.expressions.first {
+            #expect(op == "lt")
+            if case .int(let n) = val { #expect(n == 2001) }
+        }
+    }
+
+    @Test func rangeProducesInTheRange() {
+        let rule = FilterRule(field: .year, operator: .isBetween, value: .range(1980, 1989))
+        let criteria = NSPCriteria(from: FilterRuleSet(combinator: .all, rules: [rule]))
+        if case .leaf(let op, let field, let val) = criteria.expressions.first {
+            #expect(op == "inTheRange")
+            #expect(field == "year")
+            if case .range(let lo, let hi) = val {
+                if case .int(let loN) = lo { #expect(loN == 1980) }
+                if case .int(let hiN) = hi { #expect(hiN == 1989) }
+            } else {
+                #expect(Bool(false), "Expected range value")
+            }
+        }
+    }
+
+    // MARK: - Combinator
+
+    @Test func allCombinatorPreserved() {
+        let ruleSet = FilterRuleSet(combinator: .all, rules: [
+            FilterRule(field: .title, operator: .contains, value: .text("a")),
+            FilterRule(field: .artist, operator: .contains, value: .text("b")),
+        ])
+        let criteria = NSPCriteria(from: ruleSet)
+        #expect(criteria.combinator == .all)
+        #expect(criteria.expressions.count == 2)
+    }
+
+    @Test func anyCombinatorPreserved() {
+        let ruleSet = FilterRuleSet(combinator: .any, rules: [
+            FilterRule(field: .title, operator: .contains, value: .text("a")),
+            FilterRule(field: .genre, operator: .equals, value: .text("Rock")),
+        ])
+        let criteria = NSPCriteria(from: ruleSet)
+        #expect(criteria.combinator == .any)
+    }
+
+    // MARK: - Empty / effectively-empty rules skipped
+
+    @Test func emptyTextRuleIsSkipped() {
+        let rule = FilterRule(field: .title, operator: .contains, value: .text(""))
+        let criteria = NSPCriteria(from: FilterRuleSet(combinator: .all, rules: [rule]))
+        #expect(criteria.expressions.isEmpty)
+    }
+
+    @Test func mixedEmptyAndNonEmptyRules() {
+        let ruleSet = FilterRuleSet(combinator: .all, rules: [
+            FilterRule(field: .title, operator: .contains, value: .text("")),
+            FilterRule(field: .genre, operator: .equals, value: .text("Jazz")),
+        ])
+        let criteria = NSPCriteria(from: ruleSet)
+        #expect(criteria.expressions.count == 1)
+    }
+
+    // MARK: - JSON round-trip
+
+    @Test func criteriaRoundTripsJSON() throws {
+        let ruleSet = FilterRuleSet(combinator: .all, rules: [
+            FilterRule(field: .rating, operator: .isGreaterThan, value: .number(3)),
+            FilterRule(field: .isFavorited, operator: .isTrue, value: .boolean(true)),
+            FilterRule(field: .genre, operator: .contains, value: .text("Rock")),
+        ])
+        let criteria = NSPCriteria(from: ruleSet, sort: "rating", order: "desc", limit: 100)
+        let data = try JSONEncoder().encode(criteria)
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+
+        #expect(json?["sort"] as? String == "rating")
+        #expect(json?["order"] as? String == "desc")
+        #expect(json?["limit"] as? Int == 100)
+        #expect(json?["all"] != nil)
+    }
+
+    @Test func toJSONProducesNonNilDictionary() {
+        let ruleSet = FilterRuleSet(combinator: .all, rules: [
+            FilterRule(field: .artist, operator: .contains, value: .text("Beatles")),
+        ])
+        let criteria = NSPCriteria(from: ruleSet)
+        #expect(criteria.toJSON() != nil)
+    }
+
+    // MARK: - Full decode round-trip (catches NSPExpression decoder ordering bugs)
+
+    @Test func decodesNavidromeAPIResponseFormat() throws {
+        // Mirrors the JSON shape Navidrome returns from GET /api/playlist
+        let json = """
+        {
+            "all": [
+                { "contains": { "title": "love" } },
+                { "gt": { "year": 2020 } },
+                { "is": { "loved": true } }
+            ],
+            "sort": "year",
+            "order": "desc",
+            "limit": 50
+        }
+        """
+        let data = json.data(using: .utf8)!
+        let criteria = try JSONDecoder().decode(NSPCriteria.self, from: data)
+
+        #expect(criteria.combinator == .all)
+        #expect(criteria.expressions.count == 3)
+        #expect(criteria.sort == "year")
+        #expect(criteria.order == "desc")
+        #expect(criteria.limit == 50)
+
+        if case .leaf(let op, let field, let value) = criteria.expressions[0] {
+            #expect(op == "contains")
+            #expect(field == "title")
+            if case .string(let s) = value { #expect(s == "love") }
+        } else { #expect(Bool(false), "Expression 0 should be a leaf") }
+
+        if case .leaf(let op, let field, let value) = criteria.expressions[1] {
+            #expect(op == "gt")
+            #expect(field == "year")
+            if case .int(let n) = value { #expect(n == 2020) }
+        } else { #expect(Bool(false), "Expression 1 should be a leaf") }
+
+        if case .leaf(let op, let field, let value) = criteria.expressions[2] {
+            #expect(op == "is")
+            #expect(field == "loved")
+            if case .bool(let b) = value { #expect(b == true) }
+        } else { #expect(Bool(false), "Expression 2 should be a leaf") }
+    }
+}


### PR DESCRIPTION
## Summary

### Advanced filter builder
- **`FilterRule` / `FilterRuleSet` model** — composable rule type targeting metadata fields with per-field operator sets: text fields get contains / not contains / equals / starts with / ends with / **regex**; numeric fields get =, ≠, >, <, ≥, ≤, **between**; boolean and days fields also supported. Rules with blank values are no-ops.
- **`FilterRuleSet` combinator** — ALL (AND) or ANY (OR) logic; combinator picker hidden when fewer than 2 rules exist.
- **`FilterRuleBuilderView`** — expandable "Advanced Filters" section in the filter sidebar. Add/remove rules, field + operator + value pickers per row, live regex validation indicator (`/pattern/flags` syntax supported), 300 ms debounce on all inputs. Auto-expands/collapses with first/last rule. State persisted per context in `AppStorage`.
- **Live match count** — `LibraryFilter.matchCount` written back by view after each filter pass, displayed in sidebar header.
- **Sticky header** — result count and Reset button outside the scroll view.
- **Pop-out window** — filter sidebar can be detached into a standalone `WindowGroup` (280×600 pt), shares `AppState`.
- **Rule set persistence** — each context's `FilterRuleSet` encoded to `UserDefaults` and restored on next launch.
- **Expanded `FilterField` set** — added `comment`, `bitDepth`, `sampleRate`, `bpm`, `albumRating`, `lastPlayed`, `dateAdded`, `albumFavorited`; new `FieldKind.days` with `inTheLast` / `notInTheLast` operators.

### Navidrome Smart Playlist support
- **`NSPCriteria` / `NSPExpression` / `NSPValue`** — `Codable` model mirroring the Navidrome `.nsp` JSON format exactly. Decoder mirrors Go `unmarshalConjunctionType`: checks key against a known leaf-operator set first, falls back to `all`/`any` conjunction — so existing server-side rules decode correctly.
- **`PlaylistEditorView` smart mode** — detects when editing a smart playlist, pre-populates rules from the server's NSP criteria, and saves back via the native API. Supports sort field, sort order (asc/desc), and song limit. macOS layout uses `.formStyle(.grouped)`.
- **`PlaylistDetailView` detection** — identifies smart playlists by presence of `rules` field. Opens smart editor sheet on "Edit Playlist" tap.
- **NSP round-trip** — load rules from NSP JSON → display in UI → save back. All Navidrome-supported operators and fields are mapped in both directions.
- **"Save as Smart Playlist"** — filter sidebar button creates a server-side smart playlist from the current rule set.

### Navidrome native REST API sync
- **`NavidromeNativeClient`** — JWT-authenticated client for Navidrome's native `/api/song` and `/api/album` endpoints. Probed on login; cached token with transparent re-auth on 401.
- **ND API as primary sync path** — uses `_start`/`_end` pagination with `x-total-count` for both full and incremental syncs; Subsonic API used as fallback when ND is unavailable.
- **Richer metadata** — `bpm`, `channels`, `sampleRate`, `bitDepth`, MusicBrainz IDs, `playCount`, `compilation` flag, `hasCoverArt` — none of which are available via Subsonic — now stored in `CachedSong` and `CachedAlbum`.
- **`CachedSong` / `CachedAlbum` schema extensions** — new fields: `channels`, `hasCoverArt`, `isCompilation`, `bpm`, `dateAdded`, `mbzRecordingId`, `mbzArtistId`, `mbzAlbumArtistId`, `mbzReleaseGroupId`, `playCount`.

### Off-MainActor filtering
- **`AlbumsView`** — restored `async` + `Task.detached` filter loop with `FilterSnapshot: Sendable` (was in upstream, had regressed). Snapshot extended to carry `ruleSet` and `isRecentlyPlayed`.
- **`ArtistsView`** — promoted to async with `Task.detached` + `ArtistFilterSnapshot: Sendable`.
- **`SongsView`** — promoted to async with `Task.detached` + `SongFilterSnapshot: Sendable` + `CachedSongExtras: Sendable` (captures SwiftData fields as value types before the actor hop).

### Other
- **`FavoritesView`** — restored Songs / Albums / Artists tabs.
- **Filter pop-out window** — tracks active library context (`activeFilterWindowContext`).
- **Active filters re-run** on library cache rebuild (generation counter observer).
- **`gridDensity.minimumWidth`** restored across all grid views: Albums, Artists, Favorites, Genres, Songs, Playlists, Radio.
- **Locale fix** — all numeric `TextField` inputs use `.grouping(.never)` to prevent thousands-separator display in European locales.

## Rebased onto
`upstream/develop` @ `ae909f6` (hover overlay PR #39, warmImageCache fix PR #48, WebP PR #36 all included)

## Test plan
- [x] Build iOS, macOS, watchOS — 0 errors, 0 warnings
- [x] SwiftLint — 0 violations
- [x] Filter sidebar: add rules for text / numeric / boolean / days fields, verify match counts update
- [x] Regex rule: enter `/pattern/i`, verify green checkmark; enter `[broken`, verify red indicator
- [x] Pop-out window: detach filter sidebar, confirm it tracks library context switches
- [x] Smart playlist: open an existing ND smart playlist, edit rules, save — verify server round-trip
- [x] "Save as Smart Playlist" from filter sidebar — confirm playlist appears in Navidrome
- [x] ND API sync: connect to Navidrome server, sync, confirm `bpm`/`playCount`/MBz fields populated in Get Info
- [x] Subsonic fallback: disconnect ND client, sync — confirm library still populates
- [x] Grid density setting: change in Appearance Settings, confirm all grid views (Albums, Artists, Genres, Songs, Playlists, Radio) respond

🤖 Generated with [Claude Code](https://claude.com/claude-code)