### PR TITLE
Fix library filter caching pipeline & add multi-genre support

### DIFF
--- a/Vibrdrome/App/AppState.swift
+++ b/Vibrdrome/App/AppState.swift
@@ -58,6 +58,12 @@ final class AppState {
         case queue, lyrics, artistInfo
     }
     var activeSidePanel: SidePanel?
+
+    /// Library sync manager.
+    let librarySyncManager = LibrarySyncManager.shared
+
+    /// Pre-computed model arrays so library tabs are instant on first tap.
+    let libraryCache = LibraryDataCache()
     var serverURL: String = ""
     var username: String = ""
     var errorMessage: String?
@@ -115,6 +121,8 @@ final class AppState {
         #if os(iOS)
         SubsonicClientProvider.shared.client = subsonicClient
         #endif
+        LibrarySyncManager.shared.client = subsonicClient
+        LibrarySyncManager.shared.container = PersistenceController.shared.container
     }
 
     func loadSavedCredentials() {

--- a/Vibrdrome/App/AppState.swift
+++ b/Vibrdrome/App/AppState.swift
@@ -52,12 +52,25 @@ final class AppState {
     }
     var pendingNowPlayingAction: NowPlayingAction?
 
-    /// Active side panel in the macOS main window (Queue / Lyrics / Artist Info).
+    /// Active side panel in the macOS main window (Queue / Lyrics / Artist Info / Album Filters).
     /// Mutually exclusive: setting one closes the others.
     enum SidePanel: String, Equatable {
-        case queue, lyrics, artistInfo
+        case queue, lyrics, artistInfo, albumFilters, artistFilters, songFilters
     }
     var activeSidePanel: SidePanel?
+
+    /// Filter state for the macOS filter sidebars.
+    var albumFilter = LibraryFilter()
+    var artistFilter = LibraryFilter()
+    var songFilter = LibraryFilter()
+
+    /// Cached albums state for back-navigation, keyed by view configuration.
+    struct AlbumsViewSnapshot {
+        var albums: [Album]
+        var hasMore: Bool
+        var scrollIndex: Int?
+    }
+    var albumsViewSnapshots: [String: AlbumsViewSnapshot] = [:]
 
     /// Library sync manager.
     let librarySyncManager = LibrarySyncManager.shared
@@ -211,6 +224,13 @@ final class AppState {
         requiresReAuth = false
     }
 
+    func resetLibraryFilterState() {
+        albumFilter = LibraryFilter()
+        artistFilter = LibraryFilter()
+        songFilter = LibraryFilter()
+        albumsViewSnapshots = [:]
+    }
+
     func clearCredentials() {
         UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.serverURL)
         UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.username)
@@ -219,6 +239,7 @@ final class AppState {
         requiresReAuth = false
         serverURL = ""
         username = ""
+        resetLibraryFilterState()
         // Reset the client so stale creds aren't used
         subsonicClient.updateCredentials(
             baseURL: URL(string: "https://localhost")!,
@@ -243,6 +264,7 @@ final class AppState {
               let password = keychain["server_\(id)"] else { return }
         activeServerId = id
         UserDefaults.standard.set(id, forKey: Self.activeServerKey)
+        resetLibraryFilterState()
         configure(url: server.url, username: server.username, password: password)
 
         // Update legacy keys

--- a/Vibrdrome/App/Theme.swift
+++ b/Vibrdrome/App/Theme.swift
@@ -117,4 +117,18 @@ enum Theme {
         140
         #endif
     }
+
+    /// Returns the column count for grid views given the user's base preference
+    /// and the current vertical size class. Doubles the base count when the
+    /// vertical size class is `.compact` (iPhone in landscape) so a portrait-
+    /// tuned value still uses the extra horizontal space after rotation.
+    /// Clamped to the picker's 2-10 range. On iPad and macOS the size class
+    /// is regular in both orientations so the base value is used as-is.
+    static func effectiveGridColumns(
+        base: Int,
+        verticalSizeClass: UserInterfaceSizeClass?
+    ) -> Int {
+        let multiplier = verticalSizeClass == .compact ? 2 : 1
+        return max(2, min(10, base * multiplier))
+    }
 }

--- a/Vibrdrome/App/Theme.swift
+++ b/Vibrdrome/App/Theme.swift
@@ -68,6 +68,28 @@ struct ConditionalGlassModifier: ViewModifier {
 }
 #endif
 
+// MARK: - Grid Density
+
+enum GridDensity: String, CaseIterable {
+    case compact, comfortable, spacious
+
+    var minimumWidth: CGFloat {
+        switch self {
+        case .compact:     return 130
+        case .comfortable: return 170
+        case .spacious:    return 220
+        }
+    }
+
+    var label: String {
+        switch self {
+        case .compact:     return "Compact"
+        case .comfortable: return "Comfortable"
+        case .spacious:    return "Spacious"
+        }
+    }
+}
+
 // MARK: - Theme
 
 enum Theme {
@@ -116,19 +138,5 @@ enum Theme {
         #else
         140
         #endif
-    }
-
-    /// Returns the column count for grid views given the user's base preference
-    /// and the current vertical size class. Doubles the base count when the
-    /// vertical size class is `.compact` (iPhone in landscape) so a portrait-
-    /// tuned value still uses the extra horizontal space after rotation.
-    /// Clamped to the picker's 2-10 range. On iPad and macOS the size class
-    /// is regular in both orientations so the base value is used as-is.
-    static func effectiveGridColumns(
-        base: Int,
-        verticalSizeClass: UserInterfaceSizeClass?
-    ) -> Int {
-        let multiplier = verticalSizeClass == .compact ? 2 : 1
-        return max(2, min(10, base * multiplier))
     }
 }

--- a/Vibrdrome/Core/Audio/AudioEngine+Queue.swift
+++ b/Vibrdrome/Core/Audio/AudioEngine+Queue.swift
@@ -9,9 +9,20 @@ extension AudioEngine {
         return Array(queue[(currentIndex + 1)...])
     }
 
-    /// Songs actually played before the current track (most recent first, max 20).
+    /// Songs actually played before the current track (chronological: oldest
+    /// first, newest last so the newest ends up adjacent to Now Playing when
+    /// the list is rendered top-to-bottom). Max 20 items.
     var recentlyPlayed: [Song] {
-        Array(playHistory.reversed().prefix(20))
+        Array(playHistory.suffix(20))
+    }
+
+    /// Upcoming tracks (queue[currentIndex+1...]) with absolute queue indices
+    /// so callers can pass them back to skipToIndex / removeFromQueue.
+    var upNextEntries: [(index: Int, song: Song)] {
+        guard !queue.isEmpty, currentIndex + 1 < queue.count else { return [] }
+        return (currentIndex + 1 ..< queue.count).map { idx in
+            (index: idx, song: queue[idx])
+        }
     }
 
     /// All queue tracks except the currently playing one, with absolute queue indices.
@@ -51,6 +62,25 @@ extension AudioEngine {
         guard index >= 0, index < queue.count, index != currentIndex else { return }
         queue.remove(at: index)
         if index < currentIndex { currentIndex -= 1 }
+        if activeMode == .gapless { prepareLookahead() }
+    }
+
+    /// Reorder tracks within the Up Next section only.
+    /// Source/destination are offsets into `upNextEntries`; they get shifted
+    /// by currentIndex+1 to land in the real queue array. Tracks before the
+    /// current track are untouched.
+    func moveInUpNext(from source: IndexSet, to destination: Int) {
+        let startIndex = currentIndex + 1
+        guard startIndex < queue.count else { return }
+        let upNextCount = queue.count - startIndex
+        guard destination >= 0, destination <= upNextCount else { return }
+        let absoluteSource = IndexSet(source.compactMap { offset in
+            let abs = startIndex + offset
+            return abs < queue.count ? abs : nil
+        })
+        guard !absoluteSource.isEmpty else { return }
+        let absoluteDestination = startIndex + destination
+        queue.move(fromOffsets: absoluteSource, toOffset: absoluteDestination)
         if activeMode == .gapless { prepareLookahead() }
     }
 

--- a/Vibrdrome/Core/Audio/NowPlayingManager.swift
+++ b/Vibrdrome/Core/Audio/NowPlayingManager.swift
@@ -27,34 +27,6 @@ final class NowPlayingManager {
     private let infoCenter = MPNowPlayingInfoCenter.default()
     private var currentInfo = [String: Any]()
 
-    /// Update the stored artwork and flush to `infoCenter`. Used by radio
-    /// artwork loading so the station's cover art isn't overwritten by the
-    /// next elapsed-time tick (which writes `currentInfo` back).
-    func setCurrentArtwork(_ artwork: MPMediaItemArtwork) {
-        currentInfo[MPMediaItemPropertyArtwork] = artwork
-        infoCenter.nowPlayingInfo = currentInfo
-    }
-
-    /// Reset `currentInfo` to station metadata so subsequent `updateElapsedTime`
-    /// / `updatePlaybackState` ticks don't overwrite with stale song info.
-    func update(station: InternetRadioStation, isPlaying: Bool) {
-        currentInfo = [String: Any]()
-        currentInfo[MPMediaItemPropertyTitle] = station.name
-        currentInfo[MPMediaItemPropertyArtist] = "Internet Radio"
-        currentInfo[MPNowPlayingInfoPropertyIsLiveStream] = true
-        currentInfo[MPNowPlayingInfoPropertyPlaybackRate] = isPlaying ? 1.0 : 0.0
-        infoCenter.nowPlayingInfo = currentInfo
-
-        #if os(iOS)
-        WatchSessionManager.shared.sendNowPlayingUpdate(
-            title: station.name,
-            artist: "Internet Radio",
-            album: "",
-            isPlaying: isPlaying
-        )
-        #endif
-    }
-
     func update(song: Song, isPlaying: Bool) {
         currentInfo = [String: Any]()
         currentInfo[MPMediaItemPropertyTitle] = song.title
@@ -104,6 +76,41 @@ final class NowPlayingManager {
         #endif
 
         Task { await loadAndApplyArtwork(for: song) }
+    }
+
+    func update(station: InternetRadioStation, isPlaying: Bool) {
+        currentInfo = [String: Any]()
+        currentInfo[MPMediaItemPropertyTitle] = station.name
+        currentInfo[MPMediaItemPropertyArtist] = "Internet Radio"
+        currentInfo[MPMediaItemPropertyAlbumTitle] = ""
+        currentInfo[MPNowPlayingInfoPropertyElapsedPlaybackTime] = 0.0
+        currentInfo[MPNowPlayingInfoPropertyPlaybackRate] = isPlaying ? 1.0 : 0.0
+        currentInfo[MPNowPlayingInfoPropertyDefaultPlaybackRate] = 1.0
+        currentInfo[MPNowPlayingInfoPropertyIsLiveStream] = true
+        currentInfo.removeValue(forKey: MPMediaItemPropertyArtwork)
+        infoCenter.nowPlayingInfo = currentInfo
+
+        updateWidget(title: station.name, artist: "Internet Radio",
+                     album: "", isPlaying: isPlaying,
+                     coverArtId: station.radioCoverArtId)
+
+        #if os(iOS)
+        WatchSessionManager.shared.sendNowPlayingUpdate(
+            title: station.name,
+            artist: "Internet Radio",
+            album: "",
+            isPlaying: isPlaying
+        )
+        #endif
+    }
+
+    func setCurrentArtwork(_ artwork: MPMediaItemArtwork?) {
+        if let artwork {
+            currentInfo[MPMediaItemPropertyArtwork] = artwork
+        } else {
+            currentInfo.removeValue(forKey: MPMediaItemPropertyArtwork)
+        }
+        infoCenter.nowPlayingInfo = currentInfo
     }
 
     private func loadAndApplyArtwork(for song: Song) async {

--- a/Vibrdrome/Core/Constants/UserDefaultsKeys.swift
+++ b/Vibrdrome/Core/Constants/UserDefaultsKeys.swift
@@ -149,4 +149,12 @@ enum UserDefaultsKeys {
     static let macSidePanelMechanic = "macSidePanelMechanic"
     static let macSidePanelWidth = "macSidePanelWidth"
     static let macMiniPlayerPanelTrigger = "macMiniPlayerPanelTrigger"
+
+    // MARK: - Library Sync
+
+    static let lastLibrarySyncDate = "lastLibrarySyncDate"
+    static let lastFullSyncDate = "lastFullSyncDate"
+    static let lastServerModified = "lastServerModified"
+    static let backgroundSyncEnabled = "backgroundSyncEnabled"
+    static let syncPollingInterval = "syncPollingInterval"
 }

--- a/Vibrdrome/Core/Constants/UserDefaultsKeys.swift
+++ b/Vibrdrome/Core/Constants/UserDefaultsKeys.swift
@@ -143,6 +143,11 @@ enum UserDefaultsKeys {
     static let libraryLayout = "libraryLayout"
     static let activeMusicFolderId = "activeMusicFolderId"
 
+    // MARK: - macOS Track Table Columns
+
+    /// Key prefix for per-view column config. Full key = prefix + viewKey (e.g. "songs", "album").
+    static let trackTableColumnsPrefix = "trackTableColumns_"
+
     // MARK: - macOS Layout
 
     static let macNowPlayingPlacement = "macNowPlayingPlacement"

--- a/Vibrdrome/Core/Constants/UserDefaultsKeys.swift
+++ b/Vibrdrome/Core/Constants/UserDefaultsKeys.swift
@@ -123,7 +123,7 @@ enum UserDefaultsKeys {
     static let enableLiquidGlass = "enableLiquidGlass"
     static let enableMiniPlayerTint = "enableMiniPlayerTint"
     static let albumBackgroundStyle = "albumBackgroundStyle"
-    static let gridColumnsPerRow = "gridColumnsPerRow"
+    static let gridDensity = "gridDensity"
     static let showLosslessBadge = "showLosslessBadge"
 
     // MARK: - Tab Bar Extended

--- a/Vibrdrome/Core/Constants/UserDefaultsKeys.swift
+++ b/Vibrdrome/Core/Constants/UserDefaultsKeys.swift
@@ -157,4 +157,5 @@ enum UserDefaultsKeys {
     static let lastServerModified = "lastServerModified"
     static let backgroundSyncEnabled = "backgroundSyncEnabled"
     static let syncPollingInterval = "syncPollingInterval"
+    static let lastCoverArtPrefetchDate = "lastCoverArtPrefetchDate"
 }

--- a/Vibrdrome/Core/Downloads/DownloadManager.swift
+++ b/Vibrdrome/Core/Downloads/DownloadManager.swift
@@ -232,7 +232,33 @@ final class DownloadManager: NSObject, URLSessionDownloadDelegate, @unchecked Se
         return true
     }
 
-    /// Remove offline playlist metadata (does not delete song files — they may be in other playlists)
+    /// Pure function: given the songs in the playlist being removed and a list of all
+    /// other OfflinePlaylists' song lists, return the songIds safe to delete from disk
+    /// (i.e., those not referenced by any other downloaded playlist).
+    static func orphanedSongIds(
+        forRemovedPlaylistSongs removedSongs: [String],
+        otherPlaylistSongLists: [[String]]
+    ) -> [String] {
+        let stillReferenced = Set(otherPlaylistSongLists.flatMap { $0 })
+        return removedSongs.filter { !stillReferenced.contains($0) }
+    }
+
+    /// Pure function: given the previous snapshot, the new content, and the other
+    /// downloaded playlists, return the songIds that became orphaned by the refresh.
+    static func orphanedSongIds(
+        forRefreshOldSongs oldSongs: [String],
+        newSongs: [String],
+        otherPlaylistSongLists: [[String]]
+    ) -> [String] {
+        let newSet = Set(newSongs)
+        let stillReferenced = Set(otherPlaylistSongLists.flatMap { $0 })
+        return oldSongs.filter { !newSet.contains($0) && !stillReferenced.contains($0) }
+    }
+
+    /// Remove offline playlist metadata. Songs from the stored snapshot are deleted
+    /// from disk unless they're referenced by another OfflinePlaylist (shared songs
+    /// are preserved). Bug #5: smart playlists rotate, so we have to delete by the
+    /// stored songIds at download time, not by the playlist's current content.
     @MainActor
     func removeOfflinePlaylist(playlistId: String) {
         guard let serverId = AppState.shared.activeServerId else { return }
@@ -241,9 +267,51 @@ final class DownloadManager: NSObject, URLSessionDownloadDelegate, @unchecked Se
         let descriptor = FetchDescriptor<OfflinePlaylist>(
             predicate: #Predicate { $0.compositeKey == key }
         )
-        if let offline = try? modelContext.fetch(descriptor).first {
-            modelContext.delete(offline)
-            try? modelContext.save()
+        guard let offline = try? modelContext.fetch(descriptor).first else { return }
+
+        let removedSongs = offline.songIds
+        modelContext.delete(offline)
+        try? modelContext.save()
+
+        let remainingPlaylists = (try? modelContext.fetch(FetchDescriptor<OfflinePlaylist>())) ?? []
+        let orphaned = Self.orphanedSongIds(
+            forRemovedPlaylistSongs: removedSongs,
+            otherPlaylistSongLists: remainingPlaylists.map(\.songIds)
+        )
+        for songId in orphaned {
+            deleteDownload(songId: songId)
+        }
+    }
+
+    /// Re-download a playlist after its content has rotated. Deletes songs from the
+    /// previous snapshot that aren't in the new content (and aren't referenced by
+    /// other OfflinePlaylists), updates the OfflinePlaylist record, and downloads
+    /// any new songs not already on disk.
+    @MainActor
+    func refreshOfflinePlaylist(playlist: Playlist, songs: [Song], client: SubsonicClient) {
+        guard let serverId = AppState.shared.activeServerId else { return }
+        let modelContext = PersistenceController.shared.container.mainContext
+        let key = "\(serverId)_\(playlist.id)"
+        let descriptor = FetchDescriptor<OfflinePlaylist>(
+            predicate: #Predicate { $0.compositeKey == key }
+        )
+        let oldSongIds = (try? modelContext.fetch(descriptor).first?.songIds) ?? []
+
+        // downloadPlaylist upserts the OfflinePlaylist with the new songIds and
+        // dedupes per-song downloads, so reuse it.
+        downloadPlaylist(playlist: playlist, songs: songs, client: client)
+
+        // Compute orphans from the OTHER playlists (excluding the one we just refreshed,
+        // since its songIds were just overwritten with the new content).
+        let allPlaylists = (try? modelContext.fetch(FetchDescriptor<OfflinePlaylist>())) ?? []
+        let otherPlaylists = allPlaylists.filter { $0.compositeKey != key }
+        let orphaned = Self.orphanedSongIds(
+            forRefreshOldSongs: oldSongIds,
+            newSongs: songs.map(\.id),
+            otherPlaylistSongLists: otherPlaylists.map(\.songIds)
+        )
+        for songId in orphaned {
+            deleteDownload(songId: songId)
         }
     }
 

--- a/Vibrdrome/Core/Models/LibraryFilter.swift
+++ b/Vibrdrome/Core/Models/LibraryFilter.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// Tri-state filter value: no filter, must be true, or must be false.
+enum TriState: String, CaseIterable, Sendable, Equatable {
+    case none, yes, no
+
+    /// Returns true if the value satisfies this filter (`.none` always passes).
+    func matches(_ value: Bool) -> Bool {
+        switch self {
+        case .none: true
+        case .yes: value
+        case .no: !value
+        }
+    }
+}
+
+/// Observable filter state for library filter sidebars (albums, artists, songs).
+/// All filtering is done locally against SwiftData.
+/// Note: Sendable conformance is implicit via @MainActor isolation (Swift 6 strict concurrency).
+@Observable
+@MainActor
+final class LibraryFilter {
+    var isFavorited: TriState = .none
+    var isRated: TriState = .none
+    var isRecentlyPlayed: Bool = false
+    var selectedArtistIds: Set<String> = []
+    var selectedGenres: Set<String> = []
+    var selectedLabels: Set<String> = []
+    var year: Int?
+
+    var isActive: Bool {
+        isFavorited != .none ||
+        isRated != .none ||
+        isRecentlyPlayed ||
+        !selectedArtistIds.isEmpty ||
+        !selectedGenres.isEmpty ||
+        !selectedLabels.isEmpty ||
+        year != nil
+    }
+
+    var activeFilterCount: Int {
+        var count = 0
+        if isFavorited != .none { count += 1 }
+        if isRated != .none { count += 1 }
+        if isRecentlyPlayed { count += 1 }
+        if !selectedArtistIds.isEmpty { count += 1 }
+        if !selectedGenres.isEmpty { count += 1 }
+        if !selectedLabels.isEmpty { count += 1 }
+        if year != nil { count += 1 }
+        return count
+    }
+
+    func reset() {
+        isFavorited = .none
+        isRated = .none
+        isRecentlyPlayed = false
+        selectedArtistIds = []
+        selectedGenres = []
+        selectedLabels = []
+        year = nil
+    }
+}

--- a/Vibrdrome/Core/Networking/OfflineActionQueue.swift
+++ b/Vibrdrome/Core/Networking/OfflineActionQueue.swift
@@ -150,7 +150,7 @@ final class OfflineActionQueue {
 
     // MARK: - Flush
 
-    /// Sync all pending actions to server
+    /// Sync all pending actions to server, with conflict detection and resolution.
     func flushPending() async {
         guard !isSyncing else { return }
         isSyncing = true
@@ -164,9 +164,14 @@ final class OfflineActionQueue {
 
         guard let actions = try? context.fetch(descriptor), !actions.isEmpty else { return }
         let client = AppState.shared.subsonicClient
+
+        // Conflict resolution: collapse contradictory actions on the same target.
+        // e.g., star + unstar on the same song → last one wins.
+        let resolved = resolveConflicts(actions: actions, context: context)
+
         var synced = 0
 
-        for action in actions {
+        for action in resolved {
             do {
                 try await executeAction(action, client: client)
                 context.delete(action)
@@ -190,6 +195,56 @@ final class OfflineActionQueue {
         if synced > 0 {
             offlineLog.info("Synced \(synced) pending actions")
         }
+    }
+
+    // MARK: - Conflict Resolution
+
+    /// Collapse contradictory actions on the same target.
+    /// Uses last-write-wins: the most recent action for each target survives.
+    private func resolveConflicts(actions: [PendingAction],
+                                  context: ModelContext) -> [PendingAction] {
+        // Group by target ID
+        var grouped: [String: [PendingAction]] = [:]
+        for action in actions {
+            grouped[action.targetId, default: []].append(action)
+        }
+
+        var resolved: [PendingAction] = []
+
+        for (_, group) in grouped {
+            // Separate star/unstar pairs from other action types
+            let starActions = group.filter {
+                $0.actionType == "star" || $0.actionType == "unstar" ||
+                $0.actionType == "starAlbum" || $0.actionType == "unstarAlbum" ||
+                $0.actionType == "starArtist" || $0.actionType == "unstarArtist"
+            }
+            let otherActions = group.filter {
+                !($0.actionType == "star" || $0.actionType == "unstar" ||
+                  $0.actionType == "starAlbum" || $0.actionType == "unstarAlbum" ||
+                  $0.actionType == "starArtist" || $0.actionType == "unstarArtist")
+            }
+
+            // Other actions (scrobbles etc.) always go through
+            resolved.append(contentsOf: otherActions)
+
+            // For star/unstar, check for contradictions
+            if starActions.count > 1 {
+                // Multiple star/unstar on same target — keep only the latest
+                let sorted = starActions.sorted { $0.createdAt < $1.createdAt }
+                let winner = sorted.last!
+                offlineLog.info("Conflict resolved (last-write-wins): \(winner.actionType) wins for \(winner.targetId)")
+
+                // Delete the losers
+                for action in sorted.dropLast() {
+                    context.delete(action)
+                }
+                resolved.append(winner)
+            } else {
+                resolved.append(contentsOf: starActions)
+            }
+        }
+
+        return resolved
     }
 
     private func executeAction(_ action: PendingAction, client: SubsonicClient) async throws {

--- a/Vibrdrome/Core/Networking/SubsonicClient.swift
+++ b/Vibrdrome/Core/Networking/SubsonicClient.swift
@@ -20,6 +20,17 @@ final class SubsonicClient {
     }
 
     var isConnected: Bool = false
+    /// Navidrome serverVersion string from the last successful ping (e.g. "0.52.5").
+    private(set) var serverVersion: String?
+
+    /// WebP cover art requires Navidrome ≥ 0.49.0. Older servers and non-Navidrome
+    /// Subsonic implementations don't support the `format` parameter on getCoverArt.
+    var supportsWebP: Bool {
+        guard let v = serverVersion else { return false }
+        let parts = v.split(separator: ".").compactMap { Int($0) }
+        guard parts.count >= 2 else { return false }
+        return (parts[0], parts[1]) >= (0, 49)
+    }
 
     init(baseURL: URL, username: String, password: String) {
         self.baseURL = baseURL
@@ -240,6 +251,7 @@ final class SubsonicClient {
     func coverArtURL(id: String, size: Int? = nil) -> URL {
         var extra = [URLQueryItem(name: "id", value: id)]
         if let size { extra.append(URLQueryItem(name: "size", value: "\(size)")) }
+        if supportsWebP { extra.append(URLQueryItem(name: "format", value: "webp")) }
         return buildURL(path: "/rest/getCoverArt", extra: extra)
     }
 
@@ -337,6 +349,7 @@ final class SubsonicClient {
         do {
             let body = try await request(.ping)
             isConnected = body.status == "ok"
+            if let sv = body.serverVersion { serverVersion = sv }
             return isConnected
         } catch {
             isConnected = false
@@ -600,6 +613,13 @@ final class SubsonicClient {
         self.baseURL = baseURL
         self.auth = SubsonicAuth(username: username, password: password)
         self.isConnected = false
+        self.serverVersion = nil
         Task { await clearCache() }
     }
+
+    #if DEBUG
+    func setServerVersionForTesting(_ version: String) {
+        serverVersion = version
+    }
+    #endif
 }

--- a/Vibrdrome/Core/Networking/SubsonicClient.swift
+++ b/Vibrdrome/Core/Networking/SubsonicClient.swift
@@ -122,7 +122,10 @@ final class SubsonicClient {
             }
         }
 
-        throw SubsonicError.httpError(500)
+        // Unreachable: the for-loop above always exits via `return` on success or `throw`
+        // on the final attempt. Using fatalError makes that invariant explicit and will
+        // surface immediately if the control-flow assumption is ever broken by a refactor.
+        fatalError("SubsonicClient.request retry loop exited without returning or throwing")
     }
 
     private func performRequest(_ endpoint: SubsonicEndpoint) async throws -> SubsonicResponseBody {

--- a/Vibrdrome/Core/Networking/SubsonicClient.swift
+++ b/Vibrdrome/Core/Networking/SubsonicClient.swift
@@ -14,6 +14,11 @@ final class SubsonicClient {
     private static let maxRetries = 3
     private static let retryDelays: [UInt64] = [1_000_000_000, 2_000_000_000, 4_000_000_000] // 1s, 2s, 4s
 
+    /// Internal marker for HTTP 429 so retry delay can honor Retry-After when present.
+    private struct RateLimitError: Error {
+        let retryAfterNanoseconds: UInt64?
+    }
+
     var isConnected: Bool = false
 
     init(baseURL: URL, username: String, password: String) {
@@ -33,6 +38,9 @@ final class SubsonicClient {
     // MARK: - Retry Logic
 
     private func isRetryable(_ error: Error) -> Bool {
+        if error is RateLimitError {
+            return true
+        }
         if let urlError = error as? URLError {
             switch urlError.code {
             case .timedOut, .networkConnectionLost, .notConnectedToInternet,
@@ -45,7 +53,7 @@ final class SubsonicClient {
         if let subsonicError = error as? SubsonicError {
             switch subsonicError {
             case .httpError(let code):
-                return code >= 500 // Only retry server errors, not 4xx
+                return code == 429 || code >= 500
             default:
                 return false
             }
@@ -53,30 +61,68 @@ final class SubsonicClient {
         return false
     }
 
+    private func retryDelayNanoseconds(for error: Error, attempt: Int) -> UInt64? {
+        guard isRetryable(error) else { return nil }
+
+        if let rateLimitError = error as? RateLimitError,
+           let retryAfter = rateLimitError.retryAfterNanoseconds {
+            return retryAfter
+        }
+
+        return Self.retryDelays[min(attempt, Self.retryDelays.count - 1)]
+    }
+
+    private func parseRetryAfterNanoseconds(from response: HTTPURLResponse) -> UInt64? {
+        guard let header = response.value(forHTTPHeaderField: "Retry-After")?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !header.isEmpty else {
+            return nil
+        }
+
+        if let seconds = TimeInterval(header), seconds > 0 {
+            return UInt64(seconds * 1_000_000_000)
+        }
+
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss z"
+
+        guard let retryDate = formatter.date(from: header) else { return nil }
+        let seconds = max(0, retryDate.timeIntervalSinceNow)
+        guard seconds > 0 else { return nil }
+        return UInt64(seconds * 1_000_000_000)
+    }
+
     // MARK: - Core Request
 
     private func request(_ endpoint: SubsonicEndpoint) async throws -> SubsonicResponseBody {
-        var lastError: Error?
-
         for attempt in 0...Self.maxRetries {
-            if attempt > 0 {
-                let delay = Self.retryDelays[min(attempt - 1, Self.retryDelays.count - 1)]
-                networkLog.info("Retry \(attempt)/\(Self.maxRetries) for \(endpoint.path) after \(delay / 1_000_000_000)s")
-                try await Task.sleep(nanoseconds: delay)
-            }
-
             do {
                 return try await performRequest(endpoint)
             } catch {
-                lastError = error
-                if !isRetryable(error) {
+                if attempt == Self.maxRetries {
+                    if error is RateLimitError {
+                        throw SubsonicError.httpError(429)
+                    }
                     throw error
                 }
-                networkLog.warning("Transient error on \(endpoint.path): \(error.localizedDescription)")
+
+                guard let delay = retryDelayNanoseconds(for: error, attempt: attempt) else {
+                    throw error
+                }
+
+                if error is RateLimitError {
+                    networkLog.warning("Rate limited on \(endpoint.path); retry \(attempt + 1)/\(Self.maxRetries) after \(delay / 1_000_000_000)s")
+                } else {
+                    networkLog.warning("Transient error on \(endpoint.path): \(error.localizedDescription)")
+                    networkLog.info("Retry \(attempt + 1)/\(Self.maxRetries) for \(endpoint.path) after \(delay / 1_000_000_000)s")
+                }
+
+                try await Task.sleep(nanoseconds: delay)
             }
         }
 
-        throw lastError!
+        throw SubsonicError.httpError(500)
     }
 
     private func performRequest(_ endpoint: SubsonicEndpoint) async throws -> SubsonicResponseBody {
@@ -102,6 +148,9 @@ final class SubsonicClient {
         guard let httpResponse = response as? HTTPURLResponse,
               (200...299).contains(httpResponse.statusCode) else {
             let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
+            if statusCode == 429, let httpResponse = response as? HTTPURLResponse {
+                throw RateLimitError(retryAfterNanoseconds: parseRetryAfterNanoseconds(from: httpResponse))
+            }
             if statusCode == 401, !AppState.shared.requiresReAuth {
                 networkLog.warning("401 Unauthorized — triggering re-authentication prompt")
                 AppState.shared.requiresReAuth = true
@@ -480,8 +529,8 @@ final class SubsonicClient {
         return body.musicFolders?.musicFolder ?? []
     }
 
-    func getIndexes(musicFolderId: String? = nil) async throws -> IndexesResponse {
-        let body = try await request(.getIndexes(musicFolderId: musicFolderId))
+    func getIndexes(musicFolderId: String? = nil, ifModifiedSince: Int? = nil) async throws -> IndexesResponse {
+        let body = try await request(.getIndexes(musicFolderId: musicFolderId, ifModifiedSince: ifModifiedSince))
         guard let indexes = body.indexes else {
             throw SubsonicError.apiError(code: 70, message: "Indexes not found")
         }

--- a/Vibrdrome/Core/Networking/SubsonicEndpoints.swift
+++ b/Vibrdrome/Core/Networking/SubsonicEndpoints.swift
@@ -51,7 +51,7 @@ enum SubsonicEndpoint: Sendable {
     case getSimilarSongs2(id: String, count: Int = 50)
     case getTopSongs(artist: String, count: Int = 50)
     case getMusicFolders
-    case getIndexes(musicFolderId: String? = nil)
+    case getIndexes(musicFolderId: String? = nil, ifModifiedSince: Int? = nil)
     case getMusicDirectory(id: String)
     case jukeboxControl(action: String, index: Int? = nil, offset: Int? = nil,
                         ids: [String]? = nil, gain: Float? = nil)
@@ -285,9 +285,10 @@ enum SubsonicEndpoint: Sendable {
                 URLQueryItem(name: "count", value: "\(count)")
             ]
 
-        case .getIndexes(let musicFolderId):
+        case .getIndexes(let musicFolderId, let ifModifiedSince):
             var items: [URLQueryItem] = []
             if let musicFolderId { items.append(URLQueryItem(name: "musicFolderId", value: musicFolderId)) }
+            if let ifModifiedSince { items.append(URLQueryItem(name: "ifModifiedSince", value: "\(ifModifiedSince)")) }
             return items
 
         case .getMusicDirectory(let id):

--- a/Vibrdrome/Core/Networking/SubsonicModels.swift
+++ b/Vibrdrome/Core/Networking/SubsonicModels.swift
@@ -137,6 +137,10 @@ struct AlbumInfo2: Decodable, Sendable {
 
 // MARK: - Album Models
 
+struct RecordLabel: Decodable, Sendable {
+    let name: String
+}
+
 struct Album: Decodable, Identifiable, Sendable {
     let id: String
     let name: String
@@ -149,8 +153,14 @@ struct Album: Decodable, Identifiable, Sendable {
     let genre: String?
     let starred: String?
     let created: String?
+    let userRating: Int?
     let song: [Song]?
     let replayGain: ReplayGain?
+    let musicBrainzId: String?
+    let recordLabels: [RecordLabel]?
+
+    /// First record label name, for convenience.
+    var label: String? { recordLabels?.first?.name }
 }
 
 struct AlbumList2Response: Decodable, Sendable {
@@ -171,7 +181,7 @@ struct TopSongsResponse: Decodable, Sendable {
 
 // MARK: - Song Model
 
-struct Song: Decodable, Identifiable, Sendable {
+struct Song: Decodable, Identifiable, Sendable, Equatable {
     let id: String
     let parent: String?
     let title: String
@@ -223,7 +233,7 @@ struct Song: Decodable, Identifiable, Sendable {
     }
 }
 
-struct ReplayGain: Decodable, Sendable {
+struct ReplayGain: Decodable, Sendable, Equatable {
     let trackGain: Double?
     let albumGain: Double?
     let trackPeak: Double?

--- a/Vibrdrome/Core/Networking/SubsonicModels.swift
+++ b/Vibrdrome/Core/Networking/SubsonicModels.swift
@@ -141,6 +141,11 @@ struct RecordLabel: Decodable, Sendable {
     let name: String
 }
 
+/// OpenSubsonic genre tag on an album or song (name-keyed, distinct from the library Genre type).
+struct ItemGenre: Decodable, Sendable {
+    let name: String
+}
+
 struct Album: Decodable, Identifiable, Sendable {
     let id: String
     let name: String
@@ -151,6 +156,7 @@ struct Album: Decodable, Identifiable, Sendable {
     let duration: Int?
     let year: Int?
     let genre: String?
+    let genres: [ItemGenre]?
     let starred: String?
     let created: String?
     let userRating: Int?
@@ -161,6 +167,15 @@ struct Album: Decodable, Identifiable, Sendable {
 
     /// First record label name, for convenience.
     var label: String? { recordLabels?.first?.name }
+
+    /// All genres for this album. Prefers the OpenSubsonic `genres` array when present;
+    /// falls back to the legacy single `genre` string.
+    var allGenres: [String] {
+        if let items = genres, !items.isEmpty {
+            return items.map(\.name)
+        }
+        return genre.map { [$0] } ?? []
+    }
 }
 
 struct AlbumList2Response: Decodable, Sendable {

--- a/Vibrdrome/Core/Persistence/BackgroundSyncScheduler.swift
+++ b/Vibrdrome/Core/Persistence/BackgroundSyncScheduler.swift
@@ -1,0 +1,154 @@
+#if os(iOS)
+import BackgroundTasks
+import Foundation
+import os.log
+
+private let bgSyncLog = Logger(subsystem: "com.vibrdrome.app", category: "BackgroundSync")
+
+/// Manages background library sync via BGTaskScheduler on iOS.
+/// Registers and schedules both app refresh and processing tasks.
+@MainActor
+final class BackgroundSyncScheduler {
+    static let shared = BackgroundSyncScheduler()
+
+    /// Task identifier for lightweight app refresh (incremental sync).
+    static let refreshTaskId = "com.vibrdrome.app.libraryRefresh"
+    /// Task identifier for longer processing task (full sync).
+    static let processingTaskId = "com.vibrdrome.app.librarySync"
+
+    private init() {}
+
+    /// Register background task handlers. Call once at app launch.
+    func registerTasks() {
+        BGTaskScheduler.shared.register(
+            forTaskWithIdentifier: Self.refreshTaskId,
+            using: nil
+        ) { task in
+            guard let refreshTask = task as? BGAppRefreshTask else { return }
+            Task { @MainActor in
+                await self.handleRefreshTask(refreshTask)
+            }
+        }
+
+        BGTaskScheduler.shared.register(
+            forTaskWithIdentifier: Self.processingTaskId,
+            using: nil
+        ) { task in
+            guard let processingTask = task as? BGProcessingTask else { return }
+            Task { @MainActor in
+                await self.handleProcessingTask(processingTask)
+            }
+        }
+
+        bgSyncLog.info("Registered background sync tasks")
+    }
+
+    /// Schedule the next background refresh. Call after each sync completes.
+    func scheduleRefresh() {
+        guard AppState.shared.isConfigured else { return }
+        guard UserDefaults.standard.bool(forKey: UserDefaultsKeys.backgroundSyncEnabled) else {
+            bgSyncLog.info("Background sync disabled, not scheduling refresh")
+            return
+        }
+
+        let request = BGAppRefreshTaskRequest(identifier: Self.refreshTaskId)
+        // Earliest: 1 hour from now
+        request.earliestBeginDate = Date(timeIntervalSinceNow: 3600)
+
+        do {
+            try BGTaskScheduler.shared.submit(request)
+            bgSyncLog.info("Scheduled background refresh for ~1 hour from now")
+        } catch {
+            bgSyncLog.error("Failed to schedule background refresh: \(error)")
+        }
+    }
+
+    /// Schedule a longer background processing task for full sync.
+    func scheduleFullSync() {
+        guard AppState.shared.isConfigured else { return }
+        guard UserDefaults.standard.bool(forKey: UserDefaultsKeys.backgroundSyncEnabled) else { return }
+
+        let request = BGProcessingTaskRequest(identifier: Self.processingTaskId)
+        request.requiresNetworkConnectivity = true
+        request.requiresExternalPower = false
+        // Earliest: 24 hours from now
+        request.earliestBeginDate = Date(timeIntervalSinceNow: 86400)
+
+        do {
+            try BGTaskScheduler.shared.submit(request)
+            bgSyncLog.info("Scheduled background full sync for ~24 hours from now")
+        } catch {
+            bgSyncLog.error("Failed to schedule background full sync: \(error)")
+        }
+    }
+
+    /// Cancel all pending background sync tasks.
+    func cancelAll() {
+        BGTaskScheduler.shared.cancel(taskRequestWithIdentifier: Self.refreshTaskId)
+        BGTaskScheduler.shared.cancel(taskRequestWithIdentifier: Self.processingTaskId)
+        bgSyncLog.info("Cancelled all background sync tasks")
+    }
+
+    // MARK: - Task Handlers
+
+    private func handleRefreshTask(_ task: BGAppRefreshTask) async {
+        bgSyncLog.info("Background refresh task started")
+
+        // Schedule the next refresh before doing work
+        scheduleRefresh()
+
+        let appState = AppState.shared
+        guard appState.isConfigured else {
+            bgSyncLog.info("App not configured, completing background refresh")
+            task.setTaskCompleted(success: true)
+            return
+        }
+
+        // Create a cancellation handler
+        let syncTask = Task {
+            await appState.librarySyncManager.incrementalSync(
+                client: appState.subsonicClient,
+                container: PersistenceController.shared.container
+            )
+        }
+
+        task.expirationHandler = {
+            syncTask.cancel()
+            bgSyncLog.warning("Background refresh task expired")
+        }
+
+        await syncTask.value
+        task.setTaskCompleted(success: appState.librarySyncManager.syncError == nil)
+        bgSyncLog.info("Background refresh task completed")
+    }
+
+    private func handleProcessingTask(_ task: BGProcessingTask) async {
+        bgSyncLog.info("Background processing task started")
+
+        // Schedule the next full sync
+        scheduleFullSync()
+
+        let appState = AppState.shared
+        guard appState.isConfigured else {
+            task.setTaskCompleted(success: true)
+            return
+        }
+
+        let syncTask = Task {
+            await appState.librarySyncManager.sync(
+                client: appState.subsonicClient,
+                container: PersistenceController.shared.container
+            )
+        }
+
+        task.expirationHandler = {
+            syncTask.cancel()
+            bgSyncLog.warning("Background processing task expired")
+        }
+
+        await syncTask.value
+        task.setTaskCompleted(success: appState.librarySyncManager.syncError == nil)
+        bgSyncLog.info("Background processing task completed")
+    }
+}
+#endif

--- a/Vibrdrome/Core/Persistence/BackgroundSyncScheduler.swift
+++ b/Vibrdrome/Core/Persistence/BackgroundSyncScheduler.swift
@@ -12,21 +12,33 @@ final class BackgroundSyncScheduler {
     static let shared = BackgroundSyncScheduler()
 
     /// Task identifier for lightweight app refresh (incremental sync).
-    static let refreshTaskId = "com.vibrdrome.app.libraryRefresh"
+    /// `nonisolated` so `registerTasks()` (itself nonisolated, called from App.init())
+    /// can read these without hopping to the main actor.
+    nonisolated static let refreshTaskId = "com.vibrdrome.app.libraryRefresh"
     /// Task identifier for longer processing task (full sync).
-    static let processingTaskId = "com.vibrdrome.app.librarySync"
+    nonisolated static let processingTaskId = "com.vibrdrome.app.librarySync"
 
     private init() {}
 
-    /// Register background task handlers. Call once at app launch.
-    func registerTasks() {
+    /// Register background task handlers. MUST be called synchronously from `App.init()`
+    /// before the app finishes launching. If iOS launches the app specifically to handle
+    /// a background task, registration must already be in place or the handler is missing
+    /// and the task fails silently.
+    ///
+    /// `nonisolated` so it can run on whatever thread initializes the SwiftUI `App` struct
+    /// without an `await` hop; `BGTaskScheduler.register` is thread-safe.
+    nonisolated func registerTasks() {
         BGTaskScheduler.shared.register(
             forTaskWithIdentifier: Self.refreshTaskId,
             using: nil
         ) { task in
             guard let refreshTask = task as? BGAppRefreshTask else { return }
+            // BGTask subclasses are not Sendable; transferring them into a MainActor Task
+            // is safe here because the system invokes the handler exactly once and we do
+            // not touch the task from any other isolation domain.
+            nonisolated(unsafe) let unsafeTask = refreshTask
             Task { @MainActor in
-                await self.handleRefreshTask(refreshTask)
+                await self.handleRefreshTask(unsafeTask)
             }
         }
 
@@ -35,8 +47,9 @@ final class BackgroundSyncScheduler {
             using: nil
         ) { task in
             guard let processingTask = task as? BGProcessingTask else { return }
+            nonisolated(unsafe) let unsafeTask = processingTask
             Task { @MainActor in
-                await self.handleProcessingTask(processingTask)
+                await self.handleProcessingTask(unsafeTask)
             }
         }
 

--- a/Vibrdrome/Core/Persistence/LibraryDataCache.swift
+++ b/Vibrdrome/Core/Persistence/LibraryDataCache.swift
@@ -17,6 +17,8 @@ final class LibraryDataCache {
     private(set) var songFilterGenres: [String]?
 
     /// Incremented after each successful rebuild so views can detect changes via `.onChange`.
+    /// Intentionally in-session only (not persisted) — resets to 0 on launch. Views only need
+    /// to detect changes *within* a session; cross-launch staleness is handled by `LibrarySyncManager`.
     private(set) var generation: Int = 0
 
     private var buildTask: Task<Void, Never>?

--- a/Vibrdrome/Core/Persistence/LibraryDataCache.swift
+++ b/Vibrdrome/Core/Persistence/LibraryDataCache.swift
@@ -1,0 +1,118 @@
+import Foundation
+import SwiftData
+import os.log
+
+private let cacheLog = Logger(subsystem: "com.vibrdrome.app", category: "LibraryCache")
+
+/// Pre-computes converted model arrays on a background thread so library tabs
+/// are ready instantly when first selected.
+@Observable
+@MainActor
+final class LibraryDataCache {
+    private(set) var songs: [Song]?
+    private(set) var artists: [Artist]?
+    private(set) var albums: [Album]?
+    private(set) var songFilterYears: [Int]?
+    private(set) var songFilterArtists: [String]?
+    private(set) var songFilterGenres: [String]?
+
+    /// Incremented after each successful rebuild so views can detect changes via `.onChange`.
+    private(set) var generation: Int = 0
+
+    private var buildTask: Task<Void, Never>?
+
+    /// Kick off a background rebuild of all cached model arrays.
+    func rebuild(container: ModelContainer) {
+        buildTask?.cancel()
+        buildTask = Task {
+            let result = await Task.detached(priority: .userInitiated) {
+                Self.buildCache(container: container)
+            }.value
+            guard !Task.isCancelled else { return }
+            songs = result.songs
+            artists = result.artists
+            albums = result.albums
+            songFilterYears = result.years
+            songFilterArtists = result.artistNames
+            songFilterGenres = result.genres
+            generation += 1
+            cacheLog.info("Library cache ready — \(result.songs.count) songs, \(result.artists.count) artists, \(result.albums.count) albums")
+        }
+    }
+
+    /// Clear all cached data (e.g. on logout or server switch).
+    func invalidate() {
+        buildTask?.cancel()
+        songs = nil
+        artists = nil
+        albums = nil
+        songFilterYears = nil
+        songFilterArtists = nil
+        songFilterGenres = nil
+    }
+
+    // MARK: - Background Work
+
+    private struct CacheResult: Sendable {
+        let songs: [Song]
+        let artists: [Artist]
+        let albums: [Album]
+        let years: [Int]
+        let artistNames: [String]
+        let genres: [String]
+    }
+
+    nonisolated private static func buildCache(container: ModelContainer) -> CacheResult {
+        let context = ModelContext(container)
+        context.autosaveEnabled = false
+
+        // Artists
+        let artistDescriptor = FetchDescriptor<CachedArtist>(sortBy: [SortDescriptor<CachedArtist>(\.name)])
+        let convertedArtists: [Artist]
+        if let cached = try? context.fetch(artistDescriptor) {
+            convertedArtists = cached.map { $0.toArtist() }
+        } else {
+            convertedArtists = []
+        }
+
+        // Albums
+        let albumDescriptor = FetchDescriptor<CachedAlbum>(sortBy: [SortDescriptor<CachedAlbum>(\.name)])
+        let convertedAlbums: [Album]
+        if let cached = try? context.fetch(albumDescriptor) {
+            convertedAlbums = cached.map { $0.toAlbum() }
+        } else {
+            convertedAlbums = []
+        }
+
+        // Songs — single pass for conversion + filter option extraction
+        let songDescriptor = FetchDescriptor<CachedSong>(sortBy: [SortDescriptor<CachedSong>(\.title)])
+        var convertedSongs = [Song]()
+        var yearSet = Set<Int>()
+        var artistSet = Set<String>()
+        var genreSet = Set<String>()
+        if let cached = try? context.fetch(songDescriptor) {
+            convertedSongs.reserveCapacity(cached.count)
+            for item in cached {
+                convertedSongs.append(item.toSong())
+                if let year = item.year { yearSet.insert(year) }
+                if let artist = item.artist { artistSet.insert(artist) }
+                if let genre = item.genre { genreSet.insert(genre) }
+            }
+        }
+
+        let sortedYears = yearSet.sorted(by: >)
+        let sortedArtists = Array(artistSet)
+            .sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
+        let sortedGenres = Array(genreSet)
+            .sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
+
+        return CacheResult(
+            songs: convertedSongs,
+            artists: convertedArtists,
+            albums: convertedAlbums,
+            years: sortedYears,
+            artistNames: sortedArtists,
+            genres: sortedGenres
+        )
+    }
+}

--- a/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
+++ b/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
@@ -42,8 +42,10 @@ final class LibrarySyncManager {
 
     // Page sizes for paginated API calls. 500 is a safe default for most Subsonic servers;
     // could be made configurable per-server if needed for very large or constrained instances.
-    private let albumPageSize = 500
-    private let songPageSize = 500
+    // `nonisolated` so the `nonisolated static` sync helpers running off the main actor can
+    // read them without hopping back to MainActor just to read a constant.
+    nonisolated static let albumPageSize = 500
+    nonisolated static let songPageSize = 500
 
     /// Stale threshold for auto-sync (24 hours).
     private let staleInterval: TimeInterval = 86400
@@ -164,31 +166,64 @@ final class LibrarySyncManager {
             syncProgress = nil
         }
 
+        // Progress callback — hops to MainActor to update @Observable state.
+        // Marked @Sendable so it's safe to pass into nonisolated static helpers.
+        @Sendable func updateProgress(_ message: String) {
+            Task { @MainActor in
+                self.syncProgress = message
+            }
+        }
+        @Sendable func publishPartialStats(_ partial: SyncStats) {
+            Task { @MainActor in
+                self.lastSyncStats = partial
+            }
+        }
+
         do {
-            let context = ModelContext(container)
-            context.autosaveEnabled = false
+            // All heavy lifting (SwiftData fetch/insert/save + per-row diff loops) happens on a
+            // detached task using a background ModelContext. This keeps the main actor free so
+            // the polling task (which fires every 15+ min) doesn't stutter UI on large libraries.
+            // Background mode is incremental-only: BGAppRefreshTask gets ~30s of CPU, a full sync
+            // on a large library would hit the expirationHandler and be killed.
+            let incremental = (mode == .incremental || mode == .background)
 
-            switch mode {
-            case .full, .background:
-                try await syncAlbums(client: client, context: context, stats: &stats, incremental: false)
-                try await syncArtists(client: client, context: context, stats: &stats, incremental: false)
-                try await syncSongs(client: client, context: context, stats: &stats, incremental: false)
-                try await syncPlaylists(client: client, context: context, stats: &stats)
+            stats = try await Task.detached(priority: .utility) { () -> SyncStats in
+                var working = SyncStats()
+
+                try await Self.syncAlbumsOffMain(
+                    client: client, container: container,
+                    stats: &working, incremental: incremental,
+                    progress: updateProgress, publishStats: publishPartialStats
+                )
+                try await Self.syncArtistsOffMain(
+                    client: client, container: container,
+                    stats: &working, incremental: incremental,
+                    progress: updateProgress, publishStats: publishPartialStats
+                )
+                try await Self.syncSongsOffMain(
+                    client: client, container: container,
+                    stats: &working, incremental: incremental,
+                    progress: updateProgress, publishStats: publishPartialStats
+                )
+                try await Self.syncPlaylistsOffMain(
+                    client: client, container: container,
+                    stats: &working,
+                    progress: updateProgress, publishStats: publishPartialStats
+                )
+                return working
+            }.value
+
+            if mode == .full {
                 UserDefaults.standard.set(Date(), forKey: UserDefaultsKeys.lastFullSyncDate)
-
-            case .incremental:
-                try await syncAlbums(client: client, context: context, stats: &stats, incremental: true)
-                try await syncArtists(client: client, context: context, stats: &stats, incremental: true)
-                try await syncSongs(client: client, context: context, stats: &stats, incremental: true)
-                try await syncPlaylists(client: client, context: context, stats: &stats)
             }
 
-            try context.save()
             lastSyncDate = Date()
             lastSyncStats = stats
 
-            // Save sync history
-            saveSyncHistory(stats: stats, mode: mode, context: context)
+            // Save sync history on a fresh context (the work context above is already gone).
+            let historyContext = ModelContext(container)
+            historyContext.autosaveEnabled = false
+            saveSyncHistory(stats: stats, mode: mode, context: historyContext)
 
             syncLog.info("""
                 Library sync (\(mode.rawValue)) completed in \
@@ -199,9 +234,14 @@ final class LibrarySyncManager {
                 -\(stats.albumsRemoved + stats.artistsRemoved + stats.songsRemoved))
                 """)
 
-            // Prefetch cover art in background after metadata sync
-            if stats.albumsAdded > 0 || stats.artistsAdded > 0 {
-                await prefetchCoverArt(client: client, context: context)
+            // Prefetch cover art in background after metadata sync. Also fires when existing
+            // albums/artists gain a new coverArtId (e.g. server-side art-scan completes after
+            // the metadata was already cached), not just when new rows are inserted.
+            let artChanged = stats.albumsAdded > 0 || stats.artistsAdded > 0 ||
+                stats.albumsUpdated > 0 || stats.artistsUpdated > 0
+            if artChanged {
+                let prefetchContext = ModelContext(container)
+                await prefetchCoverArt(client: client, context: prefetchContext)
             }
         } catch {
             syncError = "Sync failed: \(error.localizedDescription)"
@@ -232,23 +272,22 @@ final class LibrarySyncManager {
         }
     }
 
-    /// Update the stored server lastModified timestamp.
-    private func updateServerModifiedTimestamp(client: SubsonicClient) async {
-        do {
-            let indexes = try await client.getIndexes()
-            if let lastModified = indexes.lastModified {
-                UserDefaults.standard.set(lastModified, forKey: UserDefaultsKeys.lastServerModified)
-            }
-        } catch {
-            syncLog.warning("Failed to fetch server modified timestamp: \(error.localizedDescription)")
-        }
-    }
-
     // MARK: - Albums
 
-    private func syncAlbums(client: SubsonicClient, context: ModelContext,
-                            stats: inout SyncStats, incremental: Bool) async throws {
-        syncProgress = "Syncing albums…"
+    /// Nonisolated so the fetch / insert / diff loops run off MainActor. On 10k+ libraries
+    /// these previously stuttered the UI every polling interval.
+    nonisolated static func syncAlbumsOffMain(
+        client: SubsonicClient,
+        container: ModelContainer,
+        stats: inout SyncStats,
+        incremental: Bool,
+        progress: @Sendable (String) -> Void,
+        publishStats: @Sendable (SyncStats) -> Void
+    ) async throws {
+        progress("Syncing albums…")
+
+        let context = ModelContext(container)
+        context.autosaveEnabled = false
 
         // Build lookup dictionary of existing albums for O(1) access
         let allLocal = try context.fetch(FetchDescriptor<CachedAlbum>())
@@ -300,7 +339,7 @@ final class LibrarySyncManager {
                 }
 
                 totalFetched += page.count
-                syncProgress = "Syncing albums… \(totalFetched)"
+                progress("Syncing albums… \(totalFetched)")
                 offset += page.count
 
                 if page.count < albumPageSize { break }
@@ -314,14 +353,14 @@ final class LibrarySyncManager {
         }
 
         try context.save()
-        lastSyncStats = stats
+        publishStats(stats)
         let added = stats.albumsAdded
         let updated = stats.albumsUpdated
         let removed = stats.albumsRemoved
         syncLog.info("Synced \(totalFetched) albums (+\(added) ~\(updated) -\(removed))")
     }
 
-    private func hasAlbumChanged(_ cached: CachedAlbum, _ server: Album) -> Bool {
+    nonisolated static func hasAlbumChanged(_ cached: CachedAlbum, _ server: Album) -> Bool {
         cached.name != server.name ||
         cached.artistName != server.artist ||
         cached.artistId != server.artistId ||
@@ -338,11 +377,20 @@ final class LibrarySyncManager {
 
     // MARK: - Artists
 
-    private func syncArtists(client: SubsonicClient, context: ModelContext,
-                             stats: inout SyncStats, incremental: Bool) async throws {
-        syncProgress = "Syncing artists…"
+    nonisolated static func syncArtistsOffMain(
+        client: SubsonicClient,
+        container: ModelContainer,
+        stats: inout SyncStats,
+        incremental: Bool,
+        progress: @Sendable (String) -> Void,
+        publishStats: @Sendable (SyncStats) -> Void
+    ) async throws {
+        progress("Syncing artists…")
         let indexes = try await client.getArtists()
         var serverArtistIds = Set<String>()
+
+        let context = ModelContext(container)
+        context.autosaveEnabled = false
 
         // Build lookup dictionary
         let allLocal = try context.fetch(FetchDescriptor<CachedArtist>())
@@ -376,14 +424,14 @@ final class LibrarySyncManager {
         }
 
         try context.save()
-        lastSyncStats = stats
+        publishStats(stats)
         let artAdded = stats.artistsAdded
         let artUpdated = stats.artistsUpdated
         let artRemoved = stats.artistsRemoved
         syncLog.info("Synced \(serverArtistIds.count) artists (+\(artAdded) ~\(artUpdated) -\(artRemoved))")
     }
 
-    private func hasArtistChanged(_ cached: CachedArtist, _ server: Artist) -> Bool {
+    nonisolated static func hasArtistChanged(_ cached: CachedArtist, _ server: Artist) -> Bool {
         cached.name != server.name ||
         cached.coverArtId != server.coverArt ||
         cached.albumCount != server.albumCount ||
@@ -392,9 +440,18 @@ final class LibrarySyncManager {
 
     // MARK: - Songs
 
-    private func syncSongs(client: SubsonicClient, context: ModelContext,
-                           stats: inout SyncStats, incremental: Bool) async throws {
-        syncProgress = "Syncing songs…"
+    nonisolated static func syncSongsOffMain(
+        client: SubsonicClient,
+        container: ModelContainer,
+        stats: inout SyncStats,
+        incremental: Bool,
+        progress: @Sendable (String) -> Void,
+        publishStats: @Sendable (SyncStats) -> Void
+    ) async throws {
+        progress("Syncing songs…")
+
+        let context = ModelContext(container)
+        context.autosaveEnabled = false
 
         // Build lookup dictionary for O(1) access
         let allLocal = try context.fetch(FetchDescriptor<CachedSong>())
@@ -435,12 +492,12 @@ final class LibrarySyncManager {
             }
 
             totalFetched += songs.count
-            syncProgress = "Syncing songs… \(totalFetched)"
+            progress("Syncing songs… \(totalFetched)")
             offset += songs.count
 
             if totalFetched % 2000 == 0 {
                 try context.save()
-                lastSyncStats = stats
+                publishStats(stats)
             }
 
             if songs.count < songPageSize { break }
@@ -455,7 +512,7 @@ final class LibrarySyncManager {
         }
 
         try context.save()
-        lastSyncStats = stats
+        publishStats(stats)
         await updateServerModifiedTimestamp(client: client)
         let songAdded = stats.songsAdded
         let songUpdated = stats.songsUpdated
@@ -463,7 +520,19 @@ final class LibrarySyncManager {
         syncLog.info("Synced \(totalFetched) songs (+\(songAdded) ~\(songUpdated) -\(songRemoved))")
     }
 
-    private func hasSongChanged(_ cached: CachedSong, _ server: Song) -> Bool {
+    /// Nonisolated so songs sync (off MainActor) can call it directly.
+    nonisolated static func updateServerModifiedTimestamp(client: SubsonicClient) async {
+        do {
+            let indexes = try await client.getIndexes()
+            if let lastModified = indexes.lastModified {
+                UserDefaults.standard.set(lastModified, forKey: UserDefaultsKeys.lastServerModified)
+            }
+        } catch {
+            syncLog.warning("Failed to fetch server modified timestamp: \(error.localizedDescription)")
+        }
+    }
+
+    nonisolated static func hasSongChanged(_ cached: CachedSong, _ server: Song) -> Bool {
         cached.title != server.title ||
         cached.artist != server.artist ||
         cached.albumName != server.album ||
@@ -476,7 +545,7 @@ final class LibrarySyncManager {
         cached.bitRate != server.bitRate
     }
 
-    private func updateSongFields(_ cached: CachedSong, from song: Song) {
+    nonisolated static func updateSongFields(_ cached: CachedSong, from song: Song) {
         cached.title = song.title
         cached.artist = song.artist
         cached.albumArtist = song.albumArtist
@@ -500,11 +569,24 @@ final class LibrarySyncManager {
 
     // MARK: - Playlists
 
-    private func syncPlaylists(client: SubsonicClient, context: ModelContext,
-                               stats: inout SyncStats) async throws {
-        syncProgress = "Syncing playlists…"
+    nonisolated static func syncPlaylistsOffMain(
+        client: SubsonicClient,
+        container: ModelContainer,
+        stats: inout SyncStats,
+        progress: @Sendable (String) -> Void,
+        publishStats: @Sendable (SyncStats) -> Void
+    ) async throws {
+        progress("Syncing playlists…")
+
+        let context = ModelContext(container)
+        context.autosaveEnabled = false
+
         let playlists = try await client.getPlaylists()
-        var serverPlaylistIds = Set<String>()
+
+        // Source of truth for "what exists on the server" is the getPlaylists() list — NOT the
+        // set of playlists whose details we managed to fetch below. A transient failure on a
+        // single getPlaylist(id:) call must not cause its cached row to be deleted locally.
+        let serverPlaylistIds = Set(playlists.map { $0.id })
 
         let allLocal = try context.fetch(FetchDescriptor<CachedPlaylist>())
         let localMap = Dictionary(uniqueKeysWithValues: allLocal.map { ($0.id, $0) })
@@ -538,22 +620,23 @@ final class LibrarySyncManager {
         }
 
         for detail in details {
-            serverPlaylistIds.insert(detail.id)
             upsertPlaylist(detail, context: context, localMap: localMap)
             stats.playlistsSynced += 1
         }
 
+        // Only delete local playlists that are confirmed missing from the server list.
+        // Playlists whose detail fetch failed will simply retain their existing cached entries.
         for local in allLocal where !serverPlaylistIds.contains(local.id) {
             context.delete(local)
         }
 
         try context.save()
-        lastSyncStats = stats
+        publishStats(stats)
         syncLog.info("Synced \(playlists.count) playlists with entries")
     }
 
-    private func upsertPlaylist(_ playlist: Playlist, context: ModelContext,
-                                localMap: [String: CachedPlaylist]) {
+    nonisolated static func upsertPlaylist(_ playlist: Playlist, context: ModelContext,
+                                           localMap: [String: CachedPlaylist]) {
         let cached: CachedPlaylist
         if let existing = localMap[playlist.id] {
             existing.name = playlist.name

--- a/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
+++ b/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
@@ -590,6 +590,12 @@ final class LibrarySyncManager {
     /// Skipped if a prefetch already ran during sync this session.
     func warmImageCache(client: SubsonicClient, container: ModelContainer) async {
         guard !didPrefetchThisSession else { return }
+        // Skip if a full prefetch completed recently (within 24 hours)
+        if let lastPrefetch = UserDefaults.standard.object(forKey: UserDefaultsKeys.lastCoverArtPrefetchDate) as? Date,
+           Date().timeIntervalSince(lastPrefetch) < 86_400 {
+            didPrefetchThisSession = true
+            return
+        }
         let context = ModelContext(container)
         await prefetchCoverArt(client: client, context: context)
     }
@@ -624,22 +630,39 @@ final class LibrarySyncManager {
         syncLog.info("Prefetching \(total) cover art images")
 
         let pipeline = ImagePipeline.shared
-        let urlMap: [(String, URL)] = coverArtIds.map { id in
-            (id, client.coverArtURL(id: id, size: 600))
+
+        // Filter out images already in memory or disk cache so we only fetch what's missing
+        let dataCache = pipeline.configuration.dataCache as? DataCache
+        let uncachedUrls: [(String, URL)] = coverArtIds.compactMap { id in
+            let url = client.coverArtURL(id: id, size: 600)
+            let request = ImageRequest(url: url)
+            if pipeline.cache.containsCachedImage(for: request) { return nil }
+            let key = pipeline.cache.makeDataCacheKey(for: request)
+            if dataCache?.containsData(for: key) == true { return nil }
+            return (id, url)
         }
 
-        var fetched = 0
+        let alreadyCached = total - uncachedUrls.count
+        guard !uncachedUrls.isEmpty else {
+            didPrefetchThisSession = true
+            UserDefaults.standard.set(Date(), forKey: UserDefaultsKeys.lastCoverArtPrefetchDate)
+            syncLog.info("Cover art prefetch skipped — all \(total) images already cached")
+            return
+        }
+
+        syncLog.info("Prefetching \(uncachedUrls.count) cover art images (\(alreadyCached) already cached)")
+
+        var fetched = alreadyCached
         let batchSize = 10
         let perImageTimeout: UInt64 = 15_000_000_000 // 15 seconds
 
-        for batchStart in stride(from: 0, to: urlMap.count, by: batchSize) {
+        for batchStart in stride(from: 0, to: uncachedUrls.count, by: batchSize) {
             guard !Task.isCancelled else { break }
-            let batch = urlMap[batchStart..<min(batchStart + batchSize, urlMap.count)]
+            let batch = uncachedUrls[batchStart..<min(batchStart + batchSize, uncachedUrls.count)]
             await withTaskGroup(of: Void.self) { group in
                 for (_, url) in batch {
                     group.addTask {
                         let request = ImageRequest(url: url)
-                        if pipeline.cache.containsCachedImage(for: request) { return }
                         // Timeout prevents a single stalled request from blocking the entire prefetch
                         await withTaskGroup(of: Void.self) { inner in
                             inner.addTask {
@@ -660,7 +683,8 @@ final class LibrarySyncManager {
         }
 
         didPrefetchThisSession = true
-        syncLog.info("Cover art prefetch complete: \(fetched) processed")
+        UserDefaults.standard.set(Date(), forKey: UserDefaultsKeys.lastCoverArtPrefetchDate)
+        syncLog.info("Cover art prefetch complete: \(fetched)/\(total) processed")
     }
 
     // MARK: - Sync History

--- a/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
+++ b/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
@@ -40,6 +40,8 @@ final class LibrarySyncManager {
     /// Polling timer for change detection while app is active.
     private var pollingTask: Task<Void, Never>?
 
+    // Page sizes for paginated API calls. 500 is a safe default for most Subsonic servers;
+    // could be made configurable per-server if needed for very large or constrained instances.
     private let albumPageSize = 500
     private let songPageSize = 500
 

--- a/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
+++ b/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
@@ -509,27 +509,29 @@ final class LibrarySyncManager {
         let allLocal = try context.fetch(FetchDescriptor<CachedPlaylist>())
         let localMap = Dictionary(uniqueKeysWithValues: allLocal.map { ($0.id, $0) })
 
-        // Fetch playlist details with bounded concurrency
-        let details = try await withThrowingTaskGroup(of: Playlist.self, returning: [Playlist].self) { group in
+        // Fetch playlist details with bounded concurrency (tolerates individual failures e.g. deleted playlists)
+        let details = await withTaskGroup(of: Playlist?.self, returning: [Playlist].self) { group in
             var results: [Playlist] = []
             var inflight = 0
             let maxConcurrency = 2
 
             for playlist in playlists {
                 if inflight >= maxConcurrency {
-                    if let detail = try await group.next() {
+                    if let detail = await group.next() ?? nil {
                         results.append(detail)
                     }
                     inflight -= 1
                 }
                 group.addTask {
-                    try await client.getPlaylist(id: playlist.id)
+                    try? await client.getPlaylist(id: playlist.id)
                 }
                 inflight += 1
             }
 
-            for try await detail in group {
-                results.append(detail)
+            for await detail in group {
+                if let detail {
+                    results.append(detail)
+                }
             }
             return results
         }

--- a/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
+++ b/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
@@ -154,6 +154,7 @@ final class LibrarySyncManager {
 
     // MARK: - Core Sync Engine
 
+    // swiftlint:disable:next function_body_length
     private func performSync(mode: SyncMode, client: SubsonicClient, container: ModelContainer) async {
         guard !isSyncing else { return }
         isSyncing = true
@@ -274,8 +275,7 @@ final class LibrarySyncManager {
 
     // MARK: - Albums
 
-    /// Nonisolated so the fetch / insert / diff loops run off MainActor. On 10k+ libraries
-    /// these previously stuttered the UI every polling interval.
+    // swiftlint:disable:next function_body_length function_parameter_count
     nonisolated static func syncAlbumsOffMain(
         client: SubsonicClient,
         container: ModelContainer,
@@ -377,6 +377,7 @@ final class LibrarySyncManager {
 
     // MARK: - Artists
 
+    // swiftlint:disable:next function_parameter_count
     nonisolated static func syncArtistsOffMain(
         client: SubsonicClient,
         container: ModelContainer,
@@ -440,6 +441,7 @@ final class LibrarySyncManager {
 
     // MARK: - Songs
 
+    // swiftlint:disable:next function_parameter_count
     nonisolated static func syncSongsOffMain(
         client: SubsonicClient,
         container: ModelContainer,

--- a/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
+++ b/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
@@ -37,6 +37,10 @@ final class LibrarySyncManager {
     /// Stats from the most recent sync, updated live during sync.
     var lastSyncStats: SyncStats?
 
+    /// Called on MainActor after each successful sync completes. Wire this up in the app startup
+    /// task to trigger a library cache rebuild so filters see fresh data after polling syncs.
+    var onSyncCompleted: (@MainActor () -> Void)?
+
     /// Polling timer for change detection while app is active.
     private var pollingTask: Task<Void, Never>?
 
@@ -206,6 +210,7 @@ final class LibrarySyncManager {
                     stats: &working, incremental: incremental,
                     progress: updateProgress, publishStats: publishPartialStats
                 )
+                try Self.backfillAlbumGenresOffMain(container: container, progress: updateProgress)
                 try await Self.syncPlaylistsOffMain(
                     client: client, container: container,
                     stats: &working,
@@ -220,6 +225,7 @@ final class LibrarySyncManager {
 
             lastSyncDate = Date()
             lastSyncStats = stats
+            onSyncCompleted?()
 
             // Save sync history on a fresh context (the work context above is already gone).
             let historyContext = ModelContext(container)
@@ -365,7 +371,7 @@ final class LibrarySyncManager {
         cached.artistName != server.artist ||
         cached.artistId != server.artistId ||
         cached.year != server.year ||
-        cached.genre != server.genre ||
+        Set(cached.genres) != Set(server.allGenres) ||
         cached.songCount != server.songCount ||
         cached.duration != server.duration ||
         cached.isStarred != (server.starred != nil) ||
@@ -567,6 +573,51 @@ final class LibrarySyncManager {
         cached.isStarred = song.starred != nil
         cached.rating = song.userRating ?? 0
         cached.cachedAt = Date()
+    }
+
+    // MARK: - Genre Backfill
+
+    nonisolated static func backfillAlbumGenresOffMain(
+        container: ModelContainer,
+        progress: @Sendable (String) -> Void
+    ) throws {
+        let context = ModelContext(container)
+        context.autosaveEnabled = false
+
+        // Target albums where getAlbumList returned no genres
+        let emptyGenresDescriptor = FetchDescriptor<CachedAlbum>(
+            predicate: #Predicate<CachedAlbum> { $0.genres.isEmpty }
+        )
+        let albumsNeedingGenres = try context.fetch(emptyGenresDescriptor)
+        guard !albumsNeedingGenres.isEmpty else { return }
+
+        progress("Backfilling album genres…")
+
+        let songsDescriptor = FetchDescriptor<CachedSong>(
+            predicate: #Predicate<CachedSong> { $0.genre != nil && $0.albumId != nil }
+        )
+        let songsWithGenre = try context.fetch(songsDescriptor)
+
+        // Build albumId → Set<genre> from songs belonging to empty-genre albums
+        let albumIds = Set(albumsNeedingGenres.map { $0.id })
+        var albumGenres: [String: Set<String>] = [:]
+        for song in songsWithGenre {
+            guard let albumId = song.albumId, albumIds.contains(albumId),
+                  let genre = song.genre, !genre.isEmpty else { continue }
+            albumGenres[albumId, default: []].insert(genre)
+        }
+
+        var backfilledCount = 0
+        for album in albumsNeedingGenres {
+            guard let genres = albumGenres[album.id], !genres.isEmpty else { continue }
+            album.genres = genres.sorted()
+            backfilledCount += 1
+        }
+
+        if backfilledCount > 0 {
+            try context.save()
+            syncLog.info("Backfilled genres for \(backfilledCount) albums from song metadata")
+        }
     }
 
     // MARK: - Playlists

--- a/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
+++ b/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
@@ -117,7 +117,7 @@ final class LibrarySyncManager {
         } else {
             // Server unchanged — just update the stale check timestamp
             lastSyncDate = Date()
-            syncLog.info("Server data unchanged, skipping sync")
+            syncLog.info("Server data unchanged, skipping sync (trigger: auto-stale-check)")
         }
     }
 
@@ -136,7 +136,7 @@ final class LibrarySyncManager {
 
                 let changed = await self.hasServerChanged(client: client)
                 if changed {
-                    syncLog.info("Polling detected server changes, triggering incremental sync")
+                    syncLog.info("Polling detected server changes, triggering incremental sync (trigger: auto-poll)")
                     await self.performSync(mode: .incremental, client: client, container: container)
                 }
             }
@@ -517,6 +517,7 @@ final class LibrarySyncManager {
 
             for playlist in playlists {
                 if inflight >= maxConcurrency {
+                    // swiftlint:disable:next redundant_nil_coalescing
                     if let detail = await group.next() ?? nil {
                         results.append(detail)
                     }
@@ -654,6 +655,16 @@ final class LibrarySyncManager {
 
         syncLog.info("Prefetching \(uncachedUrls.count) cover art images (\(alreadyCached) already cached)")
 
+        let fetched = await prefetchBatches(uncachedUrls: uncachedUrls, total: total, alreadyCached: alreadyCached)
+
+        didPrefetchThisSession = true
+        UserDefaults.standard.set(Date(), forKey: UserDefaultsKeys.lastCoverArtPrefetchDate)
+        syncLog.info("Cover art prefetch complete: \(fetched)/\(total) processed")
+    }
+
+    /// Fetch cover art in batches of 10 with per-image timeouts. Returns total processed count.
+    private func prefetchBatches(uncachedUrls: [(String, URL)], total: Int, alreadyCached: Int) async -> Int {
+        let pipeline = ImagePipeline.shared
         var fetched = alreadyCached
         let batchSize = 10
         let perImageTimeout: UInt64 = 15_000_000_000 // 15 seconds
@@ -683,10 +694,7 @@ final class LibrarySyncManager {
             fetched += batch.count
             syncProgress = "Prefetching cover art… \(fetched)/\(total)"
         }
-
-        didPrefetchThisSession = true
-        UserDefaults.standard.set(Date(), forKey: UserDefaultsKeys.lastCoverArtPrefetchDate)
-        syncLog.info("Cover art prefetch complete: \(fetched)/\(total) processed")
+        return fetched
     }
 
     // MARK: - Sync History

--- a/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
+++ b/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
@@ -601,9 +601,8 @@ final class LibrarySyncManager {
 
             for playlist in playlists {
                 if inflight >= maxConcurrency {
-                    // swiftlint:disable:next redundant_nil_coalescing
-                    if let detail = await group.next() ?? nil {
-                        results.append(detail)
+                    if let detail = await group.next(), let playlist = detail {
+                        results.append(playlist)
                     }
                     inflight -= 1
                 }

--- a/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
+++ b/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
@@ -1,0 +1,706 @@
+import Foundation
+import Nuke
+import SwiftData
+import os.log
+
+private let syncLog = Logger(subsystem: "com.vibrdrome.app", category: "LibrarySync")
+
+/// Sync mode determines the depth of library synchronization.
+enum SyncMode: String, Sendable {
+    /// Full re-sync of all metadata — catches additions, updates, and deletions.
+    case full
+    /// Lightweight sync — only fetches recently changed content.
+    case incremental
+    /// Triggered by BGTaskScheduler in the background.
+    case background
+}
+
+/// Syncs library metadata (albums, artists, songs, playlists) from the Subsonic API
+/// into SwiftData for local filtering, search, and offline support.
+@Observable
+@MainActor
+final class LibrarySyncManager {
+    static let shared = LibrarySyncManager()
+
+    /// Configured by AppState at login for convenience sync calls.
+    weak var client: SubsonicClient?
+    var container: ModelContainer?
+
+    var isSyncing = false
+    var syncProgress: String?
+    var lastSyncDate: Date? {
+        get { UserDefaults.standard.object(forKey: UserDefaultsKeys.lastLibrarySyncDate) as? Date }
+        set { UserDefaults.standard.set(newValue, forKey: UserDefaultsKeys.lastLibrarySyncDate) }
+    }
+    var syncError: String?
+
+    /// Stats from the most recent sync, updated live during sync.
+    var lastSyncStats: SyncStats?
+
+    /// Polling timer for change detection while app is active.
+    private var pollingTask: Task<Void, Never>?
+
+    private let albumPageSize = 500
+    private let songPageSize = 500
+
+    /// Stale threshold for auto-sync (24 hours).
+    private let staleInterval: TimeInterval = 86400
+    /// Interval between full syncs to catch deletions (7 days).
+    private let fullSyncInterval: TimeInterval = 604_800
+
+    // MARK: - Sync Stats
+
+    struct SyncStats: Sendable {
+        var albumsAdded = 0
+        var albumsUpdated = 0
+        var albumsRemoved = 0
+        var artistsAdded = 0
+        var artistsUpdated = 0
+        var artistsRemoved = 0
+        var songsAdded = 0
+        var songsUpdated = 0
+        var songsRemoved = 0
+        var playlistsSynced = 0
+        var conflictsDetected = 0
+        var conflictsResolved = 0
+        var startTime = Date()
+
+        var totalChanges: Int {
+            albumsAdded + albumsUpdated + albumsRemoved +
+            artistsAdded + artistsUpdated + artistsRemoved +
+            songsAdded + songsUpdated + songsRemoved
+        }
+
+        var duration: TimeInterval {
+            Date().timeIntervalSince(startTime)
+        }
+    }
+
+    // MARK: - Public API
+
+    /// Run a full library sync: albums, artists, songs, then playlists.
+    func sync(client: SubsonicClient, container: ModelContainer) async {
+        await performSync(mode: .full, client: client, container: container)
+    }
+
+    /// Run an incremental sync — only fetches changes since last sync.
+    func incrementalSync(client: SubsonicClient, container: ModelContainer) async {
+        await performSync(mode: .incremental, client: client, container: container)
+    }
+
+    /// Convenience: sync using the configured client and container.
+    func syncIfStale() async {
+        guard let client, let container else { return }
+        await syncIfStale(client: client, container: container)
+    }
+
+    /// Check if sync is stale and trigger the appropriate sync mode.
+    func syncIfStale(client: SubsonicClient, container: ModelContainer) async {
+        guard let last = lastSyncDate else {
+            await performSync(mode: .full, client: client, container: container)
+            return
+        }
+        let elapsed = Date().timeIntervalSince(last)
+        guard elapsed > staleInterval else { return }
+
+        // Check if server data actually changed before doing work
+        let serverChanged = await hasServerChanged(client: client)
+
+        if serverChanged {
+            // Use full sync if it's been over a week, otherwise incremental
+            let lastFull = UserDefaults.standard.object(forKey: UserDefaultsKeys.lastFullSyncDate) as? Date
+            let needsFullSync = lastFull == nil || Date().timeIntervalSince(lastFull!) > fullSyncInterval
+            let mode: SyncMode = needsFullSync ? .full : .incremental
+            await performSync(mode: mode, client: client, container: container)
+        } else {
+            // Server unchanged — just update the stale check timestamp
+            lastSyncDate = Date()
+            syncLog.info("Server data unchanged, skipping sync")
+        }
+    }
+
+    // MARK: - Change Detection Polling
+
+    /// Start periodic polling for server changes while the app is active.
+    func startPolling(client: SubsonicClient, container: ModelContainer) {
+        stopPolling()
+        let intervalMinutes = UserDefaults.standard.integer(forKey: UserDefaultsKeys.syncPollingInterval)
+        let interval = max(TimeInterval(intervalMinutes > 0 ? intervalMinutes : 15) * 60, 300)
+
+        pollingTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(interval))
+                guard !Task.isCancelled, let self, !self.isSyncing else { continue }
+
+                let changed = await self.hasServerChanged(client: client)
+                if changed {
+                    syncLog.info("Polling detected server changes, triggering incremental sync")
+                    await self.performSync(mode: .incremental, client: client, container: container)
+                }
+            }
+        }
+        syncLog.info("Started change detection polling every \(Int(interval))s")
+    }
+
+    /// Stop the periodic polling timer.
+    func stopPolling() {
+        pollingTask?.cancel()
+        pollingTask = nil
+    }
+
+    // MARK: - Core Sync Engine
+
+    private func performSync(mode: SyncMode, client: SubsonicClient, container: ModelContainer) async {
+        guard !isSyncing else { return }
+        isSyncing = true
+        syncError = nil
+        syncProgress = mode == .full ? "Starting full sync…" : "Starting incremental sync…"
+        var stats = SyncStats()
+        lastSyncStats = stats
+        defer {
+            isSyncing = false
+            syncProgress = nil
+        }
+
+        do {
+            let context = ModelContext(container)
+            context.autosaveEnabled = false
+
+            switch mode {
+            case .full, .background:
+                try await syncAlbums(client: client, context: context, stats: &stats, incremental: false)
+                try await syncArtists(client: client, context: context, stats: &stats, incremental: false)
+                try await syncSongs(client: client, context: context, stats: &stats, incremental: false)
+                try await syncPlaylists(client: client, context: context, stats: &stats)
+                UserDefaults.standard.set(Date(), forKey: UserDefaultsKeys.lastFullSyncDate)
+
+            case .incremental:
+                try await syncAlbums(client: client, context: context, stats: &stats, incremental: true)
+                try await syncArtists(client: client, context: context, stats: &stats, incremental: true)
+                try await syncSongs(client: client, context: context, stats: &stats, incremental: true)
+                try await syncPlaylists(client: client, context: context, stats: &stats)
+            }
+
+            try context.save()
+            lastSyncDate = Date()
+            lastSyncStats = stats
+
+            // Save sync history
+            saveSyncHistory(stats: stats, mode: mode, context: context)
+
+            syncLog.info("""
+                Library sync (\(mode.rawValue)) completed in \
+                \(String(format: "%.1f", stats.duration))s — \
+                \(stats.totalChanges) changes \
+                (+\(stats.albumsAdded + stats.artistsAdded + stats.songsAdded) \
+                ~\(stats.albumsUpdated + stats.artistsUpdated + stats.songsUpdated) \
+                -\(stats.albumsRemoved + stats.artistsRemoved + stats.songsRemoved))
+                """)
+
+            // Prefetch cover art in background after metadata sync
+            if stats.albumsAdded > 0 || stats.artistsAdded > 0 {
+                await prefetchCoverArt(client: client, context: context)
+            }
+        } catch {
+            syncError = "Sync failed: \(error.localizedDescription)"
+            lastSyncStats = stats
+            saveSyncHistory(stats: stats, mode: mode, context: ModelContext(container), error: error)
+            syncLog.error("Library sync (\(mode.rawValue)) failed: \(error)")
+        }
+    }
+
+    // MARK: - Server Change Detection
+
+    /// Lightweight check if server data has changed since last sync.
+    /// Uses getIndexes with ifModifiedSince to avoid fetching full data.
+    private func hasServerChanged(client: SubsonicClient) async -> Bool {
+        let lastModified = UserDefaults.standard.integer(forKey: UserDefaultsKeys.lastServerModified)
+        guard lastModified > 0 else { return true }
+
+        do {
+            let indexes = try await client.getIndexes(ifModifiedSince: lastModified)
+            if let serverModified = indexes.lastModified, serverModified > lastModified {
+                return true
+            }
+            let hasContent = indexes.index?.isEmpty == false || indexes.child?.isEmpty == false
+            return hasContent
+        } catch {
+            syncLog.warning("Change detection failed: \(error.localizedDescription)")
+            return true
+        }
+    }
+
+    /// Update the stored server lastModified timestamp.
+    private func updateServerModifiedTimestamp(client: SubsonicClient) async {
+        do {
+            let indexes = try await client.getIndexes()
+            if let lastModified = indexes.lastModified {
+                UserDefaults.standard.set(lastModified, forKey: UserDefaultsKeys.lastServerModified)
+            }
+        } catch {
+            syncLog.warning("Failed to fetch server modified timestamp: \(error.localizedDescription)")
+        }
+    }
+
+    // MARK: - Albums
+
+    private func syncAlbums(client: SubsonicClient, context: ModelContext,
+                            stats: inout SyncStats, incremental: Bool) async throws {
+        syncProgress = "Syncing albums…"
+
+        // Build lookup dictionary of existing albums for O(1) access
+        let allLocal = try context.fetch(FetchDescriptor<CachedAlbum>())
+        var localMap = Dictionary(uniqueKeysWithValues: allLocal.map { ($0.id, $0) })
+
+        var offset = 0
+        var serverAlbumIds = Set<String>()
+        var totalFetched = 0
+
+        if incremental {
+            // Fetch only newest albums (added/modified recently)
+            let newestAlbums = try await client.getAlbumList(type: .newest, size: albumPageSize)
+            for album in newestAlbums {
+                serverAlbumIds.insert(album.id)
+                if let existing = localMap[album.id] {
+                    if hasAlbumChanged(existing, album) {
+                        existing.update(from: album)
+                        stats.albumsUpdated += 1
+                    }
+                } else {
+                    let cached = CachedAlbum(from: album)
+                    context.insert(cached)
+                    localMap[album.id] = cached
+                    stats.albumsAdded += 1
+                }
+            }
+            totalFetched = newestAlbums.count
+        } else {
+            // Full sync: fetch all albums
+            while true {
+                let page = try await client.getAlbumList(
+                    type: .alphabeticalByName, size: albumPageSize, offset: offset
+                )
+                if page.isEmpty { break }
+
+                for album in page {
+                    serverAlbumIds.insert(album.id)
+                    if let existing = localMap[album.id] {
+                        if hasAlbumChanged(existing, album) {
+                            existing.update(from: album)
+                            stats.albumsUpdated += 1
+                        }
+                    } else {
+                        let cached = CachedAlbum(from: album)
+                        context.insert(cached)
+                        localMap[album.id] = cached
+                        stats.albumsAdded += 1
+                    }
+                }
+
+                totalFetched += page.count
+                syncProgress = "Syncing albums… \(totalFetched)"
+                offset += page.count
+
+                if page.count < albumPageSize { break }
+            }
+
+            // Remove albums no longer on server
+            for local in allLocal where !serverAlbumIds.contains(local.id) {
+                context.delete(local)
+                stats.albumsRemoved += 1
+            }
+        }
+
+        try context.save()
+        lastSyncStats = stats
+        let added = stats.albumsAdded
+        let updated = stats.albumsUpdated
+        let removed = stats.albumsRemoved
+        syncLog.info("Synced \(totalFetched) albums (+\(added) ~\(updated) -\(removed))")
+    }
+
+    private func hasAlbumChanged(_ cached: CachedAlbum, _ server: Album) -> Bool {
+        cached.name != server.name ||
+        cached.artistName != server.artist ||
+        cached.artistId != server.artistId ||
+        cached.year != server.year ||
+        cached.genre != server.genre ||
+        cached.songCount != server.songCount ||
+        cached.duration != server.duration ||
+        cached.isStarred != (server.starred != nil) ||
+        cached.coverArtId != server.coverArt ||
+        cached.created != server.created ||
+        cached.userRating != (server.userRating ?? 0) ||
+        cached.label != server.label
+    }
+
+    // MARK: - Artists
+
+    private func syncArtists(client: SubsonicClient, context: ModelContext,
+                             stats: inout SyncStats, incremental: Bool) async throws {
+        syncProgress = "Syncing artists…"
+        let indexes = try await client.getArtists()
+        var serverArtistIds = Set<String>()
+
+        // Build lookup dictionary
+        let allLocal = try context.fetch(FetchDescriptor<CachedArtist>())
+        let localMap = Dictionary(uniqueKeysWithValues: allLocal.map { ($0.id, $0) })
+
+        for index in indexes {
+            for artist in index.artist ?? [] {
+                serverArtistIds.insert(artist.id)
+                if let existing = localMap[artist.id] {
+                    if hasArtistChanged(existing, artist) {
+                        existing.name = artist.name
+                        existing.coverArtId = artist.coverArt
+                        existing.albumCount = artist.albumCount
+                        existing.isStarred = artist.starred != nil
+                        existing.cachedAt = Date()
+                        stats.artistsUpdated += 1
+                    }
+                } else {
+                    context.insert(CachedArtist(from: artist))
+                    stats.artistsAdded += 1
+                }
+            }
+        }
+
+        // Remove artists no longer on server (only on full sync)
+        if !incremental {
+            for local in allLocal where !serverArtistIds.contains(local.id) {
+                context.delete(local)
+                stats.artistsRemoved += 1
+            }
+        }
+
+        try context.save()
+        lastSyncStats = stats
+        let artAdded = stats.artistsAdded
+        let artUpdated = stats.artistsUpdated
+        let artRemoved = stats.artistsRemoved
+        syncLog.info("Synced \(serverArtistIds.count) artists (+\(artAdded) ~\(artUpdated) -\(artRemoved))")
+    }
+
+    private func hasArtistChanged(_ cached: CachedArtist, _ server: Artist) -> Bool {
+        cached.name != server.name ||
+        cached.coverArtId != server.coverArt ||
+        cached.albumCount != server.albumCount ||
+        cached.isStarred != (server.starred != nil)
+    }
+
+    // MARK: - Songs
+
+    private func syncSongs(client: SubsonicClient, context: ModelContext,
+                           stats: inout SyncStats, incremental: Bool) async throws {
+        syncProgress = "Syncing songs…"
+
+        // Build lookup dictionary for O(1) access
+        let allLocal = try context.fetch(FetchDescriptor<CachedSong>())
+        var localMap = Dictionary(uniqueKeysWithValues: allLocal.map { ($0.id, $0) })
+
+        // Pre-fetch album map for linking
+        let allAlbums = try context.fetch(FetchDescriptor<CachedAlbum>())
+        let albumMap = Dictionary(uniqueKeysWithValues: allAlbums.map { ($0.id, $0) })
+
+        var offset = 0
+        var serverSongIds = Set<String>()
+        var totalFetched = 0
+
+        while true {
+            let result = try await client.search(
+                query: "", artistCount: 0, albumCount: 0,
+                songCount: songPageSize, songOffset: offset
+            )
+            let songs = result.song ?? []
+            if songs.isEmpty { break }
+
+            for song in songs {
+                serverSongIds.insert(song.id)
+                if let existing = localMap[song.id] {
+                    if hasSongChanged(existing, song) {
+                        updateSongFields(existing, from: song)
+                        stats.songsUpdated += 1
+                    }
+                } else {
+                    let cached = CachedSong(from: song)
+                    if let albumId = song.albumId {
+                        cached.album = albumMap[albumId]
+                    }
+                    context.insert(cached)
+                    localMap[song.id] = cached
+                    stats.songsAdded += 1
+                }
+            }
+
+            totalFetched += songs.count
+            syncProgress = "Syncing songs… \(totalFetched)"
+            offset += songs.count
+
+            if totalFetched % 2000 == 0 {
+                try context.save()
+                lastSyncStats = stats
+            }
+
+            if songs.count < songPageSize { break }
+        }
+
+        // Remove songs no longer on server (only on full sync, preserve downloads)
+        if !incremental {
+            for local in allLocal where !serverSongIds.contains(local.id) && local.download == nil {
+                context.delete(local)
+                stats.songsRemoved += 1
+            }
+        }
+
+        try context.save()
+        lastSyncStats = stats
+        await updateServerModifiedTimestamp(client: client)
+        let songAdded = stats.songsAdded
+        let songUpdated = stats.songsUpdated
+        let songRemoved = stats.songsRemoved
+        syncLog.info("Synced \(totalFetched) songs (+\(songAdded) ~\(songUpdated) -\(songRemoved))")
+    }
+
+    private func hasSongChanged(_ cached: CachedSong, _ server: Song) -> Bool {
+        cached.title != server.title ||
+        cached.artist != server.artist ||
+        cached.albumName != server.album ||
+        cached.track != server.track ||
+        cached.year != server.year ||
+        cached.genre != server.genre ||
+        cached.duration != server.duration ||
+        cached.isStarred != (server.starred != nil) ||
+        cached.coverArtId != server.coverArt ||
+        cached.bitRate != server.bitRate
+    }
+
+    private func updateSongFields(_ cached: CachedSong, from song: Song) {
+        cached.title = song.title
+        cached.artist = song.artist
+        cached.albumArtist = song.albumArtist
+        cached.albumName = song.album
+        cached.albumId = song.albumId
+        cached.artistId = song.artistId
+        cached.coverArtId = song.coverArt
+        cached.track = song.track
+        cached.discNumber = song.discNumber
+        cached.year = song.year
+        cached.genre = song.genre
+        cached.duration = song.duration
+        cached.bitRate = song.bitRate
+        cached.suffix = song.suffix
+        cached.contentType = song.contentType
+        cached.size = song.size
+        cached.isStarred = song.starred != nil
+        cached.rating = song.userRating ?? 0
+        cached.cachedAt = Date()
+    }
+
+    // MARK: - Playlists
+
+    private func syncPlaylists(client: SubsonicClient, context: ModelContext,
+                               stats: inout SyncStats) async throws {
+        syncProgress = "Syncing playlists…"
+        let playlists = try await client.getPlaylists()
+        var serverPlaylistIds = Set<String>()
+
+        let allLocal = try context.fetch(FetchDescriptor<CachedPlaylist>())
+        let localMap = Dictionary(uniqueKeysWithValues: allLocal.map { ($0.id, $0) })
+
+        // Fetch playlist details with bounded concurrency
+        let details = try await withThrowingTaskGroup(of: Playlist.self, returning: [Playlist].self) { group in
+            var results: [Playlist] = []
+            var inflight = 0
+            let maxConcurrency = 2
+
+            for playlist in playlists {
+                if inflight >= maxConcurrency {
+                    if let detail = try await group.next() {
+                        results.append(detail)
+                    }
+                    inflight -= 1
+                }
+                group.addTask {
+                    try await client.getPlaylist(id: playlist.id)
+                }
+                inflight += 1
+            }
+
+            for try await detail in group {
+                results.append(detail)
+            }
+            return results
+        }
+
+        for detail in details {
+            serverPlaylistIds.insert(detail.id)
+            upsertPlaylist(detail, context: context, localMap: localMap)
+            stats.playlistsSynced += 1
+        }
+
+        for local in allLocal where !serverPlaylistIds.contains(local.id) {
+            context.delete(local)
+        }
+
+        try context.save()
+        lastSyncStats = stats
+        syncLog.info("Synced \(playlists.count) playlists with entries")
+    }
+
+    private func upsertPlaylist(_ playlist: Playlist, context: ModelContext,
+                                localMap: [String: CachedPlaylist]) {
+        let cached: CachedPlaylist
+        if let existing = localMap[playlist.id] {
+            existing.name = playlist.name
+            existing.songCount = playlist.songCount
+            existing.duration = playlist.duration
+            existing.coverArtId = playlist.coverArt
+            existing.owner = playlist.owner
+            existing.isPublic = playlist.isPublic ?? false
+            existing.changed = playlist.changed
+            existing.cachedAt = Date()
+            cached = existing
+        } else {
+            cached = CachedPlaylist(from: playlist)
+            context.insert(cached)
+        }
+
+        for entry in cached.entries {
+            context.delete(entry)
+        }
+
+        if let songs = playlist.entry {
+            for (index, song) in songs.enumerated() {
+                let entry = CachedPlaylistEntry(songId: song.id, order: index)
+                entry.playlist = cached
+                context.insert(entry)
+            }
+        }
+    }
+
+    // MARK: - Cover Art Prefetch
+
+    /// Whether a prefetch pass already ran this session (avoids duplicate work).
+    private var didPrefetchThisSession = false
+
+    /// Warm the in-memory image cache on startup by loading all known cover art.
+    /// Images already in memory are skipped; images in disk cache load instantly.
+    /// Skipped if a prefetch already ran during sync this session.
+    func warmImageCache(client: SubsonicClient, container: ModelContainer) async {
+        guard !didPrefetchThisSession else { return }
+        let context = ModelContext(container)
+        await prefetchCoverArt(client: client, context: context)
+    }
+
+    private func prefetchCoverArt(client: SubsonicClient, context: ModelContext) async {
+        syncProgress = "Prefetching cover art…"
+
+        // Collect cover art IDs from albums and artists without loading full objects
+        var coverArtIds = Set<String>()
+
+        let albumDescriptor = FetchDescriptor<CachedAlbum>(
+            predicate: #Predicate<CachedAlbum> { $0.coverArtId != nil }
+        )
+        let albums = (try? context.fetch(albumDescriptor)) ?? []
+        for album in albums {
+            if let id = album.coverArtId { coverArtIds.insert(id) }
+        }
+
+        let artistDescriptor = FetchDescriptor<CachedArtist>(
+            predicate: #Predicate<CachedArtist> { $0.coverArtId != nil }
+        )
+        let artists = (try? context.fetch(artistDescriptor)) ?? []
+        for artist in artists {
+            if let id = artist.coverArtId { coverArtIds.insert(id) }
+        }
+
+        let total = coverArtIds.count
+        guard total > 0 else {
+            didPrefetchThisSession = true
+            return
+        }
+        syncLog.info("Prefetching \(total) cover art images")
+
+        let pipeline = ImagePipeline.shared
+        let urlMap: [(String, URL)] = coverArtIds.map { id in
+            (id, client.coverArtURL(id: id, size: 600))
+        }
+
+        var fetched = 0
+        let batchSize = 10
+        let perImageTimeout: UInt64 = 15_000_000_000 // 15 seconds
+
+        for batchStart in stride(from: 0, to: urlMap.count, by: batchSize) {
+            guard !Task.isCancelled else { break }
+            let batch = urlMap[batchStart..<min(batchStart + batchSize, urlMap.count)]
+            await withTaskGroup(of: Void.self) { group in
+                for (_, url) in batch {
+                    group.addTask {
+                        let request = ImageRequest(url: url)
+                        if pipeline.cache.containsCachedImage(for: request) { return }
+                        // Timeout prevents a single stalled request from blocking the entire prefetch
+                        await withTaskGroup(of: Void.self) { inner in
+                            inner.addTask {
+                                _ = try? await pipeline.image(for: request)
+                            }
+                            inner.addTask {
+                                try? await Task.sleep(nanoseconds: perImageTimeout)
+                            }
+                            // Return as soon as the first child completes (image loaded or timeout)
+                            await inner.next()
+                            inner.cancelAll()
+                        }
+                    }
+                }
+            }
+            fetched += batch.count
+            syncProgress = "Prefetching cover art… \(fetched)/\(total)"
+        }
+
+        didPrefetchThisSession = true
+        syncLog.info("Cover art prefetch complete: \(fetched) processed")
+    }
+
+    // MARK: - Sync History
+
+    private func saveSyncHistory(stats: SyncStats, mode: SyncMode,
+                                 context: ModelContext, error: Error? = nil) {
+        let history = SyncHistory(syncType: mode.rawValue)
+        history.durationSeconds = stats.duration
+        history.albumsAdded = stats.albumsAdded
+        history.albumsUpdated = stats.albumsUpdated
+        history.albumsRemoved = stats.albumsRemoved
+        history.artistsAdded = stats.artistsAdded
+        history.artistsUpdated = stats.artistsUpdated
+        history.artistsRemoved = stats.artistsRemoved
+        history.songsAdded = stats.songsAdded
+        history.songsUpdated = stats.songsUpdated
+        history.songsRemoved = stats.songsRemoved
+        history.playlistsSynced = stats.playlistsSynced
+        history.conflictsDetected = stats.conflictsDetected
+        history.conflictsResolved = stats.conflictsResolved
+        history.succeeded = error == nil
+        history.errorMessage = error?.localizedDescription
+        context.insert(history)
+        try? context.save()
+
+        pruneSyncHistory(context: context)
+    }
+
+    private func pruneSyncHistory(context: ModelContext) {
+        var descriptor = FetchDescriptor<SyncHistory>(
+            sortBy: [SortDescriptor(\.syncDate, order: .reverse)]
+        )
+        descriptor.fetchOffset = 50
+        do {
+            let old = try context.fetch(descriptor)
+            guard !old.isEmpty else { return }
+            for entry in old {
+                context.delete(entry)
+            }
+            try context.save()
+        } catch {
+            syncLog.warning("Failed to prune sync history: \(error.localizedDescription)")
+        }
+    }
+}

--- a/Vibrdrome/Core/Persistence/Models/CachedAlbum.swift
+++ b/Vibrdrome/Core/Persistence/Models/CachedAlbum.swift
@@ -9,7 +9,7 @@ final class CachedAlbum {
     var artistId: String?
     var coverArtId: String?
     var year: Int?
-    var genre: String?
+    var genres: [String] = []
     var songCount: Int?
     var duration: Int?
     var isStarred: Bool = false
@@ -27,7 +27,7 @@ final class CachedAlbum {
         self.artistId = album.artistId
         self.coverArtId = album.coverArt
         self.year = album.year
-        self.genre = album.genre
+        self.genres = album.allGenres
         self.songCount = album.songCount
         self.duration = album.duration
         self.isStarred = album.starred != nil
@@ -43,7 +43,7 @@ final class CachedAlbum {
         artistId = album.artistId
         coverArtId = album.coverArt
         year = album.year
-        genre = album.genre
+        genres = album.allGenres
         songCount = album.songCount
         duration = album.duration
         isStarred = album.starred != nil
@@ -64,7 +64,8 @@ final class CachedAlbum {
             songCount: songCount,
             duration: duration,
             year: year,
-            genre: genre,
+            genre: genres.first,
+            genres: genres.map { ItemGenre(name: $0) },
             starred: isStarred ? "true" : nil,
             created: created,
             userRating: userRating > 0 ? userRating : nil,

--- a/Vibrdrome/Core/Persistence/Models/CachedAlbum.swift
+++ b/Vibrdrome/Core/Persistence/Models/CachedAlbum.swift
@@ -13,6 +13,9 @@ final class CachedAlbum {
     var songCount: Int?
     var duration: Int?
     var isStarred: Bool = false
+    var created: String?
+    var userRating: Int = 0
+    var label: String?
     var cachedAt: Date = Date()
 
     var songs: [CachedSong] = []
@@ -28,5 +31,47 @@ final class CachedAlbum {
         self.songCount = album.songCount
         self.duration = album.duration
         self.isStarred = album.starred != nil
+        self.created = album.created
+        self.userRating = album.userRating ?? 0
+        self.label = album.label
+    }
+
+    /// Update existing record with fresh server data.
+    func update(from album: Album) {
+        name = album.name
+        artistName = album.artist
+        artistId = album.artistId
+        coverArtId = album.coverArt
+        year = album.year
+        genre = album.genre
+        songCount = album.songCount
+        duration = album.duration
+        isStarred = album.starred != nil
+        created = album.created
+        userRating = album.userRating ?? 0
+        label = album.label
+        cachedAt = Date()
+    }
+
+    /// Convert back to an Album value type for view compatibility.
+    func toAlbum() -> Album {
+        Album(
+            id: id,
+            name: name,
+            artist: artistName,
+            artistId: artistId,
+            coverArt: coverArtId,
+            songCount: songCount,
+            duration: duration,
+            year: year,
+            genre: genre,
+            starred: isStarred ? "true" : nil,
+            created: created,
+            userRating: userRating > 0 ? userRating : nil,
+            song: nil,
+            replayGain: nil,
+            musicBrainzId: nil,
+            recordLabels: label.map { [RecordLabel(name: $0)] }
+        )
     }
 }

--- a/Vibrdrome/Core/Persistence/Models/CachedArtist.swift
+++ b/Vibrdrome/Core/Persistence/Models/CachedArtist.swift
@@ -17,4 +17,15 @@ final class CachedArtist {
         self.albumCount = artist.albumCount
         self.isStarred = artist.starred != nil
     }
+
+    func toArtist() -> Artist {
+        Artist(
+            id: id,
+            name: name,
+            coverArt: coverArtId,
+            albumCount: albumCount,
+            starred: isStarred ? "true" : nil,
+            album: nil
+        )
+    }
 }

--- a/Vibrdrome/Core/Persistence/Models/CachedPlaylist.swift
+++ b/Vibrdrome/Core/Persistence/Models/CachedPlaylist.swift
@@ -26,6 +26,7 @@ final class CachedPlaylist {
         self.changed = playlist.changed
     }
 
+    /// Converts to a lightweight Playlist with `entry: nil`; songs are loaded separately in PlaylistDetailView.
     func toPlaylist() -> Playlist {
         Playlist(
             id: id,

--- a/Vibrdrome/Core/Persistence/Models/CachedPlaylist.swift
+++ b/Vibrdrome/Core/Persistence/Models/CachedPlaylist.swift
@@ -10,7 +10,10 @@ final class CachedPlaylist {
     var coverArtId: String?
     var owner: String?
     var isPublic: Bool = false
+    var changed: String?
     var cachedAt: Date = Date()
+
+    @Relationship(deleteRule: .cascade) var entries: [CachedPlaylistEntry] = []
 
     init(from playlist: Playlist) {
         self.id = playlist.id
@@ -20,5 +23,21 @@ final class CachedPlaylist {
         self.coverArtId = playlist.coverArt
         self.owner = playlist.owner
         self.isPublic = playlist.isPublic ?? false
+        self.changed = playlist.changed
+    }
+
+    func toPlaylist() -> Playlist {
+        Playlist(
+            id: id,
+            name: name,
+            songCount: songCount,
+            duration: duration,
+            created: nil,
+            changed: changed,
+            coverArt: coverArtId,
+            owner: owner,
+            isPublic: isPublic,
+            entry: nil
+        )
     }
 }

--- a/Vibrdrome/Core/Persistence/Models/CachedPlaylistEntry.swift
+++ b/Vibrdrome/Core/Persistence/Models/CachedPlaylistEntry.swift
@@ -1,0 +1,15 @@
+import Foundation
+import SwiftData
+
+@Model
+final class CachedPlaylistEntry {
+    var songId: String
+    var order: Int
+
+    var playlist: CachedPlaylist?
+
+    init(songId: String, order: Int) {
+        self.songId = songId
+        self.order = order
+    }
+}

--- a/Vibrdrome/Core/Persistence/Models/SyncHistory.swift
+++ b/Vibrdrome/Core/Persistence/Models/SyncHistory.swift
@@ -1,0 +1,52 @@
+import Foundation
+import SwiftData
+
+@Model
+final class SyncHistory {
+    var syncDate: Date = Date()
+    /// "full", "incremental", "background"
+    var syncType: String = "full"
+    var durationSeconds: Double = 0
+    var albumsAdded: Int = 0
+    var albumsUpdated: Int = 0
+    var albumsRemoved: Int = 0
+    var artistsAdded: Int = 0
+    var artistsUpdated: Int = 0
+    var artistsRemoved: Int = 0
+    var songsAdded: Int = 0
+    var songsUpdated: Int = 0
+    var songsRemoved: Int = 0
+    var playlistsSynced: Int = 0
+    var conflictsDetected: Int = 0
+    var conflictsResolved: Int = 0
+    var errorMessage: String?
+    var succeeded: Bool = true
+
+    init(syncType: String) {
+        self.syncType = syncType
+        self.syncDate = Date()
+    }
+
+    var totalChanges: Int {
+        albumsAdded + albumsUpdated + albumsRemoved +
+        artistsAdded + artistsUpdated + artistsRemoved +
+        songsAdded + songsUpdated + songsRemoved
+    }
+
+    var summary: String {
+        if !succeeded, let error = errorMessage {
+            return "Failed: \(error)"
+        }
+        if totalChanges == 0 {
+            return "No changes"
+        }
+        var parts: [String] = []
+        let added = albumsAdded + artistsAdded + songsAdded
+        let updated = albumsUpdated + artistsUpdated + songsUpdated
+        let removed = albumsRemoved + artistsRemoved + songsRemoved
+        if added > 0 { parts.append("+\(added)") }
+        if updated > 0 { parts.append("~\(updated)") }
+        if removed > 0 { parts.append("-\(removed)") }
+        return parts.joined(separator: " ")
+    }
+}

--- a/Vibrdrome/Core/Persistence/PersistenceController.swift
+++ b/Vibrdrome/Core/Persistence/PersistenceController.swift
@@ -33,7 +33,6 @@ final class PersistenceController {
             AlbumCollection.self,
             GenreArtwork.self,
             SyncHistory.self,
-            GenreArtwork.self,
         ])
 
         let config = ModelConfiguration(

--- a/Vibrdrome/Core/Persistence/PersistenceController.swift
+++ b/Vibrdrome/Core/Persistence/PersistenceController.swift
@@ -33,6 +33,7 @@ final class PersistenceController {
             AlbumCollection.self,
             GenreArtwork.self,
             SyncHistory.self,
+            GenreArtwork.self,
         ])
 
         let config = ModelConfiguration(

--- a/Vibrdrome/Core/Persistence/PersistenceController.swift
+++ b/Vibrdrome/Core/Persistence/PersistenceController.swift
@@ -23,6 +23,7 @@ final class PersistenceController {
             CachedAlbum.self,
             CachedSong.self,
             CachedPlaylist.self,
+            CachedPlaylistEntry.self,
             DownloadedSong.self,
             PlayHistory.self,
             ServerConfig.self,
@@ -31,6 +32,7 @@ final class PersistenceController {
             SavedQueue.self,
             AlbumCollection.self,
             GenreArtwork.self,
+            SyncHistory.self,
         ])
 
         let config = ModelConfiguration(

--- a/Vibrdrome/Features/Library/AlbumDetailView.swift
+++ b/Vibrdrome/Features/Library/AlbumDetailView.swift
@@ -1,10 +1,12 @@
 import SwiftUI
+import SwiftData
 import NukeUI
 
 struct AlbumDetailView: View {
     let albumId: String
 
     @Environment(AppState.self) private var appState
+    @Environment(\.modelContext) private var modelContext
     @State private var album: Album?
     @State private var albumNotes: String?
     @State private var showFullNotes = false
@@ -615,7 +617,33 @@ struct AlbumDetailView: View {
     }
 
     private func loadAlbum() async {
-        isLoading = true
+        // Show cached album header instantly if available
+        if album == nil {
+            let aid = albumId
+            let descriptor = FetchDescriptor<CachedAlbum>(
+                predicate: #Predicate { $0.id == aid }
+            )
+            if let cached = try? modelContext.fetch(descriptor).first {
+                var preview = cached.toAlbum()
+                // Attach cached songs if available
+                let songs = cached.songs
+                    .sorted { ($0.discNumber ?? 0, $0.track ?? 0) < ($1.discNumber ?? 0, $1.track ?? 0) }
+                    .map { $0.toSong() }
+                if !songs.isEmpty {
+                    preview = Album(
+                        id: preview.id, name: preview.name, artist: preview.artist,
+                        artistId: preview.artistId, coverArt: preview.coverArt,
+                        songCount: preview.songCount, duration: preview.duration,
+                        year: preview.year, genre: preview.genre, starred: preview.starred,
+                        created: preview.created, userRating: preview.userRating,
+                        song: songs, replayGain: nil, musicBrainzId: nil,
+                        recordLabels: nil
+                    )
+                }
+                album = preview
+            }
+        }
+        isLoading = album == nil
         error = nil
         defer { isLoading = false }
         do {

--- a/Vibrdrome/Features/Library/AlbumDetailView.swift
+++ b/Vibrdrome/Features/Library/AlbumDetailView.swift
@@ -15,6 +15,9 @@ struct AlbumDetailView: View {
     @State private var isSelecting = false
     @State private var showAddToPlaylist = false
     @State private var isStarred = false
+    #if os(macOS)
+    @State private var columnSettings = TrackTableColumnSettings(viewKey: "album")
+    #endif
 
     var body: some View {
         ScrollView {
@@ -31,6 +34,13 @@ struct AlbumDetailView: View {
                     let discs = Set(songs.compactMap(\.discNumber)).sorted()
                     let hasMultipleDiscs = discs.count > 1
 
+                    #if os(macOS)
+                    MacTrackTableView(
+                        songs: songs,
+                        settings: columnSettings,
+                        showDiscSeparators: hasMultipleDiscs
+                    )
+                    #else
                     LazyVStack(spacing: 0) {
                         ForEach(Array(songs.enumerated()), id: \.element.id) { index, song in
                             // Disc separator
@@ -56,6 +66,7 @@ struct AlbumDetailView: View {
                                 .padding(.leading, isSelecting ? 72 : 56)
                         }
                     }
+                    #endif
 
                     // Batch action bar
                     if isSelecting && !selectedSongs.isEmpty {

--- a/Vibrdrome/Features/Library/AlbumDetailView.swift
+++ b/Vibrdrome/Features/Library/AlbumDetailView.swift
@@ -634,10 +634,10 @@ struct AlbumDetailView: View {
                         id: preview.id, name: preview.name, artist: preview.artist,
                         artistId: preview.artistId, coverArt: preview.coverArt,
                         songCount: preview.songCount, duration: preview.duration,
-                        year: preview.year, genre: preview.genre, starred: preview.starred,
-                        created: preview.created, userRating: preview.userRating,
-                        song: songs, replayGain: nil, musicBrainzId: nil,
-                        recordLabels: nil
+                        year: preview.year, genre: preview.genre, genres: preview.genres,
+                        starred: preview.starred, created: preview.created,
+                        userRating: preview.userRating, song: songs,
+                        replayGain: nil, musicBrainzId: nil, recordLabels: nil
                     )
                 }
                 album = preview

--- a/Vibrdrome/Features/Library/AlbumsView.swift
+++ b/Vibrdrome/Features/Library/AlbumsView.swift
@@ -1,3 +1,4 @@
+import Nuke
 import SwiftData
 import SwiftUI
 import os.log
@@ -42,6 +43,7 @@ struct AlbumsView: View {
     @State private var visibleIndices: Set<Int> = []
     @State private var restoredScrollIndex: Int?
     private let pageSize = 40
+    private let imagePrefetcher = ImagePrefetcher()
 
     enum AlbumFilter: String, CaseIterable, Identifiable {
         case all, favorites, downloaded
@@ -324,7 +326,7 @@ struct AlbumsView: View {
             }
             await loadFavoritedAlbumIds()
             #if os(macOS)
-            applyLocalFilters()
+            await applyLocalFilters()
             #endif
             recomputeFilteredAlbums()
         }
@@ -448,6 +450,7 @@ struct AlbumsView: View {
                         .onAppear {
                             visibleIndices.insert(index)
                             triggerLoadIfNeeded(at: index)
+                            prefetchImages(around: index)
                         }
                         .onDisappear { visibleIndices.remove(index) }
                     }
@@ -607,6 +610,19 @@ struct AlbumsView: View {
         try? modelContext.save()
     }
 
+    private func prefetchImages(around index: Int) {
+        let lookahead = 20
+        let start = min(index + 1, cachedFilteredAlbums.count)
+        let end = min(index + lookahead, cachedFilteredAlbums.count)
+        guard start < end else { return }
+        let urls = cachedFilteredAlbums[start..<end].compactMap { album -> URL? in
+            guard let artId = album.coverArt else { return nil }
+            return appState.subsonicClient.coverArtURL(id: artId, size: 440)
+        }
+        guard !urls.isEmpty else { return }
+        imagePrefetcher.startPrefetching(with: urls)
+    }
+
     private func loadAlbums() async {
         scrollLoadTask?.cancel()
         pendingPageTarget = 0
@@ -695,11 +711,11 @@ struct AlbumsView: View {
         filterTask = Task {
             try? await Task.sleep(for: .milliseconds(150))
             guard !Task.isCancelled else { return }
-            applyLocalFilters()
+            await applyLocalFilters()
         }
     }
 
-    private func applyLocalFilters() {
+    private func applyLocalFilters() async {
         let filter = appState.albumFilter
         guard filter.isActive else {
             localFilteredAlbums = nil
@@ -707,32 +723,41 @@ struct AlbumsView: View {
             return
         }
 
-        do {
-            let recentlyPlayedAlbumIds = recentlyPlayedIds(for: filter)
-            let selectedArtistNames = selectedArtistNames(for: filter)
-            let allAlbums: [Album]
-            if let cachedAlbums = appState.libraryCache.albums {
-                allAlbums = cachedAlbums
-            } else {
+        // Snapshot all MainActor state into Sendable value types before leaving the main thread.
+        let recentlyPlayedAlbumIds = recentlyPlayedIds(for: filter)
+        let selectedArtistNames = selectedArtistNames(for: filter)
+        let snapshot = FilterSnapshot(filter: filter)
+        let allAlbums: [Album]
+        if let cachedAlbums = appState.libraryCache.albums {
+            allAlbums = cachedAlbums
+        } else {
+            do {
                 var descriptor = FetchDescriptor<CachedAlbum>()
                 descriptor.sortBy = [SortDescriptor(\.name)]
                 allAlbums = try modelContext.fetch(descriptor).map { $0.toAlbum() }
+            } catch {
+                Logger(subsystem: "com.vibrdrome.app", category: "Albums")
+                    .error("Failed to fetch albums for filter: \(error)")
+                localFilteredAlbums = nil
+                return
             }
+        }
 
-            localFilteredAlbums = allAlbums.filter {
-                albumMatchesFilter(
+        // Heavy array filtering runs off the MainActor.
+        let filtered = await Task.detached(priority: .userInitiated) {
+            allAlbums.filter {
+                AlbumsView.albumMatchesFilter(
                     $0,
-                    filter: filter,
+                    snapshot: snapshot,
                     recentIds: recentlyPlayedAlbumIds,
                     selectedArtistNames: selectedArtistNames
                 )
             }
-            recomputeFilteredAlbums()
-        } catch {
-            Logger(subsystem: "com.vibrdrome.app", category: "Albums")
-                .error("Failed to apply local filters: \(error)")
-            localFilteredAlbums = nil
-        }
+        }.value
+
+        guard !Task.isCancelled else { return }
+        localFilteredAlbums = filtered
+        recomputeFilteredAlbums()
     }
 
     private func selectedArtistNames(for filter: LibraryFilter) -> Set<String> {
@@ -754,33 +779,52 @@ struct AlbumsView: View {
         return Set(recentSongs.compactMap(\.albumId))
     }
 
-    private func albumMatchesFilter(
+    struct FilterSnapshot: Sendable {
+        let isFavorited: TriState
+        let isRated: TriState
+        let selectedArtistIds: Set<String>
+        let selectedGenres: Set<String>
+        let selectedLabels: Set<String>
+        let year: Int?
+
+        @MainActor
+        init(filter: LibraryFilter) {
+            isFavorited = filter.isFavorited
+            isRated = filter.isRated
+            selectedArtistIds = filter.selectedArtistIds
+            selectedGenres = filter.selectedGenres
+            selectedLabels = filter.selectedLabels
+            year = filter.year
+        }
+    }
+
+    nonisolated static func albumMatchesFilter(
         _ album: Album,
-        filter: LibraryFilter,
+        snapshot: FilterSnapshot,
         recentIds: Set<String>?,
         selectedArtistNames: Set<String>
     ) -> Bool {
-        guard filter.isFavorited.matches(album.starred != nil) else { return false }
-        guard filter.isRated.matches((album.userRating ?? 0) != 0) else { return false }
+        guard snapshot.isFavorited.matches(album.starred != nil) else { return false }
+        guard snapshot.isRated.matches((album.userRating ?? 0) != 0) else { return false }
         if let recentIds, !recentIds.contains(album.id) { return false }
-        if !filter.selectedArtistIds.isEmpty {
-            let matchesById = album.artistId.map { filter.selectedArtistIds.contains($0) } ?? false
+        if !snapshot.selectedArtistIds.isEmpty {
+            let matchesById = album.artistId.map { snapshot.selectedArtistIds.contains($0) } ?? false
             let matchesByName = album.artist.map { selectedArtistNames.contains($0) } ?? false
             guard matchesById || matchesByName else {
                 return false
             }
         }
-        if !filter.selectedGenres.isEmpty {
-            guard let genre = album.genre, filter.selectedGenres.contains(genre) else {
+        if !snapshot.selectedGenres.isEmpty {
+            guard let genre = album.genre, snapshot.selectedGenres.contains(genre) else {
                 return false
             }
         }
-        if !filter.selectedLabels.isEmpty {
-            guard let albumLabel = album.label, filter.selectedLabels.contains(albumLabel) else {
+        if !snapshot.selectedLabels.isEmpty {
+            guard let albumLabel = album.label, snapshot.selectedLabels.contains(albumLabel) else {
                 return false
             }
         }
-        if let yearFilter = filter.year {
+        if let yearFilter = snapshot.year {
             guard album.year == yearFilter else { return false }
         }
         return true

--- a/Vibrdrome/Features/Library/AlbumsView.swift
+++ b/Vibrdrome/Features/Library/AlbumsView.swift
@@ -360,6 +360,7 @@ struct AlbumsView: View {
         .onChange(of: appState.albumFilter.selectedGenres) { debouncedApplyLocalFilters() }
         .onChange(of: appState.albumFilter.selectedLabels) { debouncedApplyLocalFilters() }
         .onChange(of: appState.albumFilter.year) { debouncedApplyLocalFilters() }
+        .onChange(of: appState.libraryCache.generation) { _, _ in debouncedApplyLocalFilters() }
         #endif
     }
 
@@ -815,9 +816,8 @@ struct AlbumsView: View {
             }
         }
         if !snapshot.selectedGenres.isEmpty {
-            guard let genre = album.genre, snapshot.selectedGenres.contains(genre) else {
-                return false
-            }
+            let albumGenres = Set(album.allGenres)
+            guard !albumGenres.isDisjoint(with: snapshot.selectedGenres) else { return false }
         }
         if !snapshot.selectedLabels.isEmpty {
             guard let albumLabel = album.label, snapshot.selectedLabels.contains(albumLabel) else {

--- a/Vibrdrome/Features/Library/AlbumsView.swift
+++ b/Vibrdrome/Features/Library/AlbumsView.swift
@@ -22,6 +22,7 @@ struct AlbumsView: View {
     @State private var getInfoTarget: GetInfoTarget?
     @AppStorage("albumsViewStyle") private var showAsList = false
     @AppStorage(UserDefaultsKeys.gridColumnsPerRow) private var gridColumns = 2
+    @Environment(\.verticalSizeClass) private var verticalSizeClass
     @Environment(\.modelContext) private var modelContext
     @State private var showSaveCollection = false
     @State private var collectionName = ""
@@ -353,7 +354,8 @@ struct AlbumsView: View {
     // MARK: - Grid view
 
     private var gridItems: [GridItem] {
-        Array(repeating: GridItem(.flexible(), spacing: 16), count: max(2, min(10, gridColumns)))
+        let cols = Theme.effectiveGridColumns(base: gridColumns, verticalSizeClass: verticalSizeClass)
+        return Array(repeating: GridItem(.flexible(), spacing: 16), count: cols)
     }
 
     private var albumGrid: some View {

--- a/Vibrdrome/Features/Library/AlbumsView.swift
+++ b/Vibrdrome/Features/Library/AlbumsView.swift
@@ -11,7 +11,10 @@ struct AlbumsView: View {
 
     @Environment(AppState.self) private var appState
     @Environment(\.openWindow) private var openWindow
+    @Environment(\.modelContext) private var modelContext
     @State private var albums: [Album] = []
+    @State private var localFilteredAlbums: [Album]?
+    @State private var filterTask: Task<Void, Never>?
     @State private var isLoading = true
     @State private var error: String?
     @State private var hasMore = true
@@ -21,9 +24,8 @@ struct AlbumsView: View {
     @State private var clientSideSort: AlbumSortOption?
     @State private var getInfoTarget: GetInfoTarget?
     @AppStorage("albumsViewStyle") private var showAsList = false
-    @AppStorage(UserDefaultsKeys.gridColumnsPerRow) private var gridColumns = 2
-    @Environment(\.verticalSizeClass) private var verticalSizeClass
-    @Environment(\.modelContext) private var modelContext
+    @AppStorage(UserDefaultsKeys.gridDensity) private var gridDensityRaw: String = GridDensity.comfortable.rawValue
+    private var gridDensity: GridDensity { GridDensity(rawValue: gridDensityRaw) ?? .comfortable }
     @State private var showSaveCollection = false
     @State private var collectionName = ""
     @State private var availableGenres: [String] = []
@@ -34,6 +36,11 @@ struct AlbumsView: View {
     @SceneStorage("albumsFilter") private var filterRaw: String = AlbumFilter.all.rawValue
     @Query(filter: #Predicate<DownloadedSong> { $0.isComplete == true })
     private var downloadedSongs: [DownloadedSong]
+    @State private var cachedFilteredAlbums: [Album] = []
+    @State private var scrollLoadTask: Task<Void, Never>?
+    @State private var pendingPageTarget: Int = 0
+    @State private var visibleIndices: Set<Int> = []
+    @State private var restoredScrollIndex: Int?
     private let pageSize = 40
 
     enum AlbumFilter: String, CaseIterable, Identifiable {
@@ -92,23 +99,43 @@ struct AlbumsView: View {
         activeGenre ?? genre
     }
 
-    private var filteredAlbums: [Album] {
-        // When searching, use server results (search3 searches the entire library,
-        // not just the paginated pages already loaded client-side).
-        var result = searchText.isEmpty ? albums : searchResults
-        if !searchText.isEmpty, let activeGenre = effectiveGenre {
-            result = result.filter {
-                $0.genre?.caseInsensitiveCompare(activeGenre) == .orderedSame
-            }
+    private var cacheKey: String {
+        "\(listType.rawValue)_\(genre ?? "")_\(fromYear ?? 0)_\(toYear ?? 0)"
+    }
+
+    init(listType: AlbumListType, title: String = "Albums", genre: String? = nil, fromYear: Int? = nil, toYear: Int? = nil) {
+        self.listType = listType
+        self.title = title
+        self.genre = genre
+        self.fromYear = fromYear
+        self.toYear = toYear
+
+        let key = "\(listType.rawValue)_\(genre ?? "")_\(fromYear ?? 0)_\(toYear ?? 0)"
+        if let snapshot = AppState.shared.albumsViewSnapshots[key] {
+            _albums = State(initialValue: snapshot.albums)
+            _hasMore = State(initialValue: snapshot.hasMore)
+            _isLoading = State(initialValue: false)
+            _cachedFilteredAlbums = State(initialValue: snapshot.albums)
+            _restoredScrollIndex = State(initialValue: snapshot.scrollIndex)
         }
+    }
+
+    private func computeFilteredAlbums() -> [Album] {
+        let source = localFilteredAlbums ?? albums
+        var result = source
         switch activeFilter {
         case .all:
             break
         case .favorites:
             result = result.filter { favoritedAlbumIds.contains($0.id) }
         case .downloaded:
-            let downloaded = downloadedAlbumNames
-            result = result.filter { downloaded.contains($0.name.lowercased()) }
+            result = result.filter { downloadedAlbumNames.contains($0.name.lowercased()) }
+        }
+        if !searchText.isEmpty {
+            result = result.filter {
+                $0.name.localizedCaseInsensitiveContains(searchText) ||
+                ($0.artist ?? "").localizedCaseInsensitiveContains(searchText)
+            }
         }
         if clientSideSort == .year {
             result.sort { ($0.year ?? 0) > ($1.year ?? 0) }
@@ -117,23 +144,8 @@ struct AlbumsView: View {
     }
 
     var body: some View {
-        Group {
-            if showAsList {
-                albumList
-            } else {
-                albumGrid
-            }
-        }
-        #if os(iOS)
-        .contentMargins(.bottom, 80)
-        #endif
-        .navigationTitle(title)
-        #if os(iOS)
-        .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .automatic), prompt: "Search in Albums")
-        .navigationBarTitleDisplayMode(.large)
-        #else
-        .searchable(text: $searchText, isPresented: $searchIsActive, prompt: "Search in Albums")
-        #endif
+        contentView
+        .overlay { albumsOverlay }
         .onChange(of: searchText) { _, newValue in
             searchTask?.cancel()
             let trimmed = newValue.trimmingCharacters(in: .whitespaces)
@@ -154,27 +166,44 @@ struct AlbumsView: View {
             searchIsActive = false
             DispatchQueue.main.async { searchIsActive = true }
         }
-        .overlay {
-            if isLoading && albums.isEmpty {
-                ProgressView("Loading albums...")
-            } else if let error, albums.isEmpty {
-                ContentUnavailableView {
-                    Label("Error", systemImage: "exclamationmark.triangle")
-                } description: {
-                    Text(error)
-                } actions: {
-                    Button("Retry") { Task { await loadAlbums() } }
-                        .buttonStyle(.bordered)
-                }
-            } else if !isLoading && albums.isEmpty {
-                ContentUnavailableView {
-                    Label("No Albums", systemImage: "square.stack")
-                } description: {
-                    Text("No albums found")
-                }
+    }
+
+    private var contentView: some View {
+        Group {
+            if showAsList {
+                albumList
+            } else {
+                albumGrid
             }
         }
+        #if os(iOS)
+        .contentMargins(.bottom, 80)
+        #endif
+        .navigationTitle(title)
+        #if os(iOS)
+        .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .automatic), prompt: "Search in Albums")
+        .navigationBarTitleDisplayMode(.large)
+        #else
+        .searchable(text: $searchText, isPresented: $searchIsActive, prompt: "Search in Albums")
+        #endif
         .toolbar {
+            #if os(macOS)
+            ToolbarItem(placement: .automatic) {
+                Button {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        if appState.activeSidePanel == .albumFilters {
+                            appState.activeSidePanel = nil
+                        } else {
+                            appState.activeSidePanel = .albumFilters
+                        }
+                    }
+                } label: {
+                    Image(systemName: appState.albumFilter.isActive ? "line.3.horizontal.decrease.circle.fill" : "line.3.horizontal.decrease.circle")
+                }
+                .accessibilityLabel("Album Filters")
+                .accessibilityIdentifier("albumFilterToggle")
+            }
+            #endif
             ToolbarItem(placement: .automatic) {
                 Button {
                     withAnimation(.easeInOut(duration: 0.2)) {
@@ -246,12 +275,14 @@ struct AlbumsView: View {
                         Label(effectiveGenre?.cleanedGenreDisplay ?? "Genre", systemImage: "guitars")
                     }
                     Divider()
+                    #if os(iOS)
                     Picker("Filter", selection: $filterRaw) {
                         ForEach(AlbumFilter.allCases) { option in
                             Label(option.label, systemImage: option.icon).tag(option.rawValue)
                         }
                     }
                     Divider()
+                    #endif
                     Button {
                         albums = []
                         hasMore = true
@@ -274,29 +305,33 @@ struct AlbumsView: View {
         }
         .alert("Save Collection", isPresented: $showSaveCollection) {
             TextField("Name", text: $collectionName)
-            Button("Save") {
-                let count = (try? modelContext.fetchCount(FetchDescriptor<AlbumCollection>())) ?? 0
-                let collection = AlbumCollection(
-                    name: collectionName,
-                    listType: effectiveListType,
-                    genre: effectiveGenre,
-                    fromYear: fromYear,
-                    toYear: toYear,
-                    order: count
-                )
-                modelContext.insert(collection)
-                try? modelContext.save()
-            }
+            Button("Save") { saveCollection() }
             Button("Cancel", role: .cancel) { }
         }
+        .navigationDestination(for: AlbumNavItem.self) { item in
+            AlbumDetailView(albumId: item.id)
+        }
         .task {
-            await loadAlbums()
+            #if os(macOS)
+            filterRaw = AlbumFilter.all.rawValue
+            #endif
+            if albums.isEmpty {
+                await loadAlbums()
+            }
             if availableGenres.isEmpty {
                 availableGenres = (try? await appState.subsonicClient.getGenres()
                     .map(\.value).sorted()) ?? []
             }
             await loadFavoritedAlbumIds()
+            #if os(macOS)
+            applyLocalFilters()
+            #endif
+            recomputeFilteredAlbums()
         }
+        .onChange(of: searchText) { recomputeFilteredAlbums() }
+        .onChange(of: filterRaw) { recomputeFilteredAlbums() }
+        .onChange(of: clientSideSort) { recomputeFilteredAlbums() }
+        .onDisappear { saveSnapshot() }
         .refreshable {
             albums = []
             hasMore = true
@@ -315,6 +350,15 @@ struct AlbumsView: View {
             .environment(appState)
         }
         #endif
+        #if os(macOS)
+        .onChange(of: appState.albumFilter.isFavorited) { debouncedApplyLocalFilters() }
+        .onChange(of: appState.albumFilter.isRated) { debouncedApplyLocalFilters() }
+        .onChange(of: appState.albumFilter.isRecentlyPlayed) { debouncedApplyLocalFilters() }
+        .onChange(of: appState.albumFilter.selectedArtistIds) { debouncedApplyLocalFilters() }
+        .onChange(of: appState.albumFilter.selectedGenres) { debouncedApplyLocalFilters() }
+        .onChange(of: appState.albumFilter.selectedLabels) { debouncedApplyLocalFilters() }
+        .onChange(of: appState.albumFilter.year) { debouncedApplyLocalFilters() }
+        #endif
     }
 
     private func loadFavoritedAlbumIds() async {
@@ -325,60 +369,92 @@ struct AlbumsView: View {
         }
     }
 
+    @ViewBuilder
+    private var albumsOverlay: some View {
+        if isLoading && albums.isEmpty {
+            ProgressView("Loading albums...")
+        } else if let error, albums.isEmpty {
+            ContentUnavailableView {
+                Label("Error", systemImage: "exclamationmark.triangle")
+            } description: {
+                Text(error)
+            } actions: {
+                Button("Retry") { Task { await loadAlbums() } }
+                    .buttonStyle(.bordered)
+            }
+        } else if !isLoading && albums.isEmpty {
+            ContentUnavailableView {
+                Label("No Albums", systemImage: "square.stack")
+            } description: {
+                Text("No albums found")
+            }
+        }
+    }
+
     // MARK: - List view
 
     private var albumList: some View {
-        List {
-            ForEach(filteredAlbums) { album in
-                NavigationLink {
-                    AlbumDetailView(albumId: album.id)
-                } label: {
-                    AlbumCard(album: album)
+        ScrollViewReader { proxy in
+            List {
+                ForEach(0..<totalItemCount, id: \.self) { index in
+                    Group {
+                        if index < cachedFilteredAlbums.count {
+                            let album = cachedFilteredAlbums[index]
+                            NavigationLink(value: AlbumNavItem(id: album.id)) {
+                                AlbumCard(album: album)
+                            }
+                            .accessibilityIdentifier("albumRow_\(album.id)")
+                            .contextMenu { rowContextMenu(for: album) }
+                        } else {
+                            albumListPlaceholder
+                        }
+                    }
+                    .id(index)
+                    .onAppear {
+                        visibleIndices.insert(index)
+                        triggerLoadIfNeeded(at: index)
+                    }
+                    .onDisappear { visibleIndices.remove(index) }
                 }
-                .accessibilityIdentifier("albumRow_\(album.id)")
-                .contextMenu { rowContextMenu(for: album) }
-                .onAppear { paginateIfNeeded(album) }
             }
-
-            if isLoading && !albums.isEmpty {
-                HStack {
-                    Spacer()
-                    ProgressView()
-                    Spacer()
-                }
-            }
+            .listStyle(.plain)
+            .onAppear { restoreScroll(proxy: proxy) }
         }
-        .listStyle(.plain)
     }
 
     // MARK: - Grid view
 
-    private var gridItems: [GridItem] {
-        let cols = Theme.effectiveGridColumns(base: gridColumns, verticalSizeClass: verticalSizeClass)
-        return Array(repeating: GridItem(.flexible(), spacing: 16), count: cols)
-    }
-
     private var albumGrid: some View {
-        ScrollView {
-            LazyVGrid(columns: gridItems, spacing: 20) {
-                ForEach(filteredAlbums) { album in
-                    NavigationLink {
-                        AlbumDetailView(albumId: album.id)
-                    } label: {
-                        albumGridCard(album)
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVGrid(columns: [
+                    GridItem(.adaptive(minimum: gridDensity.minimumWidth), spacing: 16)
+                ], spacing: 20) {
+                    ForEach(0..<totalItemCount, id: \.self) { index in
+                        Group {
+                            if index < cachedFilteredAlbums.count {
+                                let album = cachedFilteredAlbums[index]
+                                NavigationLink(value: AlbumNavItem(id: album.id)) {
+                                    albumGridCard(album)
+                                }
+                                .buttonStyle(.plain)
+                                .accessibilityIdentifier("albumCard_\(album.id)")
+                                .contextMenu { rowContextMenu(for: album) }
+                            } else {
+                                albumGridPlaceholder
+                            }
+                        }
+                        .id(index)
+                        .onAppear {
+                            visibleIndices.insert(index)
+                            triggerLoadIfNeeded(at: index)
+                        }
+                        .onDisappear { visibleIndices.remove(index) }
                     }
-                    .buttonStyle(.plain)
-                    .accessibilityIdentifier("albumCard_\(album.id)")
-                    .contextMenu { rowContextMenu(for: album) }
-                    .onAppear { paginateIfNeeded(album) }
                 }
+                .padding(16)
             }
-            .padding(16)
-
-            if isLoading && !albums.isEmpty {
-                ProgressView()
-                    .padding()
-            }
+            .onAppear { restoreScroll(proxy: proxy) }
         }
     }
 
@@ -459,13 +535,81 @@ struct AlbumsView: View {
         }
     }
 
-    private func paginateIfNeeded(_ album: Album) {
-        if album.id == albums.last?.id && hasMore {
-            Task { await loadMore() }
+    private var albumListPlaceholder: some View {
+        HStack(spacing: 12) {
+            RoundedRectangle(cornerRadius: 6)
+                .fill(.quaternary)
+                .frame(width: 56, height: 56)
+            VStack(alignment: .leading, spacing: 4) {
+                RoundedRectangle(cornerRadius: 3)
+                    .fill(.quaternary)
+                    .frame(width: 120, height: 14)
+                RoundedRectangle(cornerRadius: 3)
+                    .fill(.quaternary)
+                    .frame(width: 80, height: 12)
+            }
+            Spacer()
         }
     }
 
+    private var albumGridPlaceholder: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            RoundedRectangle(cornerRadius: 10)
+                .fill(.quaternary)
+                .aspectRatio(1, contentMode: .fit)
+            RoundedRectangle(cornerRadius: 3)
+                .fill(.quaternary)
+                .frame(height: 14)
+            RoundedRectangle(cornerRadius: 3)
+                .fill(.quaternary)
+                .frame(width: 80, height: 12)
+        }
+    }
+
+    private var totalItemCount: Int {
+        guard localFilteredAlbums == nil, searchText.isEmpty else { return cachedFilteredAlbums.count }
+        guard hasMore, let totalCount = appState.libraryCache.albums?.count else { return cachedFilteredAlbums.count }
+        return max(cachedFilteredAlbums.count, totalCount)
+    }
+
+    private func triggerLoadIfNeeded(at index: Int) {
+        guard localFilteredAlbums == nil, hasMore else { return }
+        if index >= cachedFilteredAlbums.count {
+            // Scrolled into placeholder territory — always update target, debounce the load
+            pendingPageTarget = max(pendingPageTarget, albums.count + (index - cachedFilteredAlbums.count) + pageSize)
+            scrollLoadTask?.cancel()
+            scrollLoadTask = Task {
+                try? await Task.sleep(for: .milliseconds(150))
+                guard !Task.isCancelled else { return }
+                await loadPages()
+            }
+        } else if !isLoading {
+            // Near end of loaded items — prefetch immediately
+            let prefetchThreshold = max(cachedFilteredAlbums.count - 30, 0)
+            if index >= prefetchThreshold {
+                pendingPageTarget = max(pendingPageTarget, albums.count + pageSize)
+                Task { await loadPages() }
+            }
+        }
+    }
+
+    private func saveCollection() {
+        let count = (try? modelContext.fetchCount(FetchDescriptor<AlbumCollection>())) ?? 0
+        let collection = AlbumCollection(
+            name: collectionName,
+            listType: effectiveListType,
+            genre: effectiveGenre,
+            fromYear: fromYear,
+            toYear: toYear,
+            order: count
+        )
+        modelContext.insert(collection)
+        try? modelContext.save()
+    }
+
     private func loadAlbums() async {
+        scrollLoadTask?.cancel()
+        pendingPageTarget = 0
         let client = appState.subsonicClient
         let sortType = effectiveListType
         let endpoint = SubsonicEndpoint.getAlbumList2(
@@ -485,6 +629,8 @@ struct AlbumsView: View {
                 fromYear: fromYear, toYear: toYear)
             albums = result
             hasMore = result.count >= pageSize
+            recomputeFilteredAlbums()
+            saveSnapshot()
         } catch {
             if albums.isEmpty {
                 self.error = ErrorPresenter.userMessage(for: error)
@@ -492,18 +638,152 @@ struct AlbumsView: View {
         }
     }
 
-    private func loadMore() async {
-        guard !isLoading else { return }
+    private func loadPages() async {
+        guard !isLoading, hasMore else { return }
         isLoading = true
-        defer { isLoading = false }
-        do {
-            let result = try await appState.subsonicClient.getAlbumList(
-                type: effectiveListType, size: pageSize, offset: albums.count, genre: effectiveGenre,
-                fromYear: fromYear, toYear: toYear)
-            albums.append(contentsOf: result)
-            hasMore = result.count >= pageSize
-        } catch {
-            hasMore = false
+        defer {
+            isLoading = false
+            // If target moved while loading, schedule another batch
+            if albums.count < pendingPageTarget, hasMore {
+                scrollLoadTask?.cancel()
+                scrollLoadTask = Task { await loadPages() }
+            }
+        }
+        while albums.count < pendingPageTarget, hasMore, !Task.isCancelled {
+            do {
+                let result = try await appState.subsonicClient.getAlbumList(
+                    type: effectiveListType, size: pageSize, offset: albums.count, genre: effectiveGenre,
+                    fromYear: fromYear, toYear: toYear)
+                albums.append(contentsOf: result)
+                hasMore = result.count >= pageSize
+            } catch {
+                hasMore = false
+                break
+            }
+        }
+        recomputeFilteredAlbums()
+        saveSnapshot()
+    }
+
+    private func recomputeFilteredAlbums() {
+        cachedFilteredAlbums = computeFilteredAlbums()
+    }
+
+    private func saveSnapshot() {
+        appState.albumsViewSnapshots[cacheKey] = AppState.AlbumsViewSnapshot(
+            albums: albums, hasMore: hasMore, scrollIndex: visibleIndices.min()
+        )
+        let limit = 10
+        if appState.albumsViewSnapshots.count > limit {
+            let excess = appState.albumsViewSnapshots.count - limit
+            appState.albumsViewSnapshots.keys.prefix(excess).forEach {
+                appState.albumsViewSnapshots.removeValue(forKey: $0)
+            }
         }
     }
+
+    private func restoreScroll(proxy: ScrollViewProxy) {
+        if let target = restoredScrollIndex, target > 0, target < cachedFilteredAlbums.count {
+            proxy.scrollTo(target, anchor: .top)
+            restoredScrollIndex = nil
+        }
+    }
+
+    #if os(macOS)
+    private func debouncedApplyLocalFilters() {
+        filterTask?.cancel()
+        filterTask = Task {
+            try? await Task.sleep(for: .milliseconds(150))
+            guard !Task.isCancelled else { return }
+            applyLocalFilters()
+        }
+    }
+
+    private func applyLocalFilters() {
+        let filter = appState.albumFilter
+        guard filter.isActive else {
+            localFilteredAlbums = nil
+            recomputeFilteredAlbums()
+            return
+        }
+
+        do {
+            let recentlyPlayedAlbumIds = recentlyPlayedIds(for: filter)
+            let selectedArtistNames = selectedArtistNames(for: filter)
+            let allAlbums: [Album]
+            if let cachedAlbums = appState.libraryCache.albums {
+                allAlbums = cachedAlbums
+            } else {
+                var descriptor = FetchDescriptor<CachedAlbum>()
+                descriptor.sortBy = [SortDescriptor(\.name)]
+                allAlbums = try modelContext.fetch(descriptor).map { $0.toAlbum() }
+            }
+
+            localFilteredAlbums = allAlbums.filter {
+                albumMatchesFilter(
+                    $0,
+                    filter: filter,
+                    recentIds: recentlyPlayedAlbumIds,
+                    selectedArtistNames: selectedArtistNames
+                )
+            }
+            recomputeFilteredAlbums()
+        } catch {
+            Logger(subsystem: "com.vibrdrome.app", category: "Albums")
+                .error("Failed to apply local filters: \(error)")
+            localFilteredAlbums = nil
+        }
+    }
+
+    private func selectedArtistNames(for filter: LibraryFilter) -> Set<String> {
+        guard !filter.selectedArtistIds.isEmpty else { return [] }
+        let descriptor = FetchDescriptor<CachedArtist>()
+        let cachedArtists = (try? modelContext.fetch(descriptor)) ?? []
+        return Set(cachedArtists.compactMap { artist in
+            filter.selectedArtistIds.contains(artist.id) ? artist.name : nil
+        })
+    }
+
+    private func recentlyPlayedIds(for filter: LibraryFilter) -> Set<String>? {
+        guard filter.isRecentlyPlayed else { return nil }
+        let cutoff = Calendar.current.date(byAdding: .day, value: -30, to: Date()) ?? Date()
+        let songDescriptor = FetchDescriptor<CachedSong>(
+            predicate: #Predicate { $0.lastPlayed != nil && $0.lastPlayed! > cutoff }
+        )
+        let recentSongs = (try? modelContext.fetch(songDescriptor)) ?? []
+        return Set(recentSongs.compactMap(\.albumId))
+    }
+
+    private func albumMatchesFilter(
+        _ album: Album,
+        filter: LibraryFilter,
+        recentIds: Set<String>?,
+        selectedArtistNames: Set<String>
+    ) -> Bool {
+        guard filter.isFavorited.matches(album.starred != nil) else { return false }
+        guard filter.isRated.matches((album.userRating ?? 0) != 0) else { return false }
+        if let recentIds, !recentIds.contains(album.id) { return false }
+        if !filter.selectedArtistIds.isEmpty {
+            let matchesById = album.artistId.map { filter.selectedArtistIds.contains($0) } ?? false
+            let matchesByName = album.artist.map { selectedArtistNames.contains($0) } ?? false
+            guard matchesById || matchesByName else {
+                return false
+            }
+        }
+        if !filter.selectedGenres.isEmpty {
+            guard let genre = album.genre, filter.selectedGenres.contains(genre) else {
+                return false
+            }
+        }
+        if !filter.selectedLabels.isEmpty {
+            guard let albumLabel = album.label, filter.selectedLabels.contains(albumLabel) else {
+                return false
+            }
+        }
+        if let yearFilter = filter.year {
+            guard album.year == yearFilter else { return false }
+        }
+        return true
+    }
+    #endif
 }

--- a/Vibrdrome/Features/Library/ArtistDetailView.swift
+++ b/Vibrdrome/Features/Library/ArtistDetailView.swift
@@ -12,12 +12,20 @@ struct ArtistDetailView: View {
     @State private var error: String?
     @State private var showFullBio = false
     @State private var isStarred = false
+    #if os(macOS)
+    @State private var columnSettings = TrackTableColumnSettings(viewKey: "artist")
+    #endif
 
     var body: some View {
         List {
             // Top Songs section
             if !topSongs.isEmpty {
                 Section {
+                    #if os(macOS)
+                    MacTrackTableView(songs: topSongs, settings: columnSettings)
+                        .listRowInsets(EdgeInsets())
+                        .listRowSeparator(.hidden)
+                    #else
                     ForEach(Array(topSongs.enumerated()), id: \.element.id) { index, song in
                         TrackRow(song: song, showTrackNumber: false)
                             .contentShape(Rectangle())
@@ -26,6 +34,7 @@ struct ArtistDetailView: View {
                             }
                             .trackContextMenu(song: song, queue: topSongs, index: index)
                     }
+                    #endif
                 } header: {
                     Text("Top Tracks")
                 }

--- a/Vibrdrome/Features/Library/ArtistDetailView.swift
+++ b/Vibrdrome/Features/Library/ArtistDetailView.swift
@@ -1,9 +1,11 @@
 import SwiftUI
+import SwiftData
 
 struct ArtistDetailView: View {
     let artistId: String
 
     @Environment(AppState.self) private var appState
+    @Environment(\.modelContext) private var modelContext
     @State private var artist: Artist?
     @State private var topSongs: [Song] = []
     @State private var similarArtists: [Artist] = []
@@ -175,7 +177,30 @@ struct ArtistDetailView: View {
     }
 
     private func loadArtist() async {
-        isLoading = true
+        // Show cached artist with album list instantly
+        if artist == nil {
+            let aid = artistId
+            let artistDesc = FetchDescriptor<CachedArtist>(
+                predicate: #Predicate { $0.id == aid }
+            )
+            if let cached = try? modelContext.fetch(artistDesc).first {
+                // Find this artist's albums in the cache
+                let albumDesc = FetchDescriptor<CachedAlbum>(
+                    predicate: #Predicate<CachedAlbum> { $0.artistId == aid },
+                    sortBy: [SortDescriptor(\CachedAlbum.year, order: .reverse)]
+                )
+                let cachedAlbums = (try? modelContext.fetch(albumDesc)) ?? []
+                let albums = cachedAlbums.map { $0.toAlbum() }
+                artist = Artist(
+                    id: cached.id, name: cached.name,
+                    coverArt: cached.coverArtId,
+                    albumCount: cached.albumCount,
+                    starred: cached.isStarred ? "true" : nil,
+                    album: albums.isEmpty ? nil : albums
+                )
+            }
+        }
+        isLoading = artist == nil
         error = nil
         defer { isLoading = false }
         do {

--- a/Vibrdrome/Features/Library/ArtistsView.swift
+++ b/Vibrdrome/Features/Library/ArtistsView.swift
@@ -1,9 +1,13 @@
 import SwiftData
 import SwiftUI
+import os.log
 
 struct ArtistsView: View {
     @Environment(AppState.self) private var appState
+    @Environment(\.modelContext) private var modelContext
     @State private var indexes: [ArtistIndex] = []
+    @State private var localFilteredArtists: [Artist]?
+    @State private var filterTask: Task<Void, Never>?
     @State private var isLoading = true
     @State private var error: String?
     @State private var searchText = ""
@@ -11,11 +15,12 @@ struct ArtistsView: View {
     @State private var sortReversed = false
     @State private var favoritedArtistIds: Set<String> = []
     @AppStorage("artistsViewStyle") private var showAsList = true
-    @AppStorage(UserDefaultsKeys.gridColumnsPerRow) private var gridColumns = 2
-    @Environment(\.verticalSizeClass) private var verticalSizeClass
+    @AppStorage(UserDefaultsKeys.gridDensity) private var gridDensityRaw: String = GridDensity.comfortable.rawValue
+    private var gridDensity: GridDensity { GridDensity(rawValue: gridDensityRaw) ?? .comfortable }
     @SceneStorage("artistsFilter") private var filterRaw: String = ArtistFilter.all.rawValue
     @Query(filter: #Predicate<DownloadedSong> { $0.isComplete == true })
     private var downloadedSongs: [DownloadedSong]
+    @State private var cachedFilteredIndexes: [(id: String, name: String, artists: [Artist])] = []
 
     enum ArtistFilter: String, CaseIterable, Identifiable {
         case all, favorites, downloaded
@@ -54,7 +59,18 @@ struct ArtistsView: View {
         }
     }
 
-    private var filteredIndexes: [(id: String, name: String, artists: [Artist])] {
+    private func computeFilteredIndexes() -> [(id: String, name: String, artists: [Artist])] {
+        // When local filters are active, use flat filtered list (no index grouping)
+        if let filtered = localFilteredArtists {
+            var source = filtered
+            if !searchText.isEmpty {
+                source = source.filter { $0.name.localizedCaseInsensitiveContains(searchText) }
+            }
+            let sorted = sortReversed ? source.reversed() : Array(source)
+            guard !sorted.isEmpty else { return [] }
+            return [("filtered", "Results", sorted)]
+        }
+
         var raw: [(id: String, name: String, artists: [Artist])]
         let downloaded = downloadedArtistNames
         let favorited = favoritedArtistIds
@@ -143,6 +159,23 @@ struct ArtistsView: View {
             }
         }
         .toolbar {
+            #if os(macOS)
+            ToolbarItem(placement: .automatic) {
+                Button {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        if appState.activeSidePanel == .artistFilters {
+                            appState.activeSidePanel = nil
+                        } else {
+                            appState.activeSidePanel = .artistFilters
+                        }
+                    }
+                } label: {
+                    Image(systemName: appState.artistFilter.isActive ? "line.3.horizontal.decrease.circle.fill" : "line.3.horizontal.decrease.circle")
+                }
+                .accessibilityLabel("Artist Filters")
+                .accessibilityIdentifier("artistFilterToggle")
+            }
+            #endif
             ToolbarItem(placement: .automatic) {
                 Button {
                     withAnimation(.easeInOut(duration: 0.2)) {
@@ -156,12 +189,14 @@ struct ArtistsView: View {
             }
             ToolbarItem(placement: .primaryAction) {
                 Menu {
+                    #if os(iOS)
                     Picker("Filter", selection: $filterRaw) {
                         ForEach(ArtistFilter.allCases) { option in
                             Label(option.label, systemImage: option.icon).tag(option.rawValue)
                         }
                     }
                     Divider()
+                    #endif
                     Button {
                         sortReversed = false
                     } label: {
@@ -193,9 +228,24 @@ struct ArtistsView: View {
                 }
             }
         }
-        .task { await loadArtists() }
-        .task { await loadFavorites() }
+        .task {
+            #if os(macOS)
+            filterRaw = ArtistFilter.all.rawValue
+            #endif
+            await loadArtists()
+            await loadFavorites()
+            #if os(macOS)
+            applyLocalFilters()
+            #endif
+            recomputeFilteredIndexes()
+        }
+        .onChange(of: searchText) { recomputeFilteredIndexes() }
+        .onChange(of: sortReversed) { recomputeFilteredIndexes() }
         .refreshable { await loadArtists() }
+        #if os(macOS)
+        .onChange(of: appState.artistFilter.isFavorited) { debouncedApplyLocalFilters() }
+        .onChange(of: appState.artistFilter.selectedGenres) { debouncedApplyLocalFilters() }
+        #endif
     }
 
     private func loadFavorites() async {
@@ -211,7 +261,7 @@ struct ArtistsView: View {
     private var artistList: some View {
         ScrollViewReader { proxy in
             List {
-                ForEach(filteredIndexes, id: \.id) { index in
+                ForEach(cachedFilteredIndexes, id: \.id) { index in
                     Section(header: Text(index.name).id(index.name)) {
                         ForEach(index.artists) { artist in
                             NavigationLink {
@@ -235,7 +285,7 @@ struct ArtistsView: View {
 
     private func sectionIndex(proxy: ScrollViewProxy) -> some View {
         VStack(spacing: 1) {
-            ForEach(filteredIndexes, id: \.id) { index in
+            ForEach(cachedFilteredIndexes, id: \.id) { index in
                 let label = sectionIndexLabel(index.name)
                 Text(label)
                     .font(.system(size: 11, weight: .bold, design: .rounded))
@@ -261,11 +311,11 @@ struct ArtistsView: View {
     private var artistGrid: some View {
         ScrollView {
             LazyVStack(alignment: .leading, spacing: 24, pinnedViews: [.sectionHeaders]) {
-                ForEach(filteredIndexes, id: \.id) { index in
+                ForEach(cachedFilteredIndexes, id: \.id) { index in
                     Section {
-                        LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 16),
-                                                 count: Theme.effectiveGridColumns(base: gridColumns, verticalSizeClass: verticalSizeClass)),
-                                  spacing: 20) {
+                        LazyVGrid(columns: [
+                            GridItem(.adaptive(minimum: gridDensity.minimumWidth), spacing: 16)
+                        ], spacing: 20) {
                             ForEach(index.artists) { artist in
                                 NavigationLink {
                                     ArtistDetailView(artistId: artist.id)
@@ -334,10 +384,89 @@ struct ArtistsView: View {
         defer { isLoading = false }
         do {
             indexes = try await client.getArtists()
+            recomputeFilteredIndexes()
         } catch {
             if indexes.isEmpty {
                 self.error = ErrorPresenter.userMessage(for: error)
             }
         }
     }
+
+    private func recomputeFilteredIndexes() {
+        cachedFilteredIndexes = computeFilteredIndexes()
+    }
+
+    #if os(macOS)
+    private func debouncedApplyLocalFilters() {
+        filterTask?.cancel()
+        filterTask = Task {
+            try? await Task.sleep(for: .milliseconds(150))
+            guard !Task.isCancelled else { return }
+            applyLocalFilters()
+        }
+    }
+
+    private func applyLocalFilters() {
+        let filter = appState.artistFilter
+        guard filter.isActive else {
+            localFilteredArtists = nil
+            recomputeFilteredIndexes()
+            return
+        }
+
+        do {
+            let allArtists: [Artist]
+            if let cachedArtists = appState.libraryCache.artists {
+                allArtists = cachedArtists
+            } else {
+                var descriptor = FetchDescriptor<CachedArtist>()
+                descriptor.sortBy = [SortDescriptor(\.name)]
+                allArtists = try modelContext.fetch(descriptor).map { $0.toArtist() }
+            }
+
+            // Pre-compute artist IDs that have albums matching selected genres
+            var artistIdsWithMatchingGenres: Set<String>?
+            if !filter.selectedGenres.isEmpty {
+                let allAlbums: [Album]
+                if let cachedAlbums = appState.libraryCache.albums {
+                    allAlbums = cachedAlbums
+                } else {
+                    let albumDescriptor = FetchDescriptor<CachedAlbum>()
+                    allAlbums = try modelContext.fetch(albumDescriptor).map { $0.toAlbum() }
+                }
+                var ids = Set<String>()
+                for album in allAlbums {
+                    if let genre = album.genre, filter.selectedGenres.contains(genre),
+                       let artistId = album.artistId {
+                        ids.insert(artistId)
+                    }
+                }
+                artistIdsWithMatchingGenres = ids
+            }
+
+            let filtered = allArtists.filter { artist in
+                // Favorited filter
+                switch filter.isFavorited {
+                case .yes: if artist.starred == nil { return false }
+                case .no: if artist.starred != nil { return false }
+                case .none: break
+                }
+
+                // Genre filter (via album lookup)
+                if let matchIds = artistIdsWithMatchingGenres {
+                    if !matchIds.contains(artist.id) { return false }
+                }
+
+                return true
+            }
+
+            localFilteredArtists = filtered
+            recomputeFilteredIndexes()
+        } catch {
+            Logger(subsystem: "com.vibrdrome.app", category: "Artists")
+                .error("Failed to apply local filters: \(error)")
+            localFilteredArtists = nil
+        }
+    }
+    #endif
 }

--- a/Vibrdrome/Features/Library/ArtistsView.swift
+++ b/Vibrdrome/Features/Library/ArtistsView.swift
@@ -245,6 +245,7 @@ struct ArtistsView: View {
         #if os(macOS)
         .onChange(of: appState.artistFilter.isFavorited) { debouncedApplyLocalFilters() }
         .onChange(of: appState.artistFilter.selectedGenres) { debouncedApplyLocalFilters() }
+        .onChange(of: appState.libraryCache.generation) { _, _ in debouncedApplyLocalFilters() }
         #endif
     }
 
@@ -436,7 +437,8 @@ struct ArtistsView: View {
                 }
                 var ids = Set<String>()
                 for album in allAlbums {
-                    if let genre = album.genre, filter.selectedGenres.contains(genre),
+                    let albumGenres = Set(album.allGenres)
+                    if !albumGenres.isDisjoint(with: filter.selectedGenres),
                        let artistId = album.artistId {
                         ids.insert(artistId)
                     }

--- a/Vibrdrome/Features/Library/ArtistsView.swift
+++ b/Vibrdrome/Features/Library/ArtistsView.swift
@@ -12,6 +12,7 @@ struct ArtistsView: View {
     @State private var favoritedArtistIds: Set<String> = []
     @AppStorage("artistsViewStyle") private var showAsList = true
     @AppStorage(UserDefaultsKeys.gridColumnsPerRow) private var gridColumns = 2
+    @Environment(\.verticalSizeClass) private var verticalSizeClass
     @SceneStorage("artistsFilter") private var filterRaw: String = ArtistFilter.all.rawValue
     @Query(filter: #Predicate<DownloadedSong> { $0.isComplete == true })
     private var downloadedSongs: [DownloadedSong]
@@ -263,7 +264,8 @@ struct ArtistsView: View {
                 ForEach(filteredIndexes, id: \.id) { index in
                     Section {
                         LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 16),
-                                                 count: max(2, min(10, gridColumns))), spacing: 20) {
+                                                 count: Theme.effectiveGridColumns(base: gridColumns, verticalSizeClass: verticalSizeClass)),
+                                  spacing: 20) {
                             ForEach(index.artists) { artist in
                                 NavigationLink {
                                     ArtistDetailView(artistId: artist.id)

--- a/Vibrdrome/Features/Library/FavoritesView.swift
+++ b/Vibrdrome/Features/Library/FavoritesView.swift
@@ -13,6 +13,7 @@ struct FavoritesView: View {
     @State private var selectedCategory: FavoriteCategory = .songs
     @AppStorage("favoritesViewAsList") private var showAsList = true
     @AppStorage(UserDefaultsKeys.gridColumnsPerRow) private var gridColumns = 2
+    @Environment(\.verticalSizeClass) private var verticalSizeClass
 
     enum FavoriteCategory: String, CaseIterable, Identifiable {
         case songs, albums, artists
@@ -255,7 +256,8 @@ struct FavoritesView: View {
         } else {
             ScrollView {
                 LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 16),
-                                         count: max(2, min(10, gridColumns))), spacing: 20) {
+                                         count: Theme.effectiveGridColumns(base: gridColumns, verticalSizeClass: verticalSizeClass)),
+                          spacing: 20) {
                     ForEach(albums) { album in
                         NavigationLink {
                             AlbumDetailView(albumId: album.id)
@@ -307,7 +309,8 @@ struct FavoritesView: View {
         } else {
             ScrollView {
                 LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 16),
-                                         count: max(2, min(10, gridColumns))), spacing: 20) {
+                                         count: Theme.effectiveGridColumns(base: gridColumns, verticalSizeClass: verticalSizeClass)),
+                          spacing: 20) {
                     ForEach(artists) { artist in
                         NavigationLink {
                             ArtistDetailView(artistId: artist.id)

--- a/Vibrdrome/Features/Library/FavoritesView.swift
+++ b/Vibrdrome/Features/Library/FavoritesView.swift
@@ -1,10 +1,14 @@
 import SwiftUI
+import SwiftData
 
 struct FavoritesView: View {
     @Environment(AppState.self) private var appState
-    @State private var starred: Starred2?
-    @State private var isLoading = true
-    @State private var error: String?
+    @Query(filter: #Predicate<CachedArtist> { $0.isStarred }, sort: \CachedArtist.name)
+    private var starredArtists: [CachedArtist]
+    @Query(filter: #Predicate<CachedAlbum> { $0.isStarred }, sort: \CachedAlbum.name)
+    private var starredAlbums: [CachedAlbum]
+    @Query(filter: #Predicate<CachedSong> { $0.isStarred }, sort: \CachedSong.title)
+    private var starredSongs: [CachedSong]
     @State private var searchText = ""
     @State private var searchIsActive = false
     @State private var selectedSongs = Set<String>()
@@ -12,11 +16,14 @@ struct FavoritesView: View {
     @State private var showBatchAddToPlaylist = false
     @State private var selectedCategory: FavoriteCategory = .songs
     @AppStorage("favoritesViewAsList") private var showAsList = true
-    @AppStorage(UserDefaultsKeys.gridColumnsPerRow) private var gridColumns = 2
+    @AppStorage(UserDefaultsKeys.gridDensity) private var gridDensityRaw: String = GridDensity.comfortable.rawValue
+    private var gridDensity: GridDensity { GridDensity(rawValue: gridDensityRaw) ?? .comfortable }
     #if os(macOS)
     @State private var columnSettings = TrackTableColumnSettings(viewKey: "favorites")
     #endif
-    @Environment(\.verticalSizeClass) private var verticalSizeClass
+    @State private var cachedFilteredArtists: [Artist] = []
+    @State private var cachedFilteredAlbums: [Album] = []
+    @State private var cachedFilteredSongs: [Song] = []
 
     enum FavoriteCategory: String, CaseIterable, Identifiable {
         case songs, albums, artists
@@ -37,20 +44,20 @@ struct FavoritesView: View {
         }
     }
 
-    private var filteredArtists: [Artist] {
-        guard let artists = starred?.artist else { return [] }
+    private func computeFilteredArtists() -> [Artist] {
+        let artists = starredArtists.map { $0.toArtist() }
         if searchText.isEmpty { return artists }
         return artists.filter { $0.name.localizedCaseInsensitiveContains(searchText) }
     }
 
-    private var filteredAlbums: [Album] {
-        guard let albums = starred?.album else { return [] }
+    private func computeFilteredAlbums() -> [Album] {
+        let albums = starredAlbums.map { $0.toAlbum() }
         if searchText.isEmpty { return albums }
         return albums.filter { $0.name.localizedCaseInsensitiveContains(searchText) }
     }
 
-    private var filteredSongs: [Song] {
-        guard let songs = starred?.song else { return [] }
+    private func computeFilteredSongs() -> [Song] {
+        let songs = starredSongs.map { $0.toSong() }
         if searchText.isEmpty { return songs }
         return songs.filter {
             $0.title.localizedCaseInsensitiveContains(searchText) ||
@@ -85,18 +92,13 @@ struct FavoritesView: View {
             DispatchQueue.main.async { searchIsActive = true }
         }
         .overlay {
-            if isLoading && starred == nil {
-                ProgressView("Loading favorites...")
-            } else if let error, starred == nil {
+            if appState.librarySyncManager.lastSyncDate == nil && isEmpty {
                 ContentUnavailableView {
-                    Label("Error", systemImage: "exclamationmark.triangle")
+                    Label("Loading Favorites", systemImage: "heart")
                 } description: {
-                    Text(error)
-                } actions: {
-                    Button("Retry") { Task { await loadStarred() } }
-                        .buttonStyle(.bordered)
+                    Text("Syncing your library...")
                 }
-            } else if !isLoading && isEmpty {
+            } else if isEmpty {
                 ContentUnavailableView {
                     Label("No Favorites", systemImage: "heart")
                 } description: {
@@ -131,7 +133,7 @@ struct FavoritesView: View {
             }
             #if os(macOS)
             ToolbarItem {
-                Button { Task { await loadStarred() } } label: {
+                Button { Task { await LibrarySyncManager.shared.syncIfStale() } } label: {
                     Label("Refresh", systemImage: "arrow.clockwise")
                 }
             }
@@ -141,8 +143,12 @@ struct FavoritesView: View {
             AddToPlaylistView(songIds: Array(selectedSongs))
                 .environment(appState)
         }
-        .task { await loadStarred() }
-        .refreshable { await loadStarred() }
+        .refreshable { await LibrarySyncManager.shared.syncIfStale() }
+        .onChange(of: searchText) { recomputeFilteredLists() }
+        .onChange(of: starredArtists) { recomputeFilteredLists() }
+        .onChange(of: starredAlbums) { recomputeFilteredLists() }
+        .onChange(of: starredSongs) { recomputeFilteredLists() }
+        .onAppear { recomputeFilteredLists() }
     }
 
     // MARK: - Category picker
@@ -163,7 +169,7 @@ struct FavoritesView: View {
 
     @ViewBuilder
     private var songsContent: some View {
-        let songs = filteredSongs
+        let songs = cachedFilteredSongs
         if songs.isEmpty {
             emptyCategory("No Favorited Songs")
         } else {
@@ -229,12 +235,8 @@ struct FavoritesView: View {
                 }
 
                 if isSelecting && !selectedSongs.isEmpty {
-                    BatchActionBar(
-                        selectedSongIds: selectedSongs,
-                        songs: songs,
-                        onAddToPlaylist: { showBatchAddToPlaylist = true }
-                    )
-                    .listRowSeparator(.hidden)
+                    favoritesBatchActionBar(songs: songs)
+                        .listRowSeparator(.hidden)
                 }
             }
             .listStyle(.plain)
@@ -246,7 +248,7 @@ struct FavoritesView: View {
 
     @ViewBuilder
     private var albumsContent: some View {
-        let albums = filteredAlbums
+        let albums = cachedFilteredAlbums
         if albums.isEmpty {
             emptyCategory("No Favorited Albums")
         } else if showAsList {
@@ -262,9 +264,9 @@ struct FavoritesView: View {
             .listStyle(.plain)
         } else {
             ScrollView {
-                LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 16),
-                                         count: Theme.effectiveGridColumns(base: gridColumns, verticalSizeClass: verticalSizeClass)),
-                          spacing: 20) {
+                LazyVGrid(columns: [
+                    GridItem(.adaptive(minimum: gridDensity.minimumWidth), spacing: 16)
+                ], spacing: 20) {
                     ForEach(albums) { album in
                         NavigationLink {
                             AlbumDetailView(albumId: album.id)
@@ -299,7 +301,7 @@ struct FavoritesView: View {
 
     @ViewBuilder
     private var artistsContent: some View {
-        let artists = filteredArtists
+        let artists = cachedFilteredArtists
         if artists.isEmpty {
             emptyCategory("No Favorited Artists")
         } else if showAsList {
@@ -315,9 +317,9 @@ struct FavoritesView: View {
             .listStyle(.plain)
         } else {
             ScrollView {
-                LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 16),
-                                         count: Theme.effectiveGridColumns(base: gridColumns, verticalSizeClass: verticalSizeClass)),
-                          spacing: 20) {
+                LazyVGrid(columns: [
+                    GridItem(.adaptive(minimum: gridDensity.minimumWidth), spacing: 16)
+                ], spacing: 20) {
                     ForEach(artists) { artist in
                         NavigationLink {
                             ArtistDetailView(artistId: artist.id)
@@ -351,6 +353,20 @@ struct FavoritesView: View {
         }
     }
 
+    private func recomputeFilteredLists() {
+        cachedFilteredArtists = computeFilteredArtists()
+        cachedFilteredAlbums = computeFilteredAlbums()
+        cachedFilteredSongs = computeFilteredSongs()
+    }
+
+    private func favoritesBatchActionBar(songs: [Song]) -> some View {
+        BatchActionBar(
+            selectedSongIds: selectedSongs,
+            songs: songs,
+            onAddToPlaylist: { showBatchAddToPlaylist = true }
+        )
+    }
+
     private func toggleSelection(_ songId: String) {
         if selectedSongs.contains(songId) {
             selectedSongs.remove(songId)
@@ -360,20 +376,6 @@ struct FavoritesView: View {
     }
 
     private var isEmpty: Bool {
-        guard let starred else { return true }
-        return (starred.artist?.isEmpty ?? true) &&
-               (starred.album?.isEmpty ?? true) &&
-               (starred.song?.isEmpty ?? true)
-    }
-
-    private func loadStarred() async {
-        isLoading = true
-        error = nil
-        defer { isLoading = false }
-        do {
-            starred = try await appState.subsonicClient.getStarred()
-        } catch {
-            self.error = ErrorPresenter.userMessage(for: error)
-        }
+        starredArtists.isEmpty && starredAlbums.isEmpty && starredSongs.isEmpty
     }
 }

--- a/Vibrdrome/Features/Library/FavoritesView.swift
+++ b/Vibrdrome/Features/Library/FavoritesView.swift
@@ -13,6 +13,9 @@ struct FavoritesView: View {
     @State private var selectedCategory: FavoriteCategory = .songs
     @AppStorage("favoritesViewAsList") private var showAsList = true
     @AppStorage(UserDefaultsKeys.gridColumnsPerRow) private var gridColumns = 2
+    #if os(macOS)
+    @State private var columnSettings = TrackTableColumnSettings(viewKey: "favorites")
+    #endif
     @Environment(\.verticalSizeClass) private var verticalSizeClass
 
     enum FavoriteCategory: String, CaseIterable, Identifiable {
@@ -164,6 +167,9 @@ struct FavoritesView: View {
         if songs.isEmpty {
             emptyCategory("No Favorited Songs")
         } else {
+            #if os(macOS)
+            MacTrackTableView(songs: songs, settings: columnSettings)
+            #else
             List {
                 HStack(spacing: 12) {
                     Button {
@@ -232,6 +238,7 @@ struct FavoritesView: View {
                 }
             }
             .listStyle(.plain)
+            #endif
         }
     }
 

--- a/Vibrdrome/Features/Library/FolderDetailView.swift
+++ b/Vibrdrome/Features/Library/FolderDetailView.swift
@@ -40,10 +40,6 @@ struct FolderDetailView: View {
                 contentList
             }
         }
-        .navigationDestination(for: String.self) { childId in
-            FolderDetailView(directoryId: childId)
-                .environment(appState)
-        }
         .navigationTitle(directory?.name ?? "Folder")
         #if os(iOS)
         .navigationBarTitleDisplayMode(.inline)
@@ -65,7 +61,10 @@ struct FolderDetailView: View {
             if !subfolders.isEmpty {
                 Section("Folders") {
                     ForEach(subfolders) { child in
-                        NavigationLink(value: child.id) {
+                        NavigationLink {
+                            FolderDetailView(directoryId: child.id)
+                                .environment(appState)
+                        } label: {
                             Label(child.title ?? "Unknown", systemImage: "folder.fill")
                         }
                     }

--- a/Vibrdrome/Features/Library/GenresView.swift
+++ b/Vibrdrome/Features/Library/GenresView.swift
@@ -258,9 +258,10 @@ struct GenresView: View {
         var genreSongCount: [String: Int] = [:]
 
         for album in allAlbums {
-            guard let genre = album.genre, !genre.isEmpty else { continue }
-            genreAlbumCount[genre, default: 0] += 1
-            genreSongCount[genre, default: 0] += album.songCount ?? 0
+            for genre in album.genres where !genre.isEmpty {
+                genreAlbumCount[genre, default: 0] += 1
+                genreSongCount[genre, default: 0] += album.songCount ?? 0
+            }
         }
 
         return genreAlbumCount.map { key, albumCount in

--- a/Vibrdrome/Features/Library/GenresView.swift
+++ b/Vibrdrome/Features/Library/GenresView.swift
@@ -24,8 +24,9 @@ struct GenresView: View {
     @State private var searchIsActive = false
     @State private var sortBy: GenreSortOption = .name
     @AppStorage("genresViewStyle") private var showAsList = true
-    @AppStorage(UserDefaultsKeys.gridColumnsPerRow) private var gridColumns = 2
-    @Environment(\.verticalSizeClass) private var verticalSizeClass
+    @AppStorage(UserDefaultsKeys.gridDensity) private var gridDensityRaw: String = GridDensity.comfortable.rawValue
+    private var gridDensity: GridDensity { GridDensity(rawValue: gridDensityRaw) ?? .comfortable }
+    @State private var cachedFilteredGenres: [Genre] = []
 
     enum GenreSortOption: String, CaseIterable {
         case name, songCount
@@ -37,7 +38,7 @@ struct GenresView: View {
         }
     }
 
-    private var filteredGenres: [Genre] {
+    private func computeFilteredGenres() -> [Genre] {
         let base: [Genre]
         if searchText.isEmpty {
             base = genres
@@ -136,13 +137,15 @@ struct GenresView: View {
             }
         }
         .task { await loadGenres() }
+        .onChange(of: searchText) { recomputeFilteredGenres() }
+        .onChange(of: sortBy) { recomputeFilteredGenres() }
         .refreshable { await loadGenres() }
     }
 
     // MARK: - List view
 
     private var genreList: some View {
-        List(filteredGenres) { genre in
+        List(cachedFilteredGenres) { genre in
             NavigationLink {
                 AlbumsView(listType: .byGenre, title: genre.value.cleanedGenreDisplay, genre: genre.value)
             } label: {
@@ -170,10 +173,10 @@ struct GenresView: View {
 
     private var genreGrid: some View {
         ScrollView {
-            LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 16),
-                                     count: Theme.effectiveGridColumns(base: gridColumns, verticalSizeClass: verticalSizeClass)),
-                      spacing: 20) {
-                ForEach(filteredGenres) { genre in
+            LazyVGrid(columns: [
+                GridItem(.adaptive(minimum: gridDensity.minimumWidth), spacing: 16)
+            ], spacing: 20) {
+                ForEach(cachedFilteredGenres) { genre in
                     NavigationLink {
                         AlbumsView(listType: .byGenre, title: genre.value.cleanedGenreDisplay, genre: genre.value)
                     } label: {
@@ -207,13 +210,28 @@ struct GenresView: View {
         }
     }
 
+    private func recomputeFilteredGenres() {
+        cachedFilteredGenres = computeFilteredGenres()
+    }
+
     private func loadGenres() async {
         let client = appState.subsonicClient
-        // Show cached data instantly
+
+        // Try local SwiftData first — derive genres from cached songs
+        if genres.isEmpty {
+            let localGenres = deriveGenresFromCache()
+            if !localGenres.isEmpty {
+                genres = localGenres
+                recomputeFilteredGenres()
+            }
+        }
+
+        // Show cached API response if no local data
         if genres.isEmpty,
            let cached = await client.cachedResponse(for: .getGenres, ttl: 3600) {
             genres = (cached.genres?.genre ?? [])
                 .sorted { $0.value.localizedCaseInsensitiveCompare($1.value) == .orderedAscending }
+            recomputeFilteredGenres()
         }
         isLoading = genres.isEmpty
         error = nil
@@ -221,12 +239,33 @@ struct GenresView: View {
         do {
             genres = try await client.getGenres()
                 .sorted { $0.value.localizedCaseInsensitiveCompare($1.value) == .orderedAscending }
+            recomputeFilteredGenres()
             await loadGenreArt(client: client)
         } catch {
-            if genres.isEmpty {
+            // If network fails but we have local data, load art from cache
+            if !genres.isEmpty {
+                await loadGenreArt(client: client)
+            } else {
                 self.error = ErrorPresenter.userMessage(for: error)
             }
         }
+    }
+
+    private func deriveGenresFromCache() -> [Genre] {
+        // Use albums (much fewer records) to derive genre counts
+        let allAlbums = (try? modelContext.fetch(FetchDescriptor<CachedAlbum>())) ?? []
+        var genreAlbumCount: [String: Int] = [:]
+        var genreSongCount: [String: Int] = [:]
+
+        for album in allAlbums {
+            guard let genre = album.genre, !genre.isEmpty else { continue }
+            genreAlbumCount[genre, default: 0] += 1
+            genreSongCount[genre, default: 0] += album.songCount ?? 0
+        }
+
+        return genreAlbumCount.map { key, albumCount in
+            Genre(songCount: genreSongCount[key] ?? 0, albumCount: albumCount, value: key)
+        }.sorted { $0.value.localizedCaseInsensitiveCompare($1.value) == .orderedAscending }
     }
 
     private func loadGenreArt(client: SubsonicClient) async {

--- a/Vibrdrome/Features/Library/GenresView.swift
+++ b/Vibrdrome/Features/Library/GenresView.swift
@@ -25,6 +25,7 @@ struct GenresView: View {
     @State private var sortBy: GenreSortOption = .name
     @AppStorage("genresViewStyle") private var showAsList = true
     @AppStorage(UserDefaultsKeys.gridColumnsPerRow) private var gridColumns = 2
+    @Environment(\.verticalSizeClass) private var verticalSizeClass
 
     enum GenreSortOption: String, CaseIterable {
         case name, songCount
@@ -170,7 +171,8 @@ struct GenresView: View {
     private var genreGrid: some View {
         ScrollView {
             LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 16),
-                                     count: max(2, min(10, gridColumns))), spacing: 20) {
+                                     count: Theme.effectiveGridColumns(base: gridColumns, verticalSizeClass: verticalSizeClass)),
+                      spacing: 20) {
                 ForEach(filteredGenres) { genre in
                     NavigationLink {
                         AlbumsView(listType: .byGenre, title: genre.value.cleanedGenreDisplay, genre: genre.value)

--- a/Vibrdrome/Features/Library/GetInfoView.swift
+++ b/Vibrdrome/Features/Library/GetInfoView.swift
@@ -610,13 +610,16 @@ struct GetInfoView: View {
                 let childPath = keyPath.isEmpty ? childLabel : "\(keyPath).\(childLabel)"
                 flattenMetadata(value: child.value, keyPath: childPath, rows: &rows)
             }
+        #if compiler(>=6.2)
+        case .enum, .optional, .foreignReference:
+            rows.append(RawMetadataRow(key: keyPath, value: scalarDescription(value)))
+        #else
         case .enum, .optional:
             rows.append(RawMetadataRow(key: keyPath, value: scalarDescription(value)))
+        #endif
         case .none:
             rows.append(RawMetadataRow(key: keyPath, value: scalarDescription(value)))
         @unknown default:
-            // Covers newer DisplayStyle cases (e.g. .foreignReference on Swift 6+)
-            // without making the file require the newer stdlib to compile.
             rows.append(RawMetadataRow(key: keyPath, value: scalarDescription(value)))
         }
     }

--- a/Vibrdrome/Features/Library/LibraryFilterSidebarView.swift
+++ b/Vibrdrome/Features/Library/LibraryFilterSidebarView.swift
@@ -1,0 +1,401 @@
+#if os(macOS)
+import SwiftUI
+import SwiftData
+
+/// Which entity type the filter sidebar is controlling.
+enum FilterContext {
+    case album, artist, song
+}
+
+/// Feishin-style filter sidebar shown as a macOS side panel.
+/// Adapts its controls based on the entity type being filtered.
+struct LibraryFilterSidebarView: View {
+    let context: FilterContext
+
+    @Environment(AppState.self) private var appState
+    @Environment(\.modelContext) private var modelContext
+    @Query(sort: \CachedArtist.name) private var artists: [CachedArtist]
+    @State private var genres: [String] = []
+    @State private var labels: [String] = []
+
+    private var filter: LibraryFilter {
+        switch context {
+        case .album: appState.albumFilter
+        case .artist: appState.artistFilter
+        case .song: appState.songFilter
+        }
+    }
+
+    private var panelTitle: String {
+        switch context {
+        case .album: "Album Filters"
+        case .artist: "Artist Filters"
+        case .song: "Song Filters"
+        }
+    }
+
+    var body: some View {
+        SidePanelContainer(title: panelTitle, onClose: {
+            appState.activeSidePanel = nil
+        }) {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    headerButtons
+
+                    if appState.librarySyncManager.lastSyncDate == nil {
+                        syncRequiredView
+                    } else {
+                        filterControls
+                    }
+                }
+                .padding(14)
+            }
+        }
+        .task { loadCachedMetadata() }
+    }
+
+    // MARK: - Header
+
+    @ViewBuilder
+    private var headerButtons: some View {
+        HStack {
+            if filter.isActive {
+                Text("\(filter.activeFilterCount) active")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            Button("Reset") {
+                filter.reset()
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(Color.accentColor)
+            .font(.subheadline)
+            .disabled(!filter.isActive)
+        }
+    }
+
+    // MARK: - Sync Required
+
+    @ViewBuilder
+    private var syncRequiredView: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "arrow.triangle.2.circlepath")
+                .font(.largeTitle)
+                .foregroundStyle(.secondary)
+            Text("Library sync required")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            Text("Sync your library to enable filtering.")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+                .multilineTextAlignment(.center)
+            Button("Sync Now") {
+                Task {
+                    await appState.librarySyncManager.sync(
+                        client: appState.subsonicClient,
+                        container: PersistenceController.shared.container
+                    )
+                    loadCachedMetadata()
+                }
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.small)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 20)
+    }
+
+    // MARK: - Filter Controls
+
+    @ViewBuilder
+    private var filterControls: some View {
+        if let progress = appState.librarySyncManager.syncProgress {
+            HStack(spacing: 6) {
+                ProgressView()
+                    .controlSize(.small)
+                Text(progress)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+
+        @Bindable var state = appState
+
+        // Favorited — all contexts
+        favoritedControl
+
+        // Rated — album and song only
+        if context == .album || context == .song {
+            ratedControl
+        }
+
+        // Recently played — album and song only
+        if context == .album || context == .song {
+            recentlyPlayedControl
+        }
+
+        Divider()
+
+        // Artist multi-select — album and song only
+        if context == .album || context == .song {
+            artistMultiSelect
+            Divider()
+        }
+
+        // Genre multi-select — all contexts
+        genreMultiSelect
+
+        // Label multi-select — album only
+        if context == .album {
+            Divider()
+            labelMultiSelect
+        }
+
+        // Year filter — album and song only
+        if context == .album || context == .song {
+            Divider()
+            yearFilter
+        }
+    }
+
+    // MARK: - Boolean Filter Controls
+
+    @ViewBuilder
+    private var favoritedControl: some View {
+        @Bindable var state = appState
+        switch context {
+        case .album: TriStateFilterControl(label: "Is favorited", value: $state.albumFilter.isFavorited)
+        case .artist: TriStateFilterControl(label: "Is favorited", value: $state.artistFilter.isFavorited)
+        case .song: TriStateFilterControl(label: "Is favorited", value: $state.songFilter.isFavorited)
+        }
+    }
+
+    @ViewBuilder
+    private var ratedControl: some View {
+        @Bindable var state = appState
+        switch context {
+        case .album: TriStateFilterControl(label: "Is rated", value: $state.albumFilter.isRated)
+        case .song: TriStateFilterControl(label: "Is rated", value: $state.songFilter.isRated)
+        case .artist: EmptyView()
+        }
+    }
+
+    @ViewBuilder
+    private var recentlyPlayedControl: some View {
+        @Bindable var state = appState
+        HStack {
+            Text("Is recently played")
+                .font(.subheadline)
+                .fontWeight(.medium)
+            Spacer()
+            switch context {
+            case .album:
+                Toggle("", isOn: $state.albumFilter.isRecentlyPlayed)
+                    .labelsHidden().toggleStyle(.switch).controlSize(.small)
+                    .accessibilityLabel("Is recently played")
+            case .song:
+                Toggle("", isOn: $state.songFilter.isRecentlyPlayed)
+                    .labelsHidden().toggleStyle(.switch).controlSize(.small)
+                    .accessibilityLabel("Is recently played")
+            case .artist:
+                EmptyView()
+            }
+        }
+    }
+
+    // MARK: - Artist Multi-Select
+
+    @ViewBuilder
+    private var artistMultiSelect: some View {
+        @Bindable var state = appState
+        switch context {
+        case .album:
+            FilterMultiSelectList(
+                title: "Artists", items: artists,
+                selectedIds: $state.albumFilter.selectedArtistIds,
+                id: \.id, label: \.name,
+                subtitle: { a in a.albumCount.map { "\($0) album\($0 == 1 ? "" : "s")" } },
+                imageId: { $0.coverArtId }
+            )
+        case .song:
+            FilterMultiSelectList(
+                title: "Artists", items: artists,
+                selectedIds: $state.songFilter.selectedArtistIds,
+                id: \.id, label: \.name,
+                subtitle: { a in a.albumCount.map { "\($0) album\($0 == 1 ? "" : "s")" } },
+                imageId: { $0.coverArtId }
+            )
+        case .artist:
+            EmptyView()
+        }
+    }
+
+    // MARK: - Genre Multi-Select
+
+    @ViewBuilder
+    private var genreMultiSelect: some View {
+        @Bindable var state = appState
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text("Genres")
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                Spacer()
+                if !filter.selectedGenres.isEmpty {
+                    Text("\(filter.selectedGenres.count)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            switch context {
+            case .album:
+                StringFilterList(items: genres, selectedItems: $state.albumFilter.selectedGenres, placeholder: "Search genres…")
+            case .artist:
+                StringFilterList(items: genres, selectedItems: $state.artistFilter.selectedGenres, placeholder: "Search genres…")
+            case .song:
+                StringFilterList(items: genres, selectedItems: $state.songFilter.selectedGenres, placeholder: "Search genres…")
+            }
+        }
+    }
+
+    // MARK: - Label Multi-Select
+
+    @ViewBuilder
+    private var labelMultiSelect: some View {
+        @Bindable var state = appState
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text("Labels")
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                Spacer()
+                if !filter.selectedLabels.isEmpty {
+                    Text("\(filter.selectedLabels.count)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            StringFilterList(items: labels, selectedItems: $state.albumFilter.selectedLabels, placeholder: "Search labels…")
+        }
+    }
+
+    // MARK: - Year Filter
+
+    @ViewBuilder
+    private var yearFilter: some View {
+        @Bindable var state = appState
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Year")
+                .font(.subheadline)
+                .fontWeight(.medium)
+            HStack {
+                switch context {
+                case .album:
+                    TextField("e.g. 2024", value: $state.albumFilter.year, format: .number)
+                        .textFieldStyle(.roundedBorder).font(.caption)
+                        .accessibilityLabel("Filter by year")
+                case .song:
+                    TextField("e.g. 2024", value: $state.songFilter.year, format: .number)
+                        .textFieldStyle(.roundedBorder).font(.caption)
+                        .accessibilityLabel("Filter by year")
+                case .artist:
+                    EmptyView()
+                }
+                if filter.year != nil {
+                    Button {
+                        filter.year = nil
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Clear year filter")
+                }
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func loadCachedMetadata() {
+        // Genres from albums (artists inherit album genres) or songs
+        let genreSet: Set<String>
+        if context == .song {
+            let songDescriptor = FetchDescriptor<CachedSong>()
+            let songs = (try? modelContext.fetch(songDescriptor)) ?? []
+            genreSet = Set(songs.compactMap(\.genre)).subtracting([""])
+        } else {
+            let descriptor = FetchDescriptor<CachedAlbum>()
+            let albums = (try? modelContext.fetch(descriptor)) ?? []
+            genreSet = Set(albums.compactMap(\.genre)).subtracting([""])
+
+            if context == .album {
+                let labelSet = Set(albums.compactMap(\.label)).subtracting([""])
+                labels = labelSet.sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
+            }
+        }
+        genres = genreSet.sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
+    }
+}
+
+// MARK: - Reusable String Filter List
+
+struct StringFilterList: View {
+    let items: [String]
+    @Binding var selectedItems: Set<String>
+    var placeholder: String = "Search…"
+    @State private var searchText = ""
+
+    private var filteredItems: [String] {
+        if searchText.isEmpty { return items }
+        return items.filter { $0.localizedCaseInsensitiveContains(searchText) }
+    }
+
+    var body: some View {
+        TextField(placeholder, text: $searchText)
+            .textFieldStyle(.roundedBorder)
+            .font(.caption)
+
+        ScrollView {
+            LazyVStack(spacing: 0) {
+                ForEach(filteredItems, id: \.self) { item in
+                    let isSelected = selectedItems.contains(item)
+                    Button {
+                        if isSelected {
+                            selectedItems.remove(item)
+                        } else {
+                            selectedItems.insert(item)
+                        }
+                    } label: {
+                        HStack {
+                            Text(item)
+                                .font(.caption)
+                                .lineLimit(1)
+                            Spacer()
+                            if isSelected {
+                                Image(systemName: "checkmark")
+                                    .font(.caption)
+                                    .foregroundStyle(Color.accentColor)
+                            }
+                        }
+                        .padding(.vertical, 4)
+                        .padding(.horizontal, 6)
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .background(isSelected ? Color.accentColor.opacity(0.1) : Color.clear)
+                    .accessibilityLabel(item)
+                    .accessibilityValue(isSelected ? "Selected" : "Not selected")
+                    .accessibilityAddTraits(isSelected ? .isSelected : [])
+                }
+            }
+        }
+        .frame(height: 160)
+        .background(Color(nsColor: .controlBackgroundColor).opacity(0.5))
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+    }
+}
+#endif

--- a/Vibrdrome/Features/Library/LibraryFilterSidebarView.swift
+++ b/Vibrdrome/Features/Library/LibraryFilterSidebarView.swift
@@ -330,12 +330,20 @@ struct LibraryFilterSidebarView: View {
         } else {
             let descriptor = FetchDescriptor<CachedAlbum>()
             let albums = (try? modelContext.fetch(descriptor)) ?? []
-            genreSet = Set(albums.compactMap(\.genre)).subtracting([""])
+            // Collect all genres from the multi-genre array on each album
+            var mutableGenreSet = Set(albums.flatMap(\.genres)).subtracting([""])
 
             if context == .album {
+                // Union in song genres so albums not yet backfilled still appear in the list
+                let songDescriptor = FetchDescriptor<CachedSong>()
+                let songs = (try? modelContext.fetch(songDescriptor)) ?? []
+                mutableGenreSet.formUnion(Set(songs.compactMap(\.genre)).subtracting([""]))
+
                 let labelSet = Set(albums.compactMap(\.label)).subtracting([""])
                 labels = labelSet.sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
             }
+
+            genreSet = mutableGenreSet
         }
         genres = genreSet.sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
     }

--- a/Vibrdrome/Features/Library/LibraryView.swift
+++ b/Vibrdrome/Features/Library/LibraryView.swift
@@ -4,6 +4,7 @@ import NukeUI
 
 struct LibraryView: View {
     @Environment(AppState.self) private var appState
+    @Environment(\.modelContext) private var modelContext
     @Binding var navPath: NavigationPath
     @State private var recentAlbums: [Album] = []
     @State private var frequentAlbums: [Album] = []
@@ -641,18 +642,22 @@ struct LibraryView: View {
     private func fetchSections(client: SubsonicClient, skipCache: Bool = false) async {
         let folder = folderId
 
-        // Show cached data instantly (only for unfiltered/default)
+        // Show local cache data instantly (Recently Added + Starred from SwiftData)
         if folder == nil, !skipCache {
-            if let cached = await client.cachedResponse(
-                for: .getAlbumList2(type: .newest, size: 10, offset: 0), ttl: 300) {
-                recentAlbums = cached.albumList2?.album ?? []
+            if recentAlbums.isEmpty {
+                var desc = FetchDescriptor<CachedAlbum>(sortBy: [SortDescriptor(\CachedAlbum.created, order: .reverse)])
+                desc.fetchLimit = 10
+                if let cached = try? modelContext.fetch(desc), !cached.isEmpty {
+                    recentAlbums = cached.map { $0.toAlbum() }
+                }
             }
-            if let cached = await client.cachedResponse(
-                for: .getAlbumList2(type: .frequent, size: 10, offset: 0), ttl: 900) {
-                frequentAlbums = cached.albumList2?.album ?? []
-            }
-            if let cached = await client.cachedResponse(for: .getStarred2(), ttl: 300) {
-                if var songs = cached.starred2?.song, !songs.isEmpty {
+            if starredSongs.isEmpty {
+                let starredDesc = FetchDescriptor<CachedSong>(
+                    predicate: #Predicate<CachedSong> { $0.isStarred },
+                    sortBy: [SortDescriptor(\CachedSong.title)]
+                )
+                if let fetched = try? modelContext.fetch(starredDesc), !fetched.isEmpty {
+                    var songs = fetched.map { $0.toSong() }
                     songs.shuffle()
                     starredSongs = Array(songs.prefix(15))
                 }

--- a/Vibrdrome/Features/Library/MacColumnCustomizerView.swift
+++ b/Vibrdrome/Features/Library/MacColumnCustomizerView.swift
@@ -1,0 +1,70 @@
+#if os(macOS)
+import SwiftUI
+
+// MARK: - Column customizer popover
+
+struct MacColumnCustomizerView: View {
+    @Bindable var settings: TrackTableColumnSettings
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header
+            HStack {
+                Text("Customize Columns")
+                    .font(.headline)
+                Spacer()
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 14)
+            .padding(.bottom, 8)
+
+            Divider()
+
+            List {
+                ForEach(settings.entries) { entry in
+                    HStack(spacing: 10) {
+                        // Drag handle
+                        Image(systemName: "line.3.horizontal")
+                            .font(.caption)
+                            .foregroundStyle(.tertiary)
+                            .accessibilityHidden(true)
+
+                        // Toggle
+                        Toggle(isOn: Binding(
+                            get: { entry.visible },
+                            set: { _ in settings.toggle(entry.column) }
+                        )) {
+                            Text(entry.column.label)
+                                .font(.body)
+                        }
+                        .toggleStyle(.checkbox)
+                        .disabled(!entry.column.isRemovable)
+                    }
+                    .accessibilityElement(children: .combine)
+                }
+                .onMove { source, destination in
+                    settings.move(fromOffsets: source, toOffset: destination)
+                }
+            }
+            .listStyle(.plain)
+            .frame(height: min(CGFloat(settings.entries.count) * 34 + 8, 400))
+
+            Divider()
+
+            // Reset
+            HStack {
+                Button("Reset to Defaults") {
+                    settings.resetToDefaults()
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(.secondary)
+                .font(.caption)
+                Spacer()
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 10)
+        }
+        .frame(width: 260)
+    }
+}
+#endif

--- a/Vibrdrome/Features/Library/MacTrackTableHeader.swift
+++ b/Vibrdrome/Features/Library/MacTrackTableHeader.swift
@@ -1,0 +1,160 @@
+#if os(macOS)
+import AppKit
+import SwiftUI
+
+// MARK: - Column header row
+
+struct MacTrackTableHeader: View {
+    let settings: TrackTableColumnSettings
+    /// Total pixel width of the header row (from GeometryReader in parent).
+    let availableWidth: CGFloat
+    @Binding var sortColumn: TrackTableColumn?
+    @Binding var sortAscending: Bool
+    @Binding var showCustomizer: Bool
+
+    // Reference-type box so mutations don't trigger SwiftUI re-renders,
+    // which would reset the DragGesture translation back to zero mid-drag.
+    @State private var dragBox = ColumnDragBox()
+
+    var body: some View {
+        HStack(spacing: 0) {
+            ForEach(settings.visibleColumns) { col in
+                headerCellWithHandle(col)
+            }
+
+            // Fixed trailing area — must be identical width to MacTrackTableRow trailing actions (80pt)
+            HStack(spacing: 0) {
+                Spacer()
+                Button {
+                    showCustomizer.toggle()
+                } label: {
+                    Image(systemName: "tablecells.badge.ellipsis")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+                .help("Customize Columns")
+                .accessibilityLabel("Customize Columns")
+            }
+            .frame(width: 80)
+        }
+        .padding(.horizontal, 12)
+        .frame(height: 26)
+        .background(.bar)
+        .overlay(alignment: .bottom) {
+            Divider()
+        }
+    }
+
+    // MARK: - Header cell with optional resize handle
+
+    @ViewBuilder
+    private func headerCellWithHandle(_ col: TrackTableColumn) -> some View {
+        let cellWidth: CGFloat = col.isUserResizable
+            ? settings.columnWidth(for: col)
+            : col.minWidth
+
+        Button {
+            guard col.isSortable else { return }
+            if sortColumn == col {
+                sortAscending.toggle()
+            } else {
+                sortColumn = col
+                sortAscending = true
+            }
+        } label: {
+            headerCellLabel(col)
+        }
+        .buttonStyle(.plain)
+        .frame(
+            minWidth: col == .title ? col.minWidth : cellWidth,
+            maxWidth: col == .title ? .infinity : cellWidth,
+            alignment: col == .trackNumber ? .trailing : .leading
+        )
+        .overlay(alignment: .leading) {
+            if col.isUserResizable {
+                Color.clear
+                    .frame(width: 8)
+                    .contentShape(Rectangle())
+                    .onHover { hovering in
+                        if hovering {
+                            NSCursor.resizeLeftRight.push()
+                        } else {
+                            NSCursor.pop()
+                        }
+                    }
+                    .gesture(
+                        DragGesture(minimumDistance: 2, coordinateSpace: .global)
+                            .onChanged { value in
+                                if dragBox.column != col {
+                                    dragBox.column = col
+                                    dragBox.startWidth = settings.columnWidth(for: col)
+                                }
+                                // Use global coordinates: immune to local frame re-renders
+                                // caused by settings.setWidth() triggering @Observable updates.
+                                let delta = value.location.x - value.startLocation.x
+                                let rawWidth = dragBox.startWidth - delta
+                                let maxWidth = maxColumnWidth(for: col)
+                                let newWidth = min(max(col.minWidth, rawWidth), maxWidth)
+                                settings.setWidth(newWidth, for: col)
+                            }
+                            .onEnded { _ in
+                                settings.persistWidths()
+                                dragBox.column = nil
+                                dragBox.startWidth = 0
+                            }
+                    )
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func headerCellLabel(_ col: TrackTableColumn) -> some View {
+        HStack(spacing: 3) {
+            Text(col.label)
+                .font(.caption)
+                .fontWeight(.medium)
+                .foregroundStyle(sortColumn == col ? Color.accentColor : .secondary)
+                .lineLimit(1)
+
+            if sortColumn == col {
+                Image(systemName: sortAscending ? "chevron.up" : "chevron.down")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundStyle(Color.accentColor)
+            }
+        }
+        .padding(.horizontal, 4)
+        .frame(maxWidth: .infinity, alignment: col == .trackNumber ? .trailing : .leading)
+    }
+
+    // MARK: - Max width computation
+
+    /// Maximum width `col` may be set to — leaves enough room for Title to stay at its minimum.
+    private func maxColumnWidth(for col: TrackTableColumn) -> CGFloat {
+        // Fixed layout budget consumed by non-flexible columns and chrome:
+        //   • 80pt trailing actions
+        //   • 24pt horizontal padding (12 each side)
+        //   • title minimum width
+        //   • all other visible fixed columns (not title, not the column being dragged)
+        //   • all other visible resizable columns (not the column being dragged)
+        let chrome: CGFloat = 80 + 24 + TrackTableColumn.title.minWidth
+        let otherFixed = settings.visibleColumns
+            .filter { $0 != col && $0 != .title && !$0.isUserResizable }
+            .reduce(0) { $0 + $1.minWidth }
+        let otherResizable = settings.visibleColumns
+            .filter { $0 != col && $0.isUserResizable }
+            .reduce(0) { $0 + settings.columnWidth(for: $1) }
+        let budget = availableWidth - chrome - otherFixed - otherResizable
+        return max(col.minWidth, budget)
+    }
+}
+
+// MARK: - Drag state box
+
+/// Reference type so property mutations don't trigger SwiftUI re-renders,
+/// keeping the DragGesture translation stable throughout the drag.
+private final class ColumnDragBox {
+    var column: TrackTableColumn?
+    var startWidth: CGFloat = 0
+}
+#endif

--- a/Vibrdrome/Features/Library/MacTrackTableRow.swift
+++ b/Vibrdrome/Features/Library/MacTrackTableRow.swift
@@ -1,0 +1,319 @@
+#if os(macOS)
+import SwiftUI
+import NukeUI
+
+// MARK: - Single track row for the custom macOS table
+
+struct MacTrackTableRow: View {
+    let song: Song
+    let settings: TrackTableColumnSettings
+    let queue: [Song]
+    let index: Int
+    /// Reactive set of downloaded song IDs, maintained by parent via @Query.
+    let downloadedSongIds: Set<String>
+    /// Binding to the parent-managed selected song id for single-click selection.
+    @Binding var selectedSongId: String?
+
+    @Environment(AppState.self) private var appState
+    @AppStorage(UserDefaultsKeys.showAlbumArtInLists) private var showAlbumArt: Bool = true
+    @State private var isStarred = false
+    @State private var isHovered = false
+
+    private var isDownloaded: Bool { downloadedSongIds.contains(song.id) }
+
+    private var isCurrentlyPlaying: Bool {
+        AudioEngine.shared.currentSong?.id == song.id
+    }
+
+    private var isSelected: Bool { selectedSongId == song.id }
+
+    var body: some View {
+        HStack(spacing: 0) {
+            ForEach(settings.visibleColumns) { col in
+                columnCell(col)
+            }
+            trailingActions
+        }
+        .padding(.horizontal, 12)
+        .frame(height: showAlbumArt ? 44 : 34)
+        // Now-playing gets an accent tint; selected gets a system selection bg; hover gets a subtle lift
+        .background {
+            if isCurrentlyPlaying {
+                Color.accentColor.opacity(0.12)
+            } else if isSelected {
+                Color.accentColor.opacity(0.08)
+            } else if isHovered {
+                Color.primary.opacity(0.05)
+            }
+        }
+        .contentShape(Rectangle())
+        .onHover { isHovered = $0 }
+        // Single-click: select
+        .onTapGesture(count: 1) {
+            selectedSongId = song.id
+        }
+        // Double-click: play
+        .onTapGesture(count: 2) {
+            selectedSongId = song.id
+            AudioEngine.shared.play(song: song, from: queue, at: index)
+        }
+        .trackContextMenu(song: song, queue: queue, index: index)
+        .accessibilityLabel("\(song.title), \(song.artist ?? "Unknown Artist")")
+        .accessibilityHint("Double-tap to play")
+        .onAppear {
+            isStarred = song.starred != nil
+        }
+        .onChange(of: song.starred) { _, newValue in
+            isStarred = newValue != nil
+        }
+    }
+
+    // MARK: - Column cells
+
+    @ViewBuilder
+    private func columnCell(_ col: TrackTableColumn) -> some View {
+        let content = cellContent(col)
+        let cellWidth: CGFloat = col.isUserResizable
+            ? settings.columnWidth(for: col)
+            : col.minWidth
+        content
+            .font(col == .trackNumber ? .subheadline : .body)
+            .foregroundStyle(cellForegroundStyle(col))
+            .lineLimit(1)
+            .truncationMode(.tail)
+            .padding(.horizontal, 4)
+            .frame(
+                minWidth: col == .title ? col.minWidth : cellWidth,
+                maxWidth: col == .title ? .infinity : cellWidth,
+                alignment: col == .trackNumber ? .trailing : .leading
+            )
+    }
+
+    @ViewBuilder
+    private func cellContent(_ col: TrackTableColumn) -> some View {
+        switch col {
+        case .trackNumber: trackNumberCell
+        case .title:       titleCell
+        case .artist:      artistCell
+        case .album:       albumCell
+        case .duration:    durationCell
+        case .year:        yearCell
+        case .genre:       genreCell
+        case .bitRate:     bitRateCell
+        case .format:      formatCell
+        case .bpm:         bpmCell
+        case .dateAdded:   dateAddedCell
+        }
+    }
+
+    @ViewBuilder private var trackNumberCell: some View {
+        if isCurrentlyPlaying {
+            Image(systemName: "waveform")
+                .symbolEffect(.variableColor)
+                .font(.subheadline)
+                .foregroundStyle(Color.accentColor)
+                .frame(width: TrackTableColumn.trackNumber.minWidth, alignment: .trailing)
+        } else if let track = song.track {
+            Text("\(track)")
+        } else {
+            Text("—").foregroundStyle(.quaternary)
+        }
+    }
+
+    @ViewBuilder private var titleCell: some View {
+        if showAlbumArt {
+            HStack(spacing: 8) {
+                AlbumArtView(coverArtId: song.coverArt, size: 28, cornerRadius: 3)
+                Text(song.title)
+                    .fontWeight(isCurrentlyPlaying ? .semibold : .regular)
+                    .lineLimit(1)
+            }
+        } else {
+            Text(song.title)
+                .fontWeight(isCurrentlyPlaying ? .semibold : .regular)
+        }
+    }
+
+    @ViewBuilder private var artistCell: some View {
+        if let artistId = song.artistId, let name = song.artist {
+            NavigableCellText(text: name) { appState.pendingNavigation = .artist(id: artistId) }
+        } else {
+            Text(song.artist ?? "—").foregroundStyle(song.artist != nil ? .primary : .quaternary)
+        }
+    }
+
+    @ViewBuilder private var albumCell: some View {
+        if let albumId = song.albumId, let name = song.album {
+            NavigableCellText(text: name) { appState.pendingNavigation = .album(id: albumId) }
+        } else {
+            Text(song.album ?? "—").foregroundStyle(song.album != nil ? .primary : .quaternary)
+        }
+    }
+
+    @ViewBuilder private var durationCell: some View {
+        Text(song.duration.map { formatDuration($0) } ?? "—").foregroundStyle(.secondary)
+    }
+
+    @ViewBuilder private var yearCell: some View {
+        Text(song.year.map { String($0) } ?? "—")
+            .foregroundStyle(song.year != nil ? .secondary : .quaternary)
+    }
+
+    @ViewBuilder private var genreCell: some View {
+        if let genre = song.genre {
+            NavigableCellText(text: genre) { appState.pendingNavigation = .genre(name: genre) }
+        } else {
+            Text("—").foregroundStyle(.quaternary)
+        }
+    }
+
+    @ViewBuilder private var bitRateCell: some View {
+        if let br = song.bitRate {
+            Text("\(br) kbps").foregroundStyle(.secondary)
+        } else {
+            Text("—").foregroundStyle(.quaternary)
+        }
+    }
+
+    @ViewBuilder private var formatCell: some View {
+        Text(song.suffix?.uppercased() ?? "—")
+            .foregroundStyle(song.suffix != nil ? .secondary : .quaternary)
+    }
+
+    @ViewBuilder private var bpmCell: some View {
+        Text(song.bpm.map { String($0) } ?? "—")
+            .foregroundStyle(song.bpm != nil ? .secondary : .quaternary)
+    }
+
+    @ViewBuilder private var dateAddedCell: some View {
+        Text(formattedDateAdded).foregroundStyle(.secondary)
+    }
+
+    private func cellForegroundStyle(_ col: TrackTableColumn) -> some ShapeStyle {
+        if isCurrentlyPlaying && col == .title {
+            return AnyShapeStyle(Color.accentColor)
+        }
+        return AnyShapeStyle(Color.primary)
+    }
+
+    private var formattedDateAdded: String {
+        guard let created = song.created else { return "—" }
+        // Format: "MMM d, yyyy" from ISO8601 prefix
+        let prefix = String(created.prefix(10))
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        if let date = formatter.date(from: prefix) {
+            formatter.dateStyle = .medium
+            formatter.timeStyle = .none
+            return formatter.string(from: date)
+        }
+        return prefix
+    }
+
+    // MARK: - Trailing fixed actions
+
+    private var trailingActions: some View {
+        HStack(spacing: 4) {
+            // Heart
+            Button {
+                let wasStarred = isStarred
+                isStarred = !wasStarred
+                Task {
+                    do {
+                        if wasStarred {
+                            try await OfflineActionQueue.shared.unstar(id: song.id)
+                        } else {
+                            try await OfflineActionQueue.shared.star(id: song.id)
+                            if UserDefaults.standard.bool(forKey: UserDefaultsKeys.autoDownloadFavorites) {
+                                DownloadManager.shared.download(song: song, client: AppState.shared.subsonicClient)
+                            }
+                        }
+                    } catch {
+                        isStarred = wasStarred
+                    }
+                }
+            } label: {
+                Image(systemName: isStarred ? "heart.fill" : "heart")
+                    .font(.caption)
+                    .foregroundStyle(isStarred ? .pink : .secondary)
+            }
+            .buttonStyle(.plain)
+            .opacity(isHovered || isStarred ? 1 : 0)
+            .accessibilityLabel(isStarred ? "Remove from Favorites" : "Add to Favorites")
+
+            // Download
+            if isDownloaded {
+                Image(systemName: "arrow.down.circle.fill")
+                    .font(.callout)
+                    .foregroundStyle(.green)
+                    .accessibilityLabel("Downloaded")
+            } else {
+                Button {
+                    DownloadManager.shared.download(
+                        song: song, client: AppState.shared.subsonicClient
+                    )
+                } label: {
+                    Image(systemName: "arrow.down.circle")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+                .opacity(isHovered ? 1 : 0)
+                .accessibilityLabel("Download Song")
+            }
+
+            // Context menu button
+            Menu {
+                Button {
+                    AudioEngine.shared.addToQueueNext(song)
+                } label: {
+                    Label("Play Next", systemImage: "text.insert")
+                }
+                Button {
+                    AudioEngine.shared.addToQueue(song)
+                } label: {
+                    Label("Add to Queue", systemImage: "text.append")
+                }
+                Button {
+                    AudioEngine.shared.startRadioFromSong(song)
+                } label: {
+                    Label("Start Radio", systemImage: "dot.radiowaves.left.and.right")
+                }
+                let shareText = "🎵 \(song.title) — \(song.artist ?? "Unknown Artist")"
+                ShareLink(item: shareText) {
+                    Label("Share", systemImage: "square.and.arrow.up")
+                }
+            } label: {
+                Image(systemName: "ellipsis")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .frame(width: 20, height: 20)
+            }
+            .buttonStyle(.plain)
+            .opacity(isHovered ? 1 : 0)
+            .accessibilityLabel("Song Options")
+        }
+        .frame(width: 80, alignment: .trailing)
+    }
+}
+
+// MARK: - Navigable cell text
+
+/// A tappable text cell that underlines and accents on hover, used for artist / album / genre.
+private struct NavigableCellText: View {
+    let text: String
+    let action: () -> Void
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: action) {
+            Text(text)
+                .underline(isHovered)
+                .foregroundStyle(isHovered ? Color.accentColor : .primary)
+                .lineLimit(1)
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovered = $0 }
+    }
+}
+#endif

--- a/Vibrdrome/Features/Library/MacTrackTableView.swift
+++ b/Vibrdrome/Features/Library/MacTrackTableView.swift
@@ -1,0 +1,173 @@
+#if os(macOS)
+import SwiftUI
+import SwiftData
+
+// MARK: - Unified macOS track table (header + LazyVStack rows)
+
+/// Drop-in macOS replacement for `List { ForEach { TrackRow } }`.
+/// Provide `songs`, a `TrackTableColumnSettings` instance keyed to the view,
+/// and optionally disc separators (for album detail context).
+struct MacTrackTableView: View {
+    let songs: [Song]
+    let settings: TrackTableColumnSettings
+    var showDiscSeparators: Bool = false
+
+    @State private var sortColumn: TrackTableColumn?
+    @State private var sortAscending: Bool = true
+    @State private var showCustomizer: Bool = false
+    @State private var selectedSongId: String?
+
+    @Query(filter: #Predicate<DownloadedSong> { $0.isComplete == true })
+    private var completedDownloads: [DownloadedSong]
+
+    private var downloadedSongIds: Set<String> {
+        Set(completedDownloads.map(\.songId))
+    }
+
+    // MARK: - Computed sort
+
+    private var displayedSongs: [Song] {
+        guard let col = sortColumn else { return songs }
+        // When disc separators are shown, sort within each disc group so that
+        // disc ordering is preserved and separators don't get scattered.
+        if showDiscSeparators {
+            let discNumbers = songs.compactMap(\.discNumber)
+            let hasDiscs = !discNumbers.isEmpty
+            if hasDiscs {
+                // Group by disc number (preserving disc order), sort within each group.
+                let orderedDiscs = Set(songs.compactMap((\.discNumber))).sorted()
+                let noDisc = songs.filter { $0.discNumber == nil }
+                let grouped: [[Song]] = orderedDiscs.map { disc in
+                    songs
+                        .filter { $0.discNumber == disc }
+                        .sorted { compareSongs($0, $1, by: col, ascending: sortAscending) }
+                }
+                let sortedNoDisc = noDisc.sorted { compareSongs($0, $1, by: col, ascending: sortAscending) }
+                return grouped.flatMap { $0 } + sortedNoDisc
+            }
+        }
+        return songs.sorted { compareSongs($0, $1, by: col, ascending: sortAscending) }
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        VStack(spacing: 0) {
+            GeometryReader { geo in
+                MacTrackTableHeader(
+                    settings: settings,
+                    availableWidth: geo.size.width,
+                    sortColumn: $sortColumn,
+                    sortAscending: $sortAscending,
+                    showCustomizer: $showCustomizer
+                )
+            }
+            .frame(height: 26)
+            .popover(isPresented: $showCustomizer, arrowEdge: .top) {
+                MacColumnCustomizerView(settings: settings)
+            }
+            // Right-click anywhere on the header also opens customizer
+            .contextMenu {
+                Button("Customize Columns…") { showCustomizer = true }
+            }
+
+            if songs.isEmpty {
+                ContentUnavailableView(
+                    "No Tracks",
+                    systemImage: "music.note",
+                    description: Text("No songs to display.")
+                )
+            } else {
+                ScrollView(.vertical) {
+                    LazyVStack(spacing: 0) {
+                        let ordered = displayedSongs
+                        // Pre-compute first-occurrence indices for disc separators — O(n) not O(n²)
+                        let discFirstIndices: Set<Int> = {
+                            guard showDiscSeparators else { return [] }
+                            var seen = Set<Int>()
+                            var result = Set<Int>()
+                            for (idx, song) in ordered.enumerated() {
+                                if let disc = song.discNumber, !seen.contains(disc) {
+                                    seen.insert(disc)
+                                    result.insert(idx)
+                                }
+                            }
+                            return result
+                        }()
+
+                        ForEach(Array(ordered.enumerated()), id: \.element.id) { index, song in
+                            if showDiscSeparators && discFirstIndices.contains(index),
+                               let disc = song.discNumber {
+                                discSeparator(disc)
+                            }
+
+                            MacTrackTableRow(
+                                song: song,
+                                settings: settings,
+                                queue: ordered,
+                                index: index,
+                                downloadedSongIds: downloadedSongIds,
+                                selectedSongId: $selectedSongId
+                            )
+                            .accessibilityIdentifier("macTrackRow_\(song.id)")
+
+                            Divider()
+                                .padding(.leading, 12)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Disc separator
+
+    @ViewBuilder
+    private func discSeparator(_ disc: Int) -> some View {
+        HStack {
+            Image(systemName: "opticaldisc")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+            Text("Disc \(disc)")
+                .font(.caption)
+                .fontWeight(.semibold)
+                .foregroundStyle(.secondary)
+            Spacer()
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 7)
+        .background(.ultraThinMaterial)
+    }
+
+    // MARK: - Sort comparator
+
+    private func compareSongs(_ lhs: Song, _ rhs: Song, by col: TrackTableColumn, ascending: Bool) -> Bool {
+        let result: Bool
+        switch col {
+        case .trackNumber:
+            result = (lhs.track ?? Int.max) < (rhs.track ?? Int.max)
+        case .title:
+            result = lhs.title.localizedCaseInsensitiveCompare(rhs.title) == .orderedAscending
+        case .artist:
+            result = (lhs.artist ?? "").localizedCaseInsensitiveCompare(rhs.artist ?? "") == .orderedAscending
+        case .album:
+            result = (lhs.album ?? "").localizedCaseInsensitiveCompare(rhs.album ?? "") == .orderedAscending
+        case .duration:
+            result = (lhs.duration ?? 0) < (rhs.duration ?? 0)
+        case .year:
+            result = (lhs.year ?? 0) < (rhs.year ?? 0)
+        case .genre:
+            result = (lhs.genre ?? "").localizedCaseInsensitiveCompare(rhs.genre ?? "") == .orderedAscending
+        case .bitRate:
+            result = (lhs.bitRate ?? 0) < (rhs.bitRate ?? 0)
+        case .format:
+            result = (lhs.suffix ?? "").localizedCaseInsensitiveCompare(rhs.suffix ?? "") == .orderedAscending
+        case .bpm:
+            result = (lhs.bpm ?? 0) < (rhs.bpm ?? 0)
+        case .dateAdded:
+            result = (lhs.created ?? "") < (rhs.created ?? "")
+        }
+        return ascending ? result : !result
+    }
+}
+#endif

--- a/Vibrdrome/Features/Library/PlayHistoryView.swift
+++ b/Vibrdrome/Features/Library/PlayHistoryView.swift
@@ -4,18 +4,22 @@ import SwiftData
 struct PlayHistoryView: View {
     @Environment(\.modelContext) private var modelContext
     @Query(sort: \PlayHistory.playedAt, order: .reverse) private var allPlays: [PlayHistory]
+    @State private var cachedTodayCount: Int = 0
+    @State private var cachedWeekCount: Int = 0
+    @State private var cachedTopArtists: [(String, Int)] = []
+    @State private var cachedTopAlbums: [(String, String?, Int)] = []
 
     var body: some View {
         List {
-            if !todayPlays.isEmpty {
+            if cachedTodayCount > 0 {
                 statsSection
             }
 
-            if !topArtists.isEmpty {
+            if !cachedTopArtists.isEmpty {
                 topArtistsSection
             }
 
-            if !topAlbums.isEmpty {
+            if !cachedTopAlbums.isEmpty {
                 topAlbumsSection
             }
 
@@ -39,40 +43,35 @@ struct PlayHistoryView: View {
                 }
             }
         }
+        .onChange(of: allPlays) { recomputeStats() }
+        .onAppear { recomputeStats() }
     }
 
     // MARK: - Computed Data
 
-    private var todayPlays: [PlayHistory] {
-        allPlays.filter { Calendar.current.isDateInToday($0.playedAt) }
-    }
-
-    private var weekPlays: [PlayHistory] {
+    private func recomputeStats() {
         let weekAgo = Calendar.current.date(byAdding: .day, value: -7, to: .now) ?? .now
-        return allPlays.filter { $0.playedAt >= weekAgo }
-    }
+        let weekPlays = allPlays.filter { $0.playedAt >= weekAgo }
 
-    private var topArtists: [(String, Int)] {
-        let week = weekPlays
-        var counts: [String: Int] = [:]
-        for play in week {
+        cachedTodayCount = allPlays.filter { Calendar.current.isDateInToday($0.playedAt) }.count
+        cachedWeekCount = weekPlays.count
+
+        var artistCounts: [String: Int] = [:]
+        for play in weekPlays {
             if let artist = play.artistName {
-                counts[artist, default: 0] += 1
+                artistCounts[artist, default: 0] += 1
             }
         }
-        return counts.sorted { $0.value > $1.value }.prefix(5).map { ($0.key, $0.value) }
-    }
+        cachedTopArtists = artistCounts.sorted { $0.value > $1.value }.prefix(5).map { ($0.key, $0.value) }
 
-    private var topAlbums: [(String, String?, Int)] {
-        let week = weekPlays
-        var counts: [String: (artist: String?, count: Int)] = [:]
-        for play in week {
+        var albumCounts: [String: (artist: String?, count: Int)] = [:]
+        for play in weekPlays {
             if let album = play.albumName {
-                let existing = counts[album]
-                counts[album] = (play.artistName, (existing?.count ?? 0) + 1)
+                let existing = albumCounts[album]
+                albumCounts[album] = (play.artistName, (existing?.count ?? 0) + 1)
             }
         }
-        return counts.sorted { $0.value.count > $1.value.count }
+        cachedTopAlbums = albumCounts.sorted { $0.value.count > $1.value.count }
             .prefix(5)
             .map { ($0.key, $0.value.artist, $0.value.count) }
     }
@@ -82,8 +81,8 @@ struct PlayHistoryView: View {
     private var statsSection: some View {
         Section {
             HStack(spacing: 24) {
-                statBadge(value: todayPlays.count, label: "Today")
-                statBadge(value: weekPlays.count, label: "This Week")
+                statBadge(value: cachedTodayCount, label: "Today")
+                statBadge(value: cachedWeekCount, label: "This Week")
                 statBadge(value: allPlays.count, label: "All Time")
             }
             .frame(maxWidth: .infinity)
@@ -106,7 +105,7 @@ struct PlayHistoryView: View {
 
     private var topArtistsSection: some View {
         Section("Top Artists This Week") {
-            ForEach(topArtists, id: \.0) { artist, count in
+            ForEach(cachedTopArtists, id: \.0) { artist, count in
                 HStack {
                     Text(artist)
                         .font(.body)
@@ -121,7 +120,7 @@ struct PlayHistoryView: View {
 
     private var topAlbumsSection: some View {
         Section("Top Albums This Week") {
-            ForEach(topAlbums, id: \.0) { album, artist, count in
+            ForEach(cachedTopAlbums, id: \.0) { album, artist, count in
                 HStack {
                     VStack(alignment: .leading, spacing: 2) {
                         Text(album)

--- a/Vibrdrome/Features/Library/SidebarContentView.swift
+++ b/Vibrdrome/Features/Library/SidebarContentView.swift
@@ -152,7 +152,7 @@ struct SidebarContentView: View {
             .navigationTitle("Vibrdrome")
         } detail: {
             #if os(macOS)
-            HStack(spacing: 0) {
+            GeometryReader { geometry in
                 NavigationStack(path: $detailPath) {
                     detailView
                         .navigationDestination(for: SidebarNavRoute.self) { route in
@@ -166,15 +166,17 @@ struct SidebarContentView: View {
                             }
                         }
                 }
-
+                .environment(\.contentWidth, geometry.size.width)
+            }
+            .inspector(isPresented: Binding(
+                get: { appState.activeSidePanel != nil },
+                set: { if !$0 { appState.activeSidePanel = nil } }
+            )) {
                 if let panel = appState.activeSidePanel {
-                    Divider()
                     sidePanelView(for: panel)
-                        .frame(width: sidePanelWidth)
-                        .transition(.move(edge: .trailing).combined(with: .opacity))
                 }
             }
-            .animation(.easeInOut(duration: 0.2), value: appState.activeSidePanel)
+            .inspectorColumnWidth(min: 280, ideal: sidePanelWidth, max: 500)
             #else
             NavigationStack(path: $detailPath) {
                 detailView
@@ -195,6 +197,22 @@ struct SidebarContentView: View {
             if !detailPath.isEmpty {
                 detailPath = NavigationPath()
             }
+            #if os(macOS)
+            // Auto-switch filter panel when a filter panel is already open
+            if let panel = appState.activeSidePanel,
+               panel == .albumFilters || panel == .artistFilters || panel == .songFilters {
+                switch SidebarItem(rawValue: selectionRaw) {
+                case .albums, .recentlyAdded, .mostPlayed, .recentlyPlayed:
+                    appState.activeSidePanel = .albumFilters
+                case .artists:
+                    appState.activeSidePanel = .artistFilters
+                case .songs:
+                    appState.activeSidePanel = .songFilters
+                default:
+                    appState.activeSidePanel = nil
+                }
+            }
+            #endif
         }
         .onChange(of: appState.pendingNavigation) { _, newValue in
             guard let nav = newValue else { return }
@@ -312,6 +330,12 @@ struct SidebarContentView: View {
             LyricsPanelView()
         case .artistInfo:
             ArtistInfoPanelView()
+        case .albumFilters:
+            LibraryFilterSidebarView(context: .album)
+        case .artistFilters:
+            LibraryFilterSidebarView(context: .artist)
+        case .songFilters:
+            LibraryFilterSidebarView(context: .song)
         }
     }
     #endif

--- a/Vibrdrome/Features/Library/SongsView.swift
+++ b/Vibrdrome/Features/Library/SongsView.swift
@@ -17,6 +17,7 @@ struct SongsView: View {
     @AppStorage(UserDefaultsKeys.showAlbumArtInLists) private var showAlbumArtInLists: Bool = true
     @AppStorage("songsViewStyle") private var showAsList = true
     @AppStorage(UserDefaultsKeys.gridColumnsPerRow) private var gridColumns = 2
+    @Environment(\.verticalSizeClass) private var verticalSizeClass
     @State private var sortBy: SongSortOption = .title
 
     private let pageSize = 500
@@ -388,7 +389,8 @@ struct SongsView: View {
                 }
 
                 LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 16),
-                                         count: max(2, min(10, gridColumns))), spacing: 20) {
+                                         count: Theme.effectiveGridColumns(base: gridColumns, verticalSizeClass: verticalSizeClass)),
+                          spacing: 20) {
                     ForEach(Array(displayedSongs.enumerated()), id: \.element.id) { index, song in
                         songCard(song)
                             .contentShape(Rectangle())

--- a/Vibrdrome/Features/Library/SongsView.swift
+++ b/Vibrdrome/Features/Library/SongsView.swift
@@ -1,9 +1,15 @@
 import NukeUI
 import SwiftUI
+import SwiftData
+import os.log
 
 struct SongsView: View {
     @Environment(AppState.self) private var appState
+    @Environment(\.modelContext) private var modelContext
     @State private var songs: [Song] = []
+    @State private var titleSongCount: Int?
+    @State private var localFilteredSongs: [Song]?
+    @State private var filterTask: Task<Void, Never>?
     @State private var isLoading = true
     @State private var hasMore = false
     @State private var searchText = ""
@@ -16,12 +22,15 @@ struct SongsView: View {
     @State private var filterArtist: String?
     @AppStorage(UserDefaultsKeys.showAlbumArtInLists) private var showAlbumArtInLists: Bool = true
     @AppStorage("songsViewStyle") private var showAsList = true
-    @AppStorage(UserDefaultsKeys.gridColumnsPerRow) private var gridColumns = 2
-    @Environment(\.verticalSizeClass) private var verticalSizeClass
+    @AppStorage(UserDefaultsKeys.gridDensity) private var gridDensityRaw: String = GridDensity.comfortable.rawValue
+    private var gridDensity: GridDensity { GridDensity(rawValue: gridDensityRaw) ?? .comfortable }
     @State private var sortBy: SongSortOption = .title
     #if os(macOS)
     @State private var columnSettings = TrackTableColumnSettings(viewKey: "songs")
     #endif
+    @State private var cachedDisplayedSongs: [Song] = []
+    @State private var scrollLoadTask: Task<Void, Never>?
+    @State private var pendingPageTarget: Int = 0
 
     private let pageSize = 500
 
@@ -51,8 +60,13 @@ struct SongsView: View {
         filterYear != nil || filterGenre != nil || filterArtist != nil
     }
 
-    private var displayedSongs: [Song] {
-        var base = searchText.count >= 2 ? searchResults : songs
+    private func computeDisplayedSongs() -> [Song] {
+        var base: [Song]
+        #if os(macOS)
+        base = localFilteredSongs ?? (searchText.count >= 2 ? searchResults : songs)
+        #else
+        base = searchText.count >= 2 ? searchResults : songs
+        #endif
         if let filterYear {
             base = base.filter { $0.year == filterYear }
         }
@@ -80,14 +94,32 @@ struct SongsView: View {
     }
 
     var body: some View {
-        Group {
-            if showAsList {
-                songList
-            } else {
-                songGrid
-            }
+        decoratedView
+    }
+
+    private var decoratedView: some View {
+        toolbarView
+        .task { await initialLoad() }
+        .onChange(of: sortBy) { recomputeDisplayedSongs() }
+        .onChange(of: filterYear) { recomputeDisplayedSongs() }
+        .onChange(of: filterGenre) { recomputeDisplayedSongs() }
+        .onChange(of: filterArtist) { recomputeDisplayedSongs() }
+        .onChange(of: appState.libraryCache.generation) { _, _ in
+            refreshTitleSongCount()
         }
-        .navigationTitle(songs.isEmpty ? "Songs" : "Songs (\(songs.count))")
+        #if os(macOS)
+        .onChange(of: appState.songFilter.isFavorited) { debouncedApplyLocalFilters() }
+        .onChange(of: appState.songFilter.isRated) { debouncedApplyLocalFilters() }
+        .onChange(of: appState.songFilter.isRecentlyPlayed) { debouncedApplyLocalFilters() }
+        .onChange(of: appState.songFilter.selectedArtistIds) { debouncedApplyLocalFilters() }
+        .onChange(of: appState.songFilter.selectedGenres) { debouncedApplyLocalFilters() }
+        .onChange(of: appState.songFilter.year) { debouncedApplyLocalFilters() }
+        #endif
+    }
+
+    private var toolbarView: some View {
+        contentView
+        .navigationTitle(navigationTitle)
         #if os(iOS)
         .navigationBarTitleDisplayMode(.large)
         #endif
@@ -103,6 +135,7 @@ struct SongsView: View {
         .onChange(of: searchText) { _, query in
             guard query.count >= 2 else {
                 searchResults = []
+                recomputeDisplayedSongs()
                 return
             }
             isSearching = true
@@ -113,11 +146,29 @@ struct SongsView: View {
                     let result = try await appState.subsonicClient.search(
                         query: query, artistCount: 0, albumCount: 0, songCount: 50)
                     searchResults = result.song ?? []
+                    recomputeDisplayedSongs()
                 } catch {}
                 isSearching = false
             }
         }
         .toolbar {
+            #if os(macOS)
+            ToolbarItem(placement: .automatic) {
+                Button {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        if appState.activeSidePanel == .songFilters {
+                            appState.activeSidePanel = nil
+                        } else {
+                            appState.activeSidePanel = .songFilters
+                        }
+                    }
+                } label: {
+                    Image(systemName: appState.songFilter.isActive ? "line.3.horizontal.decrease.circle.fill" : "line.3.horizontal.decrease.circle")
+                }
+                .accessibilityLabel("Song Filters")
+                .accessibilityIdentifier("songFilterToggle")
+            }
+            #endif
             ToolbarItem(placement: .automatic) {
                 Button {
                     withAnimation(.easeInOut(duration: 0.2)) {
@@ -223,9 +274,15 @@ struct SongsView: View {
                 }
             }
         }
-        .task {
-            await loadSongs()
-            await loadGenres()
+    }
+
+    private var contentView: some View {
+        Group {
+            if showAsList {
+                songList
+            } else {
+                songGrid
+            }
         }
     }
 
@@ -336,11 +393,15 @@ struct SongsView: View {
         }
     }
 
+    private var navigationTitle: String {
+        titleSongCount.map { "Songs (\($0))" } ?? "Songs"
+    }
+
     // MARK: - List view
 
     private var songList: some View {
         #if os(macOS)
-        MacTrackTableView(songs: displayedSongs, settings: columnSettings)
+        MacTrackTableView(songs: cachedDisplayedSongs, settings: columnSettings)
         #else
         List {
             if hasActiveFilters {
@@ -349,32 +410,27 @@ struct SongsView: View {
                     .listRowInsets(EdgeInsets(top: 4, leading: 16, bottom: 4, trailing: 16))
             }
 
-            if !displayedSongs.isEmpty {
+            if !cachedDisplayedSongs.isEmpty {
                 playShuffleBar
                     .listRowSeparator(.hidden)
             }
 
-            ForEach(Array(displayedSongs.enumerated()), id: \.element.id) { index, song in
-                songRow(song)
-                    .contentShape(Rectangle())
-                    .onTapGesture {
-                        AudioEngine.shared.play(song: song, from: displayedSongs, at: index)
+            ForEach(0..<totalItemCount, id: \.self) { index in
+                Group {
+                    if index < cachedDisplayedSongs.count {
+                        let song = cachedDisplayedSongs[index]
+                        songRow(song)
+                            .contentShape(Rectangle())
+                            .onTapGesture {
+                                AudioEngine.shared.play(song: song, from: cachedDisplayedSongs, at: index)
+                            }
+                            .accessibilityIdentifier("songRow_\(song.id)")
+                            .trackContextMenu(song: song)
+                    } else {
+                        songListPlaceholder
                     }
-                    .accessibilityIdentifier("songRow_\(song.id)")
-                    .trackContextMenu(song: song)
-                    .onAppear {
-                        if searchText.isEmpty && hasMore && !isLoading && song.id == songs.last?.id {
-                            Task { await loadMore() }
-                        }
-                    }
-            }
-
-            if isLoading {
-                HStack {
-                    Spacer()
-                    ProgressView()
-                    Spacer()
                 }
+                .onAppear { triggerLoadIfNeeded(at: index) }
             }
         }
         #endif
@@ -390,34 +446,33 @@ struct SongsView: View {
                         .padding(.horizontal, 16)
                 }
 
-                if !displayedSongs.isEmpty {
+                if !cachedDisplayedSongs.isEmpty {
                     playShuffleBar
                         .padding(.horizontal, 16)
                 }
 
-                LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 16),
-                                         count: Theme.effectiveGridColumns(base: gridColumns, verticalSizeClass: verticalSizeClass)),
-                          spacing: 20) {
-                    ForEach(Array(displayedSongs.enumerated()), id: \.element.id) { index, song in
-                        songCard(song)
-                            .contentShape(Rectangle())
-                            .onTapGesture {
-                                AudioEngine.shared.play(song: song, from: displayedSongs, at: index)
+                LazyVGrid(columns: [
+                    GridItem(.adaptive(minimum: gridDensity.minimumWidth), spacing: 16)
+                ], spacing: 20) {
+                    ForEach(0..<totalItemCount, id: \.self) { index in
+                        Group {
+                            if index < cachedDisplayedSongs.count {
+                                let song = cachedDisplayedSongs[index]
+                                songCard(song)
+                                    .contentShape(Rectangle())
+                                    .onTapGesture {
+                                        AudioEngine.shared.play(song: song, from: cachedDisplayedSongs, at: index)
+                                    }
+                                    .accessibilityIdentifier("songCard_\(song.id)")
+                                    .trackContextMenu(song: song)
+                            } else {
+                                songGridPlaceholder
                             }
-                            .accessibilityIdentifier("songCard_\(song.id)")
-                            .trackContextMenu(song: song)
-                            .onAppear {
-                                if searchText.isEmpty && hasMore && !isLoading && song.id == songs.last?.id {
-                                    Task { await loadMore() }
-                                }
-                            }
+                        }
+                        .onAppear { triggerLoadIfNeeded(at: index) }
                     }
                 }
                 .padding(16)
-
-                if isLoading {
-                    ProgressView().padding()
-                }
             }
         }
     }
@@ -425,7 +480,7 @@ struct SongsView: View {
     private var playShuffleBar: some View {
         HStack(spacing: 12) {
             Button {
-                let songs = displayedSongs
+                let songs = cachedDisplayedSongs
                 AudioEngine.shared.play(song: songs[0], from: songs, at: 0)
             } label: {
                 Label("Play All", systemImage: "play.fill")
@@ -438,7 +493,7 @@ struct SongsView: View {
             .accessibilityIdentifier("songsPlayAllButton")
 
             Button {
-                let shuffled = displayedSongs.shuffled()
+                let shuffled = cachedDisplayedSongs.shuffled()
                 AudioEngine.shared.play(song: shuffled[0], from: shuffled, at: 0)
             } label: {
                 Label("Shuffle", systemImage: "shuffle")
@@ -475,6 +530,16 @@ struct SongsView: View {
         }
     }
 
+    private func initialLoad() async {
+        await loadSongs()
+        await loadGenres()
+        refreshTitleSongCount()
+        #if os(macOS)
+        applyLocalFilters()
+        #endif
+        recomputeDisplayedSongs()
+    }
+
     private func loadGenres() async {
         guard availableGenres.isEmpty else { return }
         do {
@@ -486,6 +551,8 @@ struct SongsView: View {
     }
 
     private func loadSongs() async {
+        scrollLoadTask?.cancel()
+        pendingPageTarget = 0
         isLoading = true
         songs = []
         defer { isLoading = false }
@@ -495,21 +562,188 @@ struct SongsView: View {
             )
             songs = result.song ?? []
             hasMore = (result.song?.count ?? 0) >= pageSize
+            refreshTitleSongCount()
+            recomputeDisplayedSongs()
         } catch {}
     }
 
-    private func loadMore() async {
+    private func loadPages() async {
         guard hasMore, !isLoading else { return }
         isLoading = true
-        defer { isLoading = false }
-        do {
-            let result = try await appState.subsonicClient.search(
-                query: "", artistCount: 0, albumCount: 0,
-                songCount: pageSize, songOffset: songs.count
-            )
-            let newSongs = result.song ?? []
-            songs.append(contentsOf: newSongs)
-            hasMore = newSongs.count >= pageSize
-        } catch {}
+        // Accumulate into local array to avoid multiple @State updates triggering re-renders
+        var accumulated = songs
+        var stillHasMore = hasMore
+        while accumulated.count < pendingPageTarget, stillHasMore, !Task.isCancelled {
+            do {
+                let result = try await appState.subsonicClient.search(
+                    query: "", artistCount: 0, albumCount: 0,
+                    songCount: pageSize, songOffset: accumulated.count
+                )
+                let newSongs = result.song ?? []
+                accumulated.append(contentsOf: newSongs)
+                stillHasMore = newSongs.count >= pageSize
+            } catch {
+                stillHasMore = false
+                break
+            }
+        }
+        // Single state update instead of one per page
+        songs = accumulated
+        hasMore = stillHasMore
+        isLoading = false
+        recomputeDisplayedSongs()
+        refreshTitleSongCount()
+        if songs.count < pendingPageTarget, hasMore {
+            scrollLoadTask?.cancel()
+            scrollLoadTask = Task { await loadPages() }
+        }
     }
+
+    private func refreshTitleSongCount() {
+        if let cachedSongs = appState.libraryCache.songs, !cachedSongs.isEmpty {
+            titleSongCount = cachedSongs.count
+            return
+        }
+
+        let descriptor = FetchDescriptor<CachedSong>()
+        if let cachedCount = try? modelContext.fetchCount(descriptor), cachedCount > 0 {
+            titleSongCount = cachedCount
+            return
+        }
+
+        titleSongCount = songs.isEmpty ? nil : songs.count
+    }
+
+    private var songListPlaceholder: some View {
+        HStack(spacing: 12) {
+            RoundedRectangle(cornerRadius: 4)
+                .fill(.quaternary)
+                .frame(width: 40, height: 40)
+            VStack(alignment: .leading, spacing: 4) {
+                RoundedRectangle(cornerRadius: 3)
+                    .fill(.quaternary)
+                    .frame(width: 140, height: 14)
+                RoundedRectangle(cornerRadius: 3)
+                    .fill(.quaternary)
+                    .frame(width: 100, height: 12)
+            }
+            Spacer()
+        }
+    }
+
+    private var songGridPlaceholder: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            RoundedRectangle(cornerRadius: 10)
+                .fill(.quaternary)
+                .aspectRatio(1, contentMode: .fit)
+            RoundedRectangle(cornerRadius: 3)
+                .fill(.quaternary)
+                .frame(height: 14)
+            RoundedRectangle(cornerRadius: 3)
+                .fill(.quaternary)
+                .frame(width: 80, height: 12)
+        }
+    }
+
+    private var totalItemCount: Int {
+        guard localFilteredSongs == nil, searchText.isEmpty else { return cachedDisplayedSongs.count }
+        guard hasMore, let totalCount = appState.libraryCache.songs?.count else { return cachedDisplayedSongs.count }
+        return max(songs.count, totalCount)
+    }
+
+    private func triggerLoadIfNeeded(at index: Int) {
+        guard localFilteredSongs == nil, searchText.isEmpty, hasMore else { return }
+        if index >= songs.count {
+            // Scrolled into placeholder territory — always update target, debounce the load
+            pendingPageTarget = max(pendingPageTarget, songs.count + (index - songs.count) + pageSize)
+            scrollLoadTask?.cancel()
+            scrollLoadTask = Task {
+                try? await Task.sleep(for: .milliseconds(150))
+                guard !Task.isCancelled else { return }
+                await loadPages()
+            }
+        } else if !isLoading {
+            // Near end of loaded items — prefetch immediately
+            let prefetchThreshold = max(songs.count - 10, 0)
+            if index >= prefetchThreshold {
+                pendingPageTarget = max(pendingPageTarget, songs.count + pageSize)
+                Task { await loadPages() }
+            }
+        }
+    }
+
+    private func recomputeDisplayedSongs() {
+        cachedDisplayedSongs = computeDisplayedSongs()
+    }
+
+    #if os(macOS)
+    private func debouncedApplyLocalFilters() {
+        filterTask?.cancel()
+        filterTask = Task {
+            try? await Task.sleep(for: .milliseconds(150))
+            guard !Task.isCancelled else { return }
+            applyLocalFilters()
+        }
+    }
+
+    private func applyLocalFilters() {
+        let filter = appState.songFilter
+        guard filter.isActive else {
+            localFilteredSongs = nil
+            recomputeDisplayedSongs()
+            return
+        }
+
+        do {
+            let allSongs: [Song]
+            if let cachedSongs = appState.libraryCache.songs {
+                allSongs = cachedSongs
+            } else {
+                var descriptor = FetchDescriptor<CachedSong>()
+                descriptor.sortBy = [SortDescriptor(\.title)]
+                allSongs = try modelContext.fetch(descriptor).map { $0.toSong() }
+            }
+
+            let recentSongIds = recentlyPlayedSongIds(for: filter)
+            localFilteredSongs = allSongs.filter { songMatchesFilter($0, filter: filter, recentIds: recentSongIds) }
+            recomputeDisplayedSongs()
+        } catch {
+            Logger(subsystem: "com.vibrdrome.app", category: "Songs")
+                .error("Failed to apply local filters: \(error)")
+            localFilteredSongs = nil
+        }
+    }
+
+    private func recentlyPlayedSongIds(for filter: LibraryFilter) -> Set<String>? {
+        guard filter.isRecentlyPlayed else { return nil }
+        let cutoff = Calendar.current.date(byAdding: .day, value: -30, to: Date()) ?? Date()
+        let descriptor = FetchDescriptor<CachedSong>(
+            predicate: #Predicate { $0.lastPlayed != nil && $0.lastPlayed! > cutoff }
+        )
+        let recentSongs = (try? modelContext.fetch(descriptor)) ?? []
+        return Set(recentSongs.map(\.id))
+    }
+
+    private func songMatchesFilter(
+        _ song: Song, filter: LibraryFilter, recentIds: Set<String>?
+    ) -> Bool {
+        guard filter.isFavorited.matches(song.starred != nil) else { return false }
+        guard filter.isRated.matches((song.userRating ?? 0) != 0) else { return false }
+        if let recentIds, !recentIds.contains(song.id) { return false }
+        if !filter.selectedArtistIds.isEmpty {
+            guard let artistId = song.artistId, filter.selectedArtistIds.contains(artistId) else {
+                return false
+            }
+        }
+        if !filter.selectedGenres.isEmpty {
+            guard let genre = song.genre, filter.selectedGenres.contains(genre) else {
+                return false
+            }
+        }
+        if let yearFilter = filter.year {
+            guard song.year == yearFilter else { return false }
+        }
+        return true
+    }
+    #endif
 }

--- a/Vibrdrome/Features/Library/SongsView.swift
+++ b/Vibrdrome/Features/Library/SongsView.swift
@@ -19,6 +19,9 @@ struct SongsView: View {
     @AppStorage(UserDefaultsKeys.gridColumnsPerRow) private var gridColumns = 2
     @Environment(\.verticalSizeClass) private var verticalSizeClass
     @State private var sortBy: SongSortOption = .title
+    #if os(macOS)
+    @State private var columnSettings = TrackTableColumnSettings(viewKey: "songs")
+    #endif
 
     private let pageSize = 500
 
@@ -336,6 +339,9 @@ struct SongsView: View {
     // MARK: - List view
 
     private var songList: some View {
+        #if os(macOS)
+        MacTrackTableView(songs: displayedSongs, settings: columnSettings)
+        #else
         List {
             if hasActiveFilters {
                 activeFilterChips
@@ -371,6 +377,7 @@ struct SongsView: View {
                 }
             }
         }
+        #endif
     }
 
     // MARK: - Grid view

--- a/Vibrdrome/Features/Library/TrackTableColumn.swift
+++ b/Vibrdrome/Features/Library/TrackTableColumn.swift
@@ -1,0 +1,111 @@
+#if os(macOS)
+import Foundation
+
+// MARK: - Column Definition
+
+enum TrackTableColumn: String, CaseIterable, Codable, Identifiable, Sendable {
+    case trackNumber
+    case title
+    case artist
+    case album
+    case duration
+    case year
+    case genre
+    case bitRate
+    case format
+    case bpm
+    case dateAdded
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .trackNumber: return "#"
+        case .title:       return "Title"
+        case .artist:      return "Artist"
+        case .album:       return "Album"
+        case .duration:    return "Time"
+        case .year:        return "Year"
+        case .genre:       return "Genre"
+        case .bitRate:     return "Bitrate"
+        case .format:      return "Format"
+        case .bpm:         return "BPM"
+        case .dateAdded:   return "Date Added"
+        }
+    }
+
+    /// Minimum column width in points.
+    var minWidth: CGFloat {
+        switch self {
+        case .trackNumber: return 36
+        case .title:       return 180
+        case .artist:      return 140
+        case .album:       return 140
+        case .duration:    return 56
+        case .year:        return 52
+        case .genre:       return 100
+        case .bitRate:     return 72
+        case .format:      return 60
+        case .bpm:         return 52
+        case .dateAdded:   return 110
+        }
+    }
+
+    /// Whether the column is flexible (expands to fill remaining space).
+    var isFlexible: Bool {
+        switch self {
+        case .title, .artist, .album, .genre: return true
+        default: return false
+        }
+    }
+
+    /// `true` → column can be hidden by the user.
+    var isRemovable: Bool { self != .title }
+
+    /// Default visibility when no saved preference exists.
+    var isOnByDefault: Bool {
+        switch self {
+        case .trackNumber, .title, .artist, .album, .duration: return true
+        default: return false
+        }
+    }
+
+    /// `true` → clicking the column header cycles sort on this field.
+    var isSortable: Bool {
+        self != .format
+    }
+
+    /// `true` → the user can drag the column header edge to resize this column.
+    var isUserResizable: Bool {
+        switch self {
+        case .artist, .album, .genre: return true
+        default: return false
+        }
+    }
+
+    /// Starting width when no user preference has been saved.
+    var defaultWidth: CGFloat {
+        switch self {
+        case .trackNumber: return 40
+        case .title:       return 220
+        case .artist:      return 180
+        case .album:       return 180
+        case .duration:    return 60
+        case .year:        return 52
+        case .genre:       return 130
+        case .bitRate:     return 80
+        case .format:      return 65
+        case .bpm:         return 52
+        case .dateAdded:   return 120
+        }
+    }
+}
+
+// MARK: - Column Entry (order + visibility tuple)
+
+struct TrackTableColumnEntry: Codable, Identifiable, Equatable {
+    var id: String { column.rawValue }
+    var column: TrackTableColumn
+    var visible: Bool
+}
+#endif

--- a/Vibrdrome/Features/Library/TrackTableColumnSettings.swift
+++ b/Vibrdrome/Features/Library/TrackTableColumnSettings.swift
@@ -1,0 +1,108 @@
+#if os(macOS)
+import Foundation
+import Observation
+
+// MARK: - Per-view column settings
+
+/// Manages column visibility and ordering for a single macOS track table context.
+/// Each view instantiates this with its own `viewKey`, keeping preferences independent.
+@Observable
+@MainActor
+final class TrackTableColumnSettings {
+
+    // MARK: - Public state
+
+    /// Ordered list of all columns with their current visibility.
+    private(set) var entries: [TrackTableColumnEntry]
+
+    /// Per-column user-preferred widths (keyed by `TrackTableColumn.rawValue`).
+    private(set) var columnWidths: [String: CGFloat]
+
+    /// Ordered list of currently visible columns (for rendering).
+    var visibleColumns: [TrackTableColumn] {
+        entries.filter(\.visible).map(\.column)
+    }
+
+    // MARK: - Private
+
+    private let storageKey: String
+    private let widthsKey: String
+
+    // MARK: - Init
+
+    init(viewKey: String) {
+        self.storageKey = UserDefaultsKeys.trackTableColumnsPrefix + viewKey
+        self.widthsKey = UserDefaultsKeys.trackTableColumnsPrefix + viewKey + ".widths"
+        if let data = UserDefaults.standard.data(forKey: storageKey),
+           let decoded = try? JSONDecoder().decode([TrackTableColumnEntry].self, from: data) {
+            // Merge saved prefs: honour saved order/visibility, append any new columns at end
+            var merged = decoded
+            let savedIds = Set(decoded.map(\.column))
+            for col in TrackTableColumn.allCases where !savedIds.contains(col) {
+                merged.append(TrackTableColumnEntry(column: col, visible: col.isOnByDefault))
+            }
+            self.entries = merged
+        } else {
+            self.entries = TrackTableColumn.allCases.map {
+                TrackTableColumnEntry(column: $0, visible: $0.isOnByDefault)
+            }
+        }
+        if let data = UserDefaults.standard.data(forKey: self.widthsKey),
+           let decoded = try? JSONDecoder().decode([String: CGFloat].self, from: data) {
+            self.columnWidths = decoded
+        } else {
+            self.columnWidths = [:]
+        }
+    }
+
+    // MARK: - Mutations
+
+    func toggle(_ column: TrackTableColumn) {
+        guard column.isRemovable else { return }
+        guard let idx = entries.firstIndex(where: { $0.column == column }) else { return }
+        entries[idx].visible.toggle()
+        save()
+    }
+
+    func move(fromOffsets source: IndexSet, toOffset destination: Int) {
+        entries.move(fromOffsets: source, toOffset: destination)
+        save()
+    }
+
+    func resetToDefaults() {
+        entries = TrackTableColumn.allCases.map {
+            TrackTableColumnEntry(column: $0, visible: $0.isOnByDefault)
+        }
+        columnWidths = [:]
+        save()
+        saveWidths()
+    }
+
+    // MARK: - Column widths
+
+    func columnWidth(for column: TrackTableColumn) -> CGFloat {
+        let stored = columnWidths[column.rawValue] ?? column.defaultWidth
+        return max(stored, column.minWidth)
+    }
+
+    func setWidth(_ width: CGFloat, for column: TrackTableColumn) {
+        columnWidths[column.rawValue] = max(column.minWidth, width)
+    }
+
+    func persistWidths() {
+        saveWidths()
+    }
+
+    // MARK: - Persistence
+
+    private func save() {
+        guard let data = try? JSONEncoder().encode(entries) else { return }
+        UserDefaults.standard.set(data, forKey: storageKey)
+    }
+
+    private func saveWidths() {
+        guard let data = try? JSONEncoder().encode(columnWidths) else { return }
+        UserDefaults.standard.set(data, forKey: widthsKey)
+    }
+}
+#endif

--- a/Vibrdrome/Features/Player/QueueView.swift
+++ b/Vibrdrome/Features/Player/QueueView.swift
@@ -88,11 +88,11 @@ struct QueueView: View {
                     }
                 }
 
-                // Queue (all tracks except currently playing)
-                let entries = engine.queueEntries
+                // Up Next (tracks after currently playing)
+                let entries = engine.upNextEntries
                 if !entries.isEmpty {
                     let totalSeconds = entries.compactMap(\.song.duration).reduce(0, +)
-                    Section("Queue -- \(entries.count) songs -- \(formatDuration(totalSeconds))") {
+                    Section("Up Next -- \(entries.count) songs -- \(formatDuration(totalSeconds))") {
                         ForEach(Array(entries.enumerated()), id: \.element.song.id) { _, entry in
                             HStack(spacing: 12) {
                                 AlbumArtView(coverArtId: entry.song.coverArt, size: 40)
@@ -119,7 +119,6 @@ struct QueueView: View {
                                         .monospacedDigit()
                                 }
                             }
-                            .opacity(entry.index < engine.currentIndex ? 0.5 : 1.0)
                             .contentShape(Rectangle())
                             .onTapGesture {
                                 #if os(iOS)
@@ -140,7 +139,7 @@ struct QueueView: View {
                             }
                         }
                         .onMove { source, destination in
-                            engine.moveInQueue(from: source, to: destination)
+                            engine.moveInUpNext(from: source, to: destination)
                         }
                     }
                 }

--- a/Vibrdrome/Features/Player/SidePanels.swift
+++ b/Vibrdrome/Features/Player/SidePanels.swift
@@ -49,15 +49,36 @@ struct QueuePanelView: View {
             appState.activeSidePanel = nil
         }) {
             List {
+                let history = engine.recentlyPlayed
+                if !history.isEmpty {
+                    Section("Recently Played") {
+                        ForEach(history, id: \.id) { song in
+                            HStack(spacing: 12) {
+                                AlbumArtView(coverArtId: song.coverArt, size: 36)
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(song.title)
+                                        .font(.subheadline)
+                                        .lineLimit(1)
+                                    Text(song.artist ?? "")
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                        .lineLimit(1)
+                                }
+                            }
+                            .opacity(0.6)
+                        }
+                    }
+                }
+
                 if let current = engine.currentSong {
                     Section("Now Playing") {
                         nowPlayingRow(current)
                     }
                 }
 
-                let entries = engine.queueEntries
+                let entries = engine.upNextEntries
                 if !entries.isEmpty {
-                    Section("Queue -- \(entries.count) songs") {
+                    Section("Up Next -- \(entries.count) songs") {
                         ForEach(Array(entries.enumerated()), id: \.element.song.id) { _, entry in
                             queueRow(entry)
                         }
@@ -147,7 +168,6 @@ struct QueuePanelView: View {
                     .monospacedDigit()
             }
         }
-        .opacity(entry.index < engine.currentIndex ? 0.5 : 1.0)
         .contentShape(Rectangle())
         .onTapGesture {
             engine.skipToIndex(entry.index)

--- a/Vibrdrome/Features/Playlists/PlaylistDetailView.swift
+++ b/Vibrdrome/Features/Playlists/PlaylistDetailView.swift
@@ -19,6 +19,9 @@ struct PlaylistDetailView: View {
     @State private var showBatchAddToPlaylist = false
     @State private var showRemoveOfflineConfirmation = false
     @Query private var downloadedSongs: [DownloadedSong]
+    #if os(macOS)
+    @State private var columnSettings = TrackTableColumnSettings(viewKey: "playlist")
+    #endif
 
     private var filteredSongs: [Song] {
         guard let songs = playlist?.entry else { return [] }
@@ -110,6 +113,11 @@ struct PlaylistDetailView: View {
 
                 // Songs
                 Section {
+                    #if os(macOS)
+                    MacTrackTableView(songs: filteredSongs, settings: columnSettings)
+                        .listRowInsets(EdgeInsets())
+                        .listRowSeparator(.hidden)
+                    #else
                     ForEach(Array(filteredSongs.enumerated()), id: \.element.id) { index, song in
                         HStack(spacing: 0) {
                             if isSelecting {
@@ -151,6 +159,7 @@ struct PlaylistDetailView: View {
                             at: IndexSet(originalIndices), songs: allSongs
                         )
                     }
+                    #endif
                 }
 
                 // Batch action bar

--- a/Vibrdrome/Features/Playlists/PlaylistDetailView.swift
+++ b/Vibrdrome/Features/Playlists/PlaylistDetailView.swift
@@ -17,6 +17,7 @@ struct PlaylistDetailView: View {
     @State private var selectedSongs = Set<String>()
     @State private var isSelecting = false
     @State private var showBatchAddToPlaylist = false
+    @State private var showRemoveOfflineConfirmation = false
     @Query private var downloadedSongs: [DownloadedSong]
 
     private var filteredSongs: [Song] {
@@ -240,8 +241,18 @@ struct PlaylistDetailView: View {
                         if let playlist, let songs = playlist.entry, !songs.isEmpty {
                             let isFullyDownloaded = DownloadManager.shared.isPlaylistDownloaded(playlistId: playlistId)
                             if isFullyDownloaded {
+                                Button {
+                                    isDownloading = true
+                                    DownloadManager.shared.refreshOfflinePlaylist(
+                                        playlist: playlist,
+                                        songs: songs,
+                                        client: appState.subsonicClient
+                                    )
+                                } label: {
+                                    Label("Refresh Download", systemImage: "arrow.triangle.2.circlepath")
+                                }
                                 Button(role: .destructive) {
-                                    DownloadManager.shared.removeOfflinePlaylist(playlistId: playlistId)
+                                    showRemoveOfflineConfirmation = true
                                 } label: {
                                     Label("Remove Offline", systemImage: "icloud.slash")
                                 }
@@ -267,6 +278,14 @@ struct PlaylistDetailView: View {
         .sheet(isPresented: $showBatchAddToPlaylist) {
             AddToPlaylistView(songIds: Array(selectedSongs))
                 .environment(appState)
+        }
+        .alert("Remove Offline Playlist?", isPresented: $showRemoveOfflineConfirmation) {
+            Button("Remove", role: .destructive) {
+                DownloadManager.shared.removeOfflinePlaylist(playlistId: playlistId)
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Songs from this download will be deleted unless they're also part of another offline playlist.")
         }
         .sheet(isPresented: $showEditSheet) {
             if let playlist {

--- a/Vibrdrome/Features/Playlists/PlaylistDetailView.swift
+++ b/Vibrdrome/Features/Playlists/PlaylistDetailView.swift
@@ -328,15 +328,19 @@ struct PlaylistDetailView: View {
         descriptor.fetchLimit = 1
         guard let cached = try? modelContext.fetch(descriptor).first else { return nil }
 
-        // Resolve entries to songs via CachedSong
+        // Resolve entries to songs in a single fetch + dictionary lookup.
+        // Previously this did one modelContext.fetch per entry — a 1000-song playlist
+        // issued 1000 queries on the main thread.
         let sortedEntries = cached.entries.sorted { $0.order < $1.order }
+        let entrySongIds = sortedEntries.map(\.songId)
+        let idSet = Set(entrySongIds)
+        let songsDesc = FetchDescriptor<CachedSong>(
+            predicate: #Predicate<CachedSong> { idSet.contains($0.id) }
+        )
+        let cachedSongs = (try? modelContext.fetch(songsDesc)) ?? []
+        let songMap = Dictionary(uniqueKeysWithValues: cachedSongs.map { ($0.id, $0) })
         let songs: [Song] = sortedEntries.compactMap { entry in
-            let sid = entry.songId
-            var songDesc = FetchDescriptor<CachedSong>(
-                predicate: #Predicate { $0.id == sid }
-            )
-            songDesc.fetchLimit = 1
-            return try? modelContext.fetch(songDesc).first?.toSong()
+            songMap[entry.songId]?.toSong()
         }
 
         return Playlist(

--- a/Vibrdrome/Features/Playlists/PlaylistDetailView.swift
+++ b/Vibrdrome/Features/Playlists/PlaylistDetailView.swift
@@ -5,6 +5,7 @@ struct PlaylistDetailView: View {
     let playlistId: String
 
     @Environment(AppState.self) private var appState
+    @Environment(\.modelContext) private var modelContext
     @State private var playlist: Playlist?
     @State private var isLoading = true
     @State private var error: String?
@@ -303,14 +304,53 @@ struct PlaylistDetailView: View {
     }
 
     private func loadPlaylist() async {
-        isLoading = true
+        // Show cached playlist data instantly while fetching fresh
+        if playlist == nil {
+            playlist = loadCachedPlaylist()
+        }
+        isLoading = playlist == nil
         error = nil
         defer { isLoading = false }
         do {
             playlist = try await appState.subsonicClient.getPlaylist(id: playlistId)
         } catch {
-            self.error = ErrorPresenter.userMessage(for: error)
+            if playlist == nil {
+                self.error = ErrorPresenter.userMessage(for: error)
+            }
         }
+    }
+
+    private func loadCachedPlaylist() -> Playlist? {
+        let pid = playlistId
+        var descriptor = FetchDescriptor<CachedPlaylist>(
+            predicate: #Predicate { $0.id == pid }
+        )
+        descriptor.fetchLimit = 1
+        guard let cached = try? modelContext.fetch(descriptor).first else { return nil }
+
+        // Resolve entries to songs via CachedSong
+        let sortedEntries = cached.entries.sorted { $0.order < $1.order }
+        let songs: [Song] = sortedEntries.compactMap { entry in
+            let sid = entry.songId
+            var songDesc = FetchDescriptor<CachedSong>(
+                predicate: #Predicate { $0.id == sid }
+            )
+            songDesc.fetchLimit = 1
+            return try? modelContext.fetch(songDesc).first?.toSong()
+        }
+
+        return Playlist(
+            id: cached.id,
+            name: cached.name,
+            songCount: cached.songCount,
+            duration: cached.duration,
+            created: nil,
+            changed: nil,
+            coverArt: cached.coverArtId,
+            owner: cached.owner,
+            isPublic: cached.isPublic,
+            entry: songs.isEmpty ? nil : songs
+        )
     }
 
     private func toggleSelection(_ songId: String) {

--- a/Vibrdrome/Features/Playlists/PlaylistsView.swift
+++ b/Vibrdrome/Features/Playlists/PlaylistsView.swift
@@ -9,8 +9,8 @@ struct PlaylistsView: View {
     @State private var showCreateSheet = false
     @State private var showSmartSheet = false
     @AppStorage("playlistViewStyle") private var showAsList = false
-    @AppStorage(UserDefaultsKeys.gridColumnsPerRow) private var gridColumns = 2
-    @Environment(\.verticalSizeClass) private var verticalSizeClass
+    @AppStorage(UserDefaultsKeys.gridDensity) private var gridDensityRaw: String = GridDensity.comfortable.rawValue
+    private var gridDensity: GridDensity { GridDensity(rawValue: gridDensityRaw) ?? .comfortable }
     @State private var searchText = ""
     @State private var searchIsActive = false
     @State private var sortBy: PlaylistSortOption = .name
@@ -256,9 +256,9 @@ struct PlaylistsView: View {
     // MARK: - Playlist Grid
 
     private var playlistGrid: some View {
-        let cols = Theme.effectiveGridColumns(base: gridColumns, verticalSizeClass: verticalSizeClass)
-        let gridItems = Array(repeating: GridItem(.flexible(), spacing: 16), count: cols)
-        return LazyVGrid(columns: gridItems, spacing: 20) {
+        LazyVGrid(columns: [
+            GridItem(.adaptive(minimum: gridDensity.minimumWidth), spacing: 16)
+        ], spacing: 20) {
             ForEach(filteredPlaylists) { playlist in
                 NavigationLink {
                     PlaylistDetailView(playlistId: playlist.id)
@@ -323,8 +323,6 @@ struct PlaylistsView: View {
 
     private func playlistCard(_ playlist: Playlist) -> some View {
         VStack(alignment: .leading, spacing: 8) {
-            // GeometryReader + aspectRatio so the mosaic scales with grid
-            // column count instead of being stuck at the 2-column cell size.
             GeometryReader { geo in
                 PlaylistMosaicView(playlist: playlist, size: geo.size.width, cornerRadius: 12)
             }

--- a/Vibrdrome/Features/Playlists/PlaylistsView.swift
+++ b/Vibrdrome/Features/Playlists/PlaylistsView.swift
@@ -10,6 +10,7 @@ struct PlaylistsView: View {
     @State private var showSmartSheet = false
     @AppStorage("playlistViewStyle") private var showAsList = false
     @AppStorage(UserDefaultsKeys.gridColumnsPerRow) private var gridColumns = 2
+    @Environment(\.verticalSizeClass) private var verticalSizeClass
     @State private var searchText = ""
     @State private var searchIsActive = false
     @State private var sortBy: PlaylistSortOption = .name
@@ -255,8 +256,9 @@ struct PlaylistsView: View {
     // MARK: - Playlist Grid
 
     private var playlistGrid: some View {
-        LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 16),
-                                 count: max(2, min(10, gridColumns))), spacing: 20) {
+        let cols = Theme.effectiveGridColumns(base: gridColumns, verticalSizeClass: verticalSizeClass)
+        let gridItems = Array(repeating: GridItem(.flexible(), spacing: 16), count: cols)
+        return LazyVGrid(columns: gridItems, spacing: 20) {
             ForEach(filteredPlaylists) { playlist in
                 NavigationLink {
                     PlaylistDetailView(playlistId: playlist.id)

--- a/Vibrdrome/Features/Playlists/PlaylistsView.swift
+++ b/Vibrdrome/Features/Playlists/PlaylistsView.swift
@@ -321,9 +321,13 @@ struct PlaylistsView: View {
 
     private func playlistCard(_ playlist: Playlist) -> some View {
         VStack(alignment: .leading, spacing: 8) {
-            PlaylistMosaicView(playlist: playlist, size: Theme.playlistCardSize, cornerRadius: 12)
-                .frame(maxWidth: .infinity)
-                .shadow(color: .black.opacity(0.15), radius: 6, y: 3)
+            // GeometryReader + aspectRatio so the mosaic scales with grid
+            // column count instead of being stuck at the 2-column cell size.
+            GeometryReader { geo in
+                PlaylistMosaicView(playlist: playlist, size: geo.size.width, cornerRadius: 12)
+            }
+            .aspectRatio(1, contentMode: .fit)
+            .shadow(color: .black.opacity(0.15), radius: 6, y: 3)
 
             Text(playlist.name)
                 .font(.subheadline)

--- a/Vibrdrome/Features/Radio/RadioView.swift
+++ b/Vibrdrome/Features/Radio/RadioView.swift
@@ -11,8 +11,8 @@ struct RadioView: View {
     @State private var showAddSheet = false
     @State private var showSearchSheet = false
     @AppStorage("radioViewStyle") private var showAsList = false
-    @AppStorage(UserDefaultsKeys.gridColumnsPerRow) private var gridColumns = 2
-    @Environment(\.verticalSizeClass) private var verticalSizeClass
+    @AppStorage(UserDefaultsKeys.gridDensity) private var gridDensityRaw: String = GridDensity.comfortable.rawValue
+    private var gridDensity: GridDensity { GridDensity(rawValue: gridDensityRaw) ?? .comfortable }
 
     private var engine: AudioEngine { AudioEngine.shared }
 
@@ -256,9 +256,9 @@ struct RadioView: View {
     }
 
     private var stationGrid: some View {
-        LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 16),
-                                 count: Theme.effectiveGridColumns(base: gridColumns, verticalSizeClass: verticalSizeClass)),
-                  spacing: 16) {
+        LazyVGrid(columns: [
+            GridItem(.adaptive(minimum: gridDensity.minimumWidth), spacing: 16)
+        ], spacing: 16) {
             ForEach(Array(filteredStations.enumerated()), id: \.element.id) { index, station in
                 stationCardView(station, colorIndex: index)
             }

--- a/Vibrdrome/Features/Radio/RadioView.swift
+++ b/Vibrdrome/Features/Radio/RadioView.swift
@@ -12,6 +12,7 @@ struct RadioView: View {
     @State private var showSearchSheet = false
     @AppStorage("radioViewStyle") private var showAsList = false
     @AppStorage(UserDefaultsKeys.gridColumnsPerRow) private var gridColumns = 2
+    @Environment(\.verticalSizeClass) private var verticalSizeClass
 
     private var engine: AudioEngine { AudioEngine.shared }
 
@@ -256,7 +257,8 @@ struct RadioView: View {
 
     private var stationGrid: some View {
         LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 16),
-                                 count: max(2, min(10, gridColumns))), spacing: 16) {
+                                 count: Theme.effectiveGridColumns(base: gridColumns, verticalSizeClass: verticalSizeClass)),
+                  spacing: 16) {
             ForEach(Array(filteredStations.enumerated()), id: \.element.id) { index, station in
                 stationCardView(station, colorIndex: index)
             }

--- a/Vibrdrome/Features/Search/SearchView+Filters.swift
+++ b/Vibrdrome/Features/Search/SearchView+Filters.swift
@@ -1,3 +1,4 @@
+import SwiftData
 import SwiftUI
 
 // MARK: - Filter UI & Logic
@@ -185,6 +186,15 @@ extension SearchView {
     }
 
     func loadGenres() async {
+        // Try local SwiftData first — fetch album genres (much smaller than all songs)
+        let albums = (try? modelContext.fetch(FetchDescriptor<CachedAlbum>())) ?? []
+        let localGenres = Set(albums.compactMap(\.genre).filter { !$0.isEmpty })
+        if !localGenres.isEmpty {
+            availableGenres = localGenres.sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
+            return
+        }
+
+        // Fall back to API
         do {
             let genres = try await appState.subsonicClient.getGenres()
             availableGenres = genres

--- a/Vibrdrome/Features/Search/SearchView+Filters.swift
+++ b/Vibrdrome/Features/Search/SearchView+Filters.swift
@@ -188,7 +188,7 @@ extension SearchView {
     func loadGenres() async {
         // Try local SwiftData first — fetch album genres (much smaller than all songs)
         let albums = (try? modelContext.fetch(FetchDescriptor<CachedAlbum>())) ?? []
-        let localGenres = Set(albums.compactMap(\.genre).filter { !$0.isEmpty })
+        let localGenres = Set(albums.flatMap(\.genres).filter { !$0.isEmpty })
         if !localGenres.isEmpty {
             availableGenres = localGenres.sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
             return

--- a/Vibrdrome/Features/Search/SearchView.swift
+++ b/Vibrdrome/Features/Search/SearchView.swift
@@ -6,7 +6,7 @@ private let maxRecentSearches = 10
 
 struct SearchView: View {
     @Environment(AppState.self) var appState
-    @Environment(\.modelContext) private var modelContext
+    @Environment(\.modelContext) var modelContext
     @State private var query = ""
     @State private var results: SearchResult3?
     @State private var isSearching = false
@@ -351,6 +351,12 @@ struct SearchView: View {
         try? await Task.sleep(for: .milliseconds(300))
         guard !Task.isCancelled else { return }
 
+        // Show local results instantly while waiting for network
+        let localResults = searchLocally(query: query)
+        if let localResults, resultCount(localResults) > 0, results == nil {
+            results = localResults
+        }
+
         isSearching = true
         defer { isSearching = false }
 
@@ -386,16 +392,63 @@ struct SearchView: View {
             results = searchResults
         } catch {
             guard !Task.isCancelled else { return }
-            // Offline fallback: search downloaded songs locally
-            let offlineResults = searchDownloadsLocally(query: query)
-            if let songs = offlineResults, !songs.isEmpty {
+            // Offline fallback: search cached library locally
+            let offlineResults = searchLocally(query: query)
+                ?? searchDownloadsLocally(query: query).map {
+                    SearchResult3(artist: nil, album: nil, song: $0)
+                }
+            if let offlineResults, resultCount(offlineResults) > 0 {
                 searchError = nil
-                results = SearchResult3(artist: nil, album: nil, song: songs)
+                results = offlineResults
             } else {
                 searchError = ErrorPresenter.userMessage(for: error)
                 results = nil
             }
         }
+    }
+
+    private func searchLocally(query: String) -> SearchResult3? {
+        let q = query
+
+        // Search cached songs using predicate
+        var songDescriptor = FetchDescriptor<CachedSong>(
+            predicate: #Predicate<CachedSong> {
+                $0.title.localizedStandardContains(q)
+                || ($0.artist?.localizedStandardContains(q) ?? false)
+                || ($0.albumName?.localizedStandardContains(q) ?? false)
+            }
+        )
+        songDescriptor.fetchLimit = 40
+        let matchedSongs = ((try? modelContext.fetch(songDescriptor)) ?? []).map { $0.toSong() }
+
+        // Search cached albums using predicate
+        var albumDescriptor = FetchDescriptor<CachedAlbum>(
+            predicate: #Predicate<CachedAlbum> {
+                $0.name.localizedStandardContains(q)
+                || ($0.artistName?.localizedStandardContains(q) ?? false)
+            }
+        )
+        albumDescriptor.fetchLimit = 20
+        let matchedAlbums = ((try? modelContext.fetch(albumDescriptor)) ?? []).map { $0.toAlbum() }
+
+        // Search cached artists using predicate
+        var artistDescriptor = FetchDescriptor<CachedArtist>(
+            predicate: #Predicate<CachedArtist> {
+                $0.name.localizedStandardContains(q)
+            }
+        )
+        artistDescriptor.fetchLimit = 20
+        let matchedArtists = ((try? modelContext.fetch(artistDescriptor)) ?? []).map { $0.toArtist() }
+
+        guard !matchedSongs.isEmpty || !matchedAlbums.isEmpty || !matchedArtists.isEmpty else {
+            return nil
+        }
+
+        return SearchResult3(
+            artist: matchedArtists.isEmpty ? nil : Array(matchedArtists),
+            album: matchedAlbums.isEmpty ? nil : Array(matchedAlbums),
+            song: matchedSongs.isEmpty ? nil : Array(matchedSongs)
+        )
     }
 
     private func searchDownloadsLocally(query: String) -> [Song]? {

--- a/Vibrdrome/Features/Settings/AppearanceSettingsView.swift
+++ b/Vibrdrome/Features/Settings/AppearanceSettingsView.swift
@@ -14,6 +14,7 @@ struct AppearanceSettingsView: View {
 
     // Lists
     @AppStorage(UserDefaultsKeys.showAlbumArtInLists) private var showAlbumArtInLists: Bool = true
+    @AppStorage(UserDefaultsKeys.gridDensity) private var gridDensityRaw: String = GridDensity.comfortable.rawValue
 
     // Mini Player
     @AppStorage(UserDefaultsKeys.disableSpinningArt) private var disableSpinningArt: Bool = false
@@ -121,8 +122,6 @@ struct AppearanceSettingsView: View {
 
     // MARK: - Lists Section
 
-    @AppStorage(UserDefaultsKeys.gridColumnsPerRow) private var gridColumns = 2
-
     private var listsSection: some View {
         Section {
             Toggle(isOn: $showAlbumArtInLists) {
@@ -131,21 +130,15 @@ struct AppearanceSettingsView: View {
             }
             .accessibilityIdentifier("albumArtInListsToggle")
 
-            Picker(selection: $gridColumns) {
-                Text("2").tag(2)
-                Text("3").tag(3)
-                Text("4").tag(4)
-                Text("5").tag(5)
-                Text("6").tag(6)
-                #if os(macOS)
-                Text("8").tag(8)
-                Text("10").tag(10)
-                #endif
+            Picker(selection: $gridDensityRaw) {
+                ForEach(GridDensity.allCases, id: \.rawValue) { density in
+                    Text(density.label).tag(density.rawValue)
+                }
             } label: {
-                Label("Grid Columns", systemImage: "square.grid.2x2")
+                Label("Grid Density", systemImage: "square.grid.2x2")
                     .foregroundColor(.primary)
             }
-            .accessibilityIdentifier("gridColumnsPicker")
+            .accessibilityIdentifier("gridDensityPicker")
         } header: {
             settingSectionHeader("Lists", icon: "list.bullet", color: .green)
         }

--- a/Vibrdrome/Features/Settings/SettingsView.swift
+++ b/Vibrdrome/Features/Settings/SettingsView.swift
@@ -408,6 +408,15 @@ struct SettingsView: View {
                 .accessibilityIdentifier("incrementalSyncButton")
             }
 
+            Button {
+                appState.libraryCache.invalidate()
+                appState.libraryCache.rebuild(container: PersistenceController.shared.container)
+            } label: {
+                Label("Reset Cache", systemImage: "memorychip")
+            }
+            .disabled(appState.librarySyncManager.isSyncing)
+            .accessibilityIdentifier("resetCacheButton")
+
             NavigationLink {
                 SyncHistoryView()
             } label: {

--- a/Vibrdrome/Features/Settings/SettingsView.swift
+++ b/Vibrdrome/Features/Settings/SettingsView.swift
@@ -437,7 +437,15 @@ struct SettingsView: View {
                     let val = UserDefaults.standard.integer(forKey: UserDefaultsKeys.syncPollingInterval)
                     return [5, 15, 30, 60].contains(val) ? val : 15
                 },
-                set: { UserDefaults.standard.set($0, forKey: UserDefaultsKeys.syncPollingInterval) }
+                set: { newValue in
+                    UserDefaults.standard.set(newValue, forKey: UserDefaultsKeys.syncPollingInterval)
+                    // Restart the running polling task so the change takes effect immediately
+                    // rather than waiting until the next launch.
+                    appState.librarySyncManager.startPolling(
+                        client: appState.subsonicClient,
+                        container: PersistenceController.shared.container
+                    )
+                }
             )) {
                 Text("5 min").tag(5)
                 Text("15 min").tag(15)

--- a/Vibrdrome/Features/Settings/SettingsView.swift
+++ b/Vibrdrome/Features/Settings/SettingsView.swift
@@ -96,6 +96,7 @@ struct SettingsView: View {
             #endif
 
             downloadsSection
+            librarySyncSection
 
             #if os(iOS)
             carPlaySection
@@ -310,6 +311,143 @@ struct SettingsView: View {
             }
         } header: {
             settingSectionHeader("Downloads", icon: "arrow.down.circle.fill", color: .cyan)
+        }
+    }
+
+    // MARK: - Library Sync Section
+
+    private var librarySyncSection: some View {
+        Section {
+            HStack {
+                Label("Library Sync", systemImage: "arrow.triangle.2.circlepath.circle.fill")
+                Spacer()
+                if appState.librarySyncManager.isSyncing {
+                    ProgressView()
+                        .controlSize(.small)
+                } else if let lastSync = appState.librarySyncManager.lastSyncDate {
+                    Text(lastSync, style: .relative)
+                        .foregroundStyle(.secondary)
+                        .font(.caption)
+                    Text("ago")
+                        .foregroundStyle(.secondary)
+                        .font(.caption)
+                } else {
+                    Text("Never")
+                        .foregroundStyle(.secondary)
+                        .font(.caption)
+                }
+            }
+
+            if let progress = appState.librarySyncManager.syncProgress {
+                Text(progress)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            if let syncError = appState.librarySyncManager.syncError {
+                Text(syncError)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+            }
+
+            // Live sync stats during sync
+            if let stats = appState.librarySyncManager.lastSyncStats,
+               appState.librarySyncManager.isSyncing {
+                HStack(spacing: 12) {
+                    Label("+\(stats.albumsAdded + stats.artistsAdded + stats.songsAdded)", systemImage: "plus.circle")
+                        .foregroundStyle(.green)
+                    Label("~\(stats.albumsUpdated + stats.artistsUpdated + stats.songsUpdated)", systemImage: "pencil.circle")
+                        .foregroundStyle(.orange)
+                    Label("-\(stats.albumsRemoved + stats.artistsRemoved + stats.songsRemoved)", systemImage: "minus.circle")
+                        .foregroundStyle(.red)
+                }
+                .font(.caption)
+            }
+
+            // Last sync result summary
+            if let stats = appState.librarySyncManager.lastSyncStats,
+               !appState.librarySyncManager.isSyncing,
+               stats.totalChanges > 0 {
+                HStack {
+                    Text("Last sync: \(stats.totalChanges) changes in \(String(format: "%.1f", stats.duration))s")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            HStack {
+                Button {
+                    Task {
+                        await appState.librarySyncManager.sync(
+                            client: appState.subsonicClient,
+                            container: PersistenceController.shared.container
+                        )
+                    }
+                } label: {
+                    Label(
+                        appState.librarySyncManager.isSyncing ? "Syncing…" : "Full Sync",
+                        systemImage: "arrow.clockwise"
+                    )
+                }
+                .disabled(appState.librarySyncManager.isSyncing)
+                .accessibilityIdentifier("librarySyncButton")
+
+                Spacer()
+
+                Button {
+                    Task {
+                        await appState.librarySyncManager.incrementalSync(
+                            client: appState.subsonicClient,
+                            container: PersistenceController.shared.container
+                        )
+                    }
+                } label: {
+                    Label("Quick Sync", systemImage: "bolt.circle")
+                }
+                .disabled(appState.librarySyncManager.isSyncing)
+                .accessibilityIdentifier("incrementalSyncButton")
+            }
+
+            NavigationLink {
+                SyncHistoryView()
+            } label: {
+                Label("Sync History", systemImage: "clock.arrow.circlepath")
+            }
+            .accessibilityIdentifier("syncHistoryLink")
+
+            #if os(iOS)
+            Toggle(isOn: Binding(
+                get: { UserDefaults.standard.bool(forKey: UserDefaultsKeys.backgroundSyncEnabled) },
+                set: { newValue in
+                    UserDefaults.standard.set(newValue, forKey: UserDefaultsKeys.backgroundSyncEnabled)
+                    if newValue {
+                        BackgroundSyncScheduler.shared.scheduleRefresh()
+                        BackgroundSyncScheduler.shared.scheduleFullSync()
+                    } else {
+                        BackgroundSyncScheduler.shared.cancelAll()
+                    }
+                }
+            )) {
+                Label("Background Sync", systemImage: "arrow.triangle.2.circlepath")
+            }
+            #endif
+
+            Picker(selection: Binding(
+                get: {
+                    let val = UserDefaults.standard.integer(forKey: UserDefaultsKeys.syncPollingInterval)
+                    return [5, 15, 30, 60].contains(val) ? val : 15
+                },
+                set: { UserDefaults.standard.set($0, forKey: UserDefaultsKeys.syncPollingInterval) }
+            )) {
+                Text("5 min").tag(5)
+                Text("15 min").tag(15)
+                Text("30 min").tag(30)
+                Text("60 min").tag(60)
+            } label: {
+                Label("Check for Changes", systemImage: "timer")
+            }
+        } header: {
+            settingSectionHeader("Library", icon: "books.vertical.fill", color: .purple)
         }
     }
 

--- a/Vibrdrome/Features/Settings/SyncHistoryView.swift
+++ b/Vibrdrome/Features/Settings/SyncHistoryView.swift
@@ -1,0 +1,119 @@
+import SwiftData
+import SwiftUI
+
+struct SyncHistoryView: View {
+    @Query(sort: \SyncHistory.syncDate, order: .reverse) private var history: [SyncHistory]
+
+    var body: some View {
+        List {
+            if history.isEmpty {
+                ContentUnavailableView(
+                    "No Sync History",
+                    systemImage: "clock.arrow.circlepath",
+                    description: Text("Sync history will appear here after your first library sync.")
+                )
+            } else {
+                ForEach(history) { entry in
+                    SyncHistoryRow(entry: entry)
+                }
+            }
+        }
+        .navigationTitle("Sync History")
+    }
+}
+
+private struct SyncHistoryRow: View {
+    let entry: SyncHistory
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Image(systemName: entry.succeeded ? "checkmark.circle.fill" : "xmark.circle.fill")
+                    .foregroundStyle(entry.succeeded ? .green : .red)
+                    .font(.caption)
+
+                Text(entry.syncType.capitalized)
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+
+                Spacer()
+
+                Text(entry.syncDate, style: .relative)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text("ago")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            if entry.succeeded {
+                HStack(spacing: 12) {
+                    if entry.totalChanges > 0 {
+                        statsLabel(value: entry.albumsAdded + entry.artistsAdded + entry.songsAdded,
+                                   label: "added", color: .green)
+                        statsLabel(value: entry.albumsUpdated + entry.artistsUpdated + entry.songsUpdated,
+                                   label: "updated", color: .orange)
+                        statsLabel(value: entry.albumsRemoved + entry.artistsRemoved + entry.songsRemoved,
+                                   label: "removed", color: .red)
+                    } else {
+                        Text("No changes")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    Spacer()
+
+                    Text(String(format: "%.1fs", entry.durationSeconds))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                if entry.totalChanges > 0 {
+                    HStack(spacing: 8) {
+                        if entry.albumsAdded + entry.albumsUpdated + entry.albumsRemoved > 0 {
+                            Text("\(entry.albumsAdded + entry.albumsUpdated + entry.albumsRemoved) albums")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+                        if entry.artistsAdded + entry.artistsUpdated + entry.artistsRemoved > 0 {
+                            Text("\(entry.artistsAdded + entry.artistsUpdated + entry.artistsRemoved) artists")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+                        if entry.songsAdded + entry.songsUpdated + entry.songsRemoved > 0 {
+                            Text("\(entry.songsAdded + entry.songsUpdated + entry.songsRemoved) songs")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+                        if entry.playlistsSynced > 0 {
+                            Text("\(entry.playlistsSynced) playlists")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+
+                if entry.conflictsDetected > 0 {
+                    Text("\(entry.conflictsResolved)/\(entry.conflictsDetected) conflicts resolved")
+                        .font(.caption2)
+                        .foregroundStyle(.orange)
+                }
+            } else if let error = entry.errorMessage {
+                Text(error)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+                    .lineLimit(2)
+            }
+        }
+        .padding(.vertical, 2)
+    }
+
+    @ViewBuilder
+    private func statsLabel(value: Int, label: String, color: Color) -> some View {
+        if value > 0 {
+            Text("\(value) \(label)")
+                .font(.caption)
+                .foregroundStyle(color)
+        }
+    }
+}

--- a/Vibrdrome/Info.plist
+++ b/Vibrdrome/Info.plist
@@ -71,6 +71,13 @@
     <key>UIBackgroundModes</key>
     <array>
         <string>audio</string>
+        <string>fetch</string>
+        <string>processing</string>
+    </array>
+    <key>BGTaskSchedulerPermittedIdentifiers</key>
+    <array>
+        <string>com.vibrdrome.app.libraryRefresh</string>
+        <string>com.vibrdrome.app.librarySync</string>
     </array>
     <key>NSPhotoLibraryAddUsageDescription</key>
     <string>Save album artwork to your photo library</string>

--- a/Vibrdrome/Shared/Components/FilterMultiSelectList.swift
+++ b/Vibrdrome/Shared/Components/FilterMultiSelectList.swift
@@ -1,0 +1,116 @@
+import SwiftUI
+
+/// A searchable, scrollable multi-select list for filter sidebars.
+/// Each item has a label, optional subtitle, optional image, and a checkmark when selected.
+struct FilterMultiSelectList<T: Identifiable & Hashable>: View {
+    let title: String
+    let items: [T]
+    @Binding var selectedIds: Set<String>
+    let id: KeyPath<T, String>
+    let label: KeyPath<T, String>
+    let subtitle: ((T) -> String?)?
+    let imageId: ((T) -> String?)?
+
+    @State private var searchText = ""
+
+    init(
+        title: String,
+        items: [T],
+        selectedIds: Binding<Set<String>>,
+        id: KeyPath<T, String>,
+        label: KeyPath<T, String>,
+        subtitle: ((T) -> String?)? = nil,
+        imageId: ((T) -> String?)? = nil
+    ) {
+        self.title = title
+        self.items = items
+        self._selectedIds = selectedIds
+        self.id = id
+        self.label = label
+        self.subtitle = subtitle
+        self.imageId = imageId
+    }
+
+    private var filteredItems: [T] {
+        if searchText.isEmpty { return items }
+        return items.filter { $0[keyPath: label].localizedCaseInsensitiveContains(searchText) }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text(title)
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                Spacer()
+                if !selectedIds.isEmpty {
+                    Text("\(selectedIds.count)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            TextField("Search \(title.lowercased())…", text: $searchText)
+                .textFieldStyle(.roundedBorder)
+                .font(.caption)
+                .accessibilityLabel("Search \(title.lowercased())")
+
+            ScrollView {
+                LazyVStack(spacing: 0) {
+                    ForEach(filteredItems, id: id) { item in
+                        let itemId = item[keyPath: self.id]
+                        let isSelected = selectedIds.contains(itemId)
+                        Button {
+                            if isSelected {
+                                selectedIds.remove(itemId)
+                            } else {
+                                selectedIds.insert(itemId)
+                            }
+                        } label: {
+                            HStack(spacing: 8) {
+                                if let imageId, let artId = imageId(item) {
+                                    AlbumArtView(coverArtId: artId, size: 30, cornerRadius: 4)
+                                }
+
+                                VStack(alignment: .leading, spacing: 1) {
+                                    Text(item[keyPath: label])
+                                        .font(.caption)
+                                        .lineLimit(1)
+                                    if let subtitle, let sub = subtitle(item) {
+                                        Text(sub)
+                                            .font(.caption2)
+                                            .foregroundStyle(.secondary)
+                                            .lineLimit(1)
+                                    }
+                                }
+
+                                Spacer()
+
+                                if isSelected {
+                                    Image(systemName: "checkmark")
+                                        .font(.caption)
+                                        .foregroundStyle(Color.accentColor)
+                                }
+                            }
+                            .padding(.vertical, 4)
+                            .padding(.horizontal, 6)
+                            .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
+                        .background(isSelected ? Color.accentColor.opacity(0.1) : Color.clear)
+                        .accessibilityLabel(item[keyPath: label])
+                        .accessibilityValue(isSelected ? "Selected" : "Not selected")
+                        .accessibilityAddTraits(isSelected ? .isSelected : [])
+                    }
+                }
+            }
+            .frame(height: 200)
+            #if os(macOS)
+            .background(Color(nsColor: .controlBackgroundColor).opacity(0.5))
+            #else
+            .background(Color(.systemBackground).opacity(0.5))
+            #endif
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+        }
+    }
+}

--- a/Vibrdrome/Shared/Components/GenreIconView.swift
+++ b/Vibrdrome/Shared/Components/GenreIconView.swift
@@ -250,25 +250,3 @@ struct GenreIconView: View {
         }
     }
 }
-
-#if os(iOS)
-import UIKit
-
-extension GenreIconView {
-    /// Rasterized icon for surfaces that can't host SwiftUI (e.g. CarPlay CPListItem).
-    /// Uses the gradient + SF Symbol fallback — the album-art path is only
-    /// visible in SwiftUI contexts because ImageRenderer here doesn't get the
-    /// model container. Callers wanting real album art (CarPlay) should fetch
-    /// the cover art URL via SubsonicClient.coverArtURL(id:) and load the image
-    /// themselves, falling back to this method if no artwork is cached yet.
-    @MainActor
-    static func uiImage(for genre: String, size: CGSize = CGSize(width: 80, height: 80)) -> UIImage? {
-        let view = GenreIconView(genre: genre)
-            .frame(width: size.width, height: size.height)
-            .clipShape(RoundedRectangle(cornerRadius: size.width * 0.15))
-        let renderer = ImageRenderer(content: view)
-        renderer.scale = UIScreen.main.scale
-        return renderer.uiImage
-    }
-}
-#endif

--- a/Vibrdrome/Shared/Components/GenreIconView.swift
+++ b/Vibrdrome/Shared/Components/GenreIconView.swift
@@ -250,3 +250,25 @@ struct GenreIconView: View {
         }
     }
 }
+
+#if os(iOS)
+import UIKit
+
+extension GenreIconView {
+    /// Rasterized icon for surfaces that can't host SwiftUI (e.g. CarPlay CPListItem).
+    /// Uses the gradient + SF Symbol fallback — the album-art path is only
+    /// visible in SwiftUI contexts because ImageRenderer here doesn't get the
+    /// model container. Callers wanting real album art (CarPlay) should fetch
+    /// the cover art URL via SubsonicClient.coverArtURL(id:) and load the image
+    /// themselves, falling back to this method if no artwork is cached yet.
+    @MainActor
+    static func uiImage(for genre: String, size: CGSize = CGSize(width: 80, height: 80)) -> UIImage? {
+        let view = GenreIconView(genre: genre)
+            .frame(width: size.width, height: size.height)
+            .clipShape(RoundedRectangle(cornerRadius: size.width * 0.15))
+        let renderer = ImageRenderer(content: view)
+        renderer.scale = UIScreen.main.scale
+        return renderer.uiImage
+    }
+}
+#endif

--- a/Vibrdrome/Shared/Components/TrackContextMenu.swift
+++ b/Vibrdrome/Shared/Components/TrackContextMenu.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import os.log
 
-struct TrackContextMenuModifier: ViewModifier {
+struct TrackContextMenuModifier: ViewModifier, Equatable {
     let song: Song
     var queue: [Song]?
     var index: Int?
@@ -12,19 +12,25 @@ struct TrackContextMenuModifier: ViewModifier {
     @State private var showAddToPlaylist = false
     @State private var showGetInfo = false
 
+    nonisolated static func == (lhs: TrackContextMenuModifier, rhs: TrackContextMenuModifier) -> Bool {
+        lhs.song == rhs.song && lhs.index == rhs.index
+    }
+
     func body(content: Content) -> some View {
         content
-            // Opaque backer so the system's context-menu preview snapshot has
-            // a solid background. Without it, when iOS has to reposition the
-            // preview to fit the menu on screen the lifted row is transparent
-            // and adjacent rows' text bleeds through (reported Apr 16).
             #if os(iOS)
             .background(Color(.systemBackground))
             #endif
-            .contextMenu { contextMenuItems }
+            .contextMenu {
+                TrackContextMenuContent(
+                    song: song, queue: queue, index: index,
+                    onRemove: onRemove,
+                    showAddToPlaylist: $showAddToPlaylist,
+                    showGetInfo: $showGetInfo
+                )
+            }
             .sheet(isPresented: $showAddToPlaylist) {
                 AddToPlaylistView(songIds: [song.id])
-                    .environment(appState)
             }
             #if os(iOS)
             .sheet(isPresented: $showGetInfo) {
@@ -40,9 +46,23 @@ struct TrackContextMenuModifier: ViewModifier {
             }
             #endif
     }
+}
 
-    @ViewBuilder
-    private var contextMenuItems: some View {
+/// Lazy inner view — `@Environment(AppState.self)` is only resolved when the context menu opens.
+private struct TrackContextMenuContent: View {
+    let song: Song
+    var queue: [Song]?
+    var index: Int?
+    var onRemove: (() -> Void)?
+    @Binding var showAddToPlaylist: Bool
+    @Binding var showGetInfo: Bool
+
+    @Environment(AppState.self) private var appState
+    #if os(macOS)
+    @Environment(\.openWindow) private var openWindow
+    #endif
+
+    var body: some View {
         playbackActions
         Divider()
         libraryActions

--- a/Vibrdrome/Shared/Components/TrackContextMenu.swift
+++ b/Vibrdrome/Shared/Components/TrackContextMenu.swift
@@ -14,6 +14,13 @@ struct TrackContextMenuModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         content
+            // Opaque backer so the system's context-menu preview snapshot has
+            // a solid background. Without it, when iOS has to reposition the
+            // preview to fit the menu on screen the lifted row is transparent
+            // and adjacent rows' text bleeds through (reported Apr 16).
+            #if os(iOS)
+            .background(Color(.systemBackground))
+            #endif
             .contextMenu { contextMenuItems }
             .sheet(isPresented: $showAddToPlaylist) {
                 AddToPlaylistView(songIds: [song.id])

--- a/Vibrdrome/Shared/Components/TriStateFilterControl.swift
+++ b/Vibrdrome/Shared/Components/TriStateFilterControl.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+/// A button-group control with Yes / No options for tri-state filtering.
+/// Tapping the active button deselects it (returns to .none).
+/// When .none is active, neither button is highlighted.
+struct TriStateFilterControl: View {
+    let label: String
+    @Binding var value: TriState
+
+    var body: some View {
+        HStack {
+            Text(label)
+                .font(.subheadline)
+                .fontWeight(.medium)
+            Spacer()
+            HStack(spacing: 1) {
+                filterButton("Yes", state: .yes)
+                filterButton("No", state: .no)
+            }
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+        }
+    }
+
+    private func filterButton(_ title: String, state: TriState) -> some View {
+        let isActive = value == state
+        return Button {
+            withAnimation(.easeInOut(duration: 0.15)) {
+                value = isActive ? .none : state
+            }
+        } label: {
+            Text(title)
+                .font(.caption)
+                .fontWeight(isActive ? .semibold : .regular)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 5)
+                .background(isActive ? Color.accentColor : Color.secondary.opacity(0.15))
+                .foregroundStyle(isActive ? .white : .secondary)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("\(label) \(title)")
+        .accessibilityValue(isActive ? "Active" : "Inactive")
+        .accessibilityAddTraits(isActive ? .isSelected : [])
+    }
+}

--- a/Vibrdrome/Shared/Extensions/ContentWidth+Environment.swift
+++ b/Vibrdrome/Shared/Extensions/ContentWidth+Environment.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+private struct ContentWidthKey: EnvironmentKey {
+    static let defaultValue: CGFloat = 0
+}
+
+extension EnvironmentValues {
+    var contentWidth: CGFloat {
+        get { self[ContentWidthKey.self] }
+        set { self[ContentWidthKey.self] = newValue }
+    }
+}

--- a/Vibrdrome/Shared/Extensions/ErrorPresenter.swift
+++ b/Vibrdrome/Shared/Extensions/ErrorPresenter.swift
@@ -33,6 +33,7 @@ enum ErrorPresenter {
         case 401: return "Authentication failed. Check your credentials."
         case 403: return "Access denied. Your account may not have permission."
         case 404: return "The requested item was not found on the server."
+        case 429: return "Server is rate limiting requests. Please wait a moment and try again."
         case 500...599: return "The server encountered an error. Please try again later."
         default: return "Server returned an error (HTTP \(code))."
         }

--- a/Vibrdrome/Vibrdrome.swift
+++ b/Vibrdrome/Vibrdrome.swift
@@ -76,6 +76,15 @@ struct VibrdromeApp: App {
 
     init() {
         Self.migrateCredentialsToKeychain()
+        // BGTaskScheduler.register() MUST run synchronously during app initialization,
+        // before UIApplication finishes launching. If iOS launches the app specifically to
+        // handle a scheduled background task, registration has to already be in place or
+        // the system drops the task silently. `.onAppear` is too late.
+        // scheduleRefresh() / scheduleFullSync() stay in `.onAppear` below — those require
+        // the app to be configured (credentials loaded) and can be submitted at any time.
+        #if os(iOS)
+        BackgroundSyncScheduler.shared.registerTasks()
+        #endif
     }
 
     /// One-time migration: move Last.fm/ListenBrainz credentials from UserDefaults to Keychain.
@@ -168,7 +177,8 @@ struct VibrdromeApp: App {
                     ImagePipeline.shared = ImagePipeline(configuration: .withDataCache(name: "com.vibrdrome.images"))
                     RemoteCommandManager.shared.setup()
                     DownloadManager.shared.resumeIncompleteDownloads()
-                    BackgroundSyncScheduler.shared.registerTasks()
+                    // registerTasks() already ran synchronously in App.init(); here we just
+                    // submit the scheduled requests once credentials are confirmed loaded.
                     BackgroundSyncScheduler.shared.scheduleRefresh()
                     BackgroundSyncScheduler.shared.scheduleFullSync()
                     Task {

--- a/Vibrdrome/Vibrdrome.swift
+++ b/Vibrdrome/Vibrdrome.swift
@@ -136,6 +136,22 @@ struct VibrdromeApp: App {
                     ImagePipeline.shared = ImagePipeline(configuration: .withDataCache(name: "com.vibrdrome.images"))
                     RemoteCommandManager.shared.setup()
                     DownloadManager.shared.resumeIncompleteDownloads()
+                    Task {
+                        appState.libraryCache.rebuild(container: persistenceController.container)
+                        await appState.librarySyncManager.syncIfStale(
+                            client: appState.subsonicClient,
+                            container: persistenceController.container
+                        )
+                        appState.libraryCache.rebuild(container: persistenceController.container)
+                        appState.librarySyncManager.startPolling(
+                            client: appState.subsonicClient,
+                            container: persistenceController.container
+                        )
+                        await appState.librarySyncManager.warmImageCache(
+                            client: appState.subsonicClient,
+                            container: persistenceController.container
+                        )
+                    }
                 }
                 .onOpenURL { url in
                     handleDeepLink(url)
@@ -152,6 +168,25 @@ struct VibrdromeApp: App {
                     ImagePipeline.shared = ImagePipeline(configuration: .withDataCache(name: "com.vibrdrome.images"))
                     RemoteCommandManager.shared.setup()
                     DownloadManager.shared.resumeIncompleteDownloads()
+                    BackgroundSyncScheduler.shared.registerTasks()
+                    BackgroundSyncScheduler.shared.scheduleRefresh()
+                    BackgroundSyncScheduler.shared.scheduleFullSync()
+                    Task {
+                        appState.libraryCache.rebuild(container: persistenceController.container)
+                        await appState.librarySyncManager.syncIfStale(
+                            client: appState.subsonicClient,
+                            container: persistenceController.container
+                        )
+                        appState.libraryCache.rebuild(container: persistenceController.container)
+                        appState.librarySyncManager.startPolling(
+                            client: appState.subsonicClient,
+                            container: persistenceController.container
+                        )
+                        await appState.librarySyncManager.warmImageCache(
+                            client: appState.subsonicClient,
+                            container: persistenceController.container
+                        )
+                    }
                 }
                 .onOpenURL { url in
                     handleDeepLink(url)

--- a/Vibrdrome/Vibrdrome.swift
+++ b/Vibrdrome/Vibrdrome.swift
@@ -145,6 +145,9 @@ struct VibrdromeApp: App {
                     ImagePipeline.shared = ImagePipeline(configuration: .withDataCache(name: "com.vibrdrome.images"))
                     RemoteCommandManager.shared.setup()
                     DownloadManager.shared.resumeIncompleteDownloads()
+                    appState.librarySyncManager.onSyncCompleted = {
+                        appState.libraryCache.rebuild(container: persistenceController.container)
+                    }
                     Task {
                         appState.libraryCache.rebuild(container: persistenceController.container)
                         await appState.librarySyncManager.syncIfStale(
@@ -181,6 +184,9 @@ struct VibrdromeApp: App {
                     // submit the scheduled requests once credentials are confirmed loaded.
                     BackgroundSyncScheduler.shared.scheduleRefresh()
                     BackgroundSyncScheduler.shared.scheduleFullSync()
+                    appState.librarySyncManager.onSyncCompleted = {
+                        appState.libraryCache.rebuild(container: persistenceController.container)
+                    }
                     Task {
                         appState.libraryCache.rebuild(container: persistenceController.container)
                         await appState.librarySyncManager.syncIfStale(

--- a/VibrdromeTests/Core/LibrarySyncTests.swift
+++ b/VibrdromeTests/Core/LibrarySyncTests.swift
@@ -1,0 +1,238 @@
+import Testing
+import Foundation
+@testable import Vibrdrome
+
+/// Tests for library sync infrastructure: SyncMode, SyncStats,
+/// CachedAlbum/CachedArtist round-trip conversions, and update detection.
+struct LibrarySyncTests {
+
+    // MARK: - SyncMode
+
+    @Test func syncModeRawValues() {
+        #expect(SyncMode.full.rawValue == "full")
+        #expect(SyncMode.incremental.rawValue == "incremental")
+        #expect(SyncMode.background.rawValue == "background")
+    }
+
+    // MARK: - SyncStats
+
+    @Test func syncStatsTotalChangesEmpty() {
+        let stats = LibrarySyncManager.SyncStats()
+        #expect(stats.totalChanges == 0)
+    }
+
+    @Test func syncStatsTotalChangesAggregatesAll() {
+        var stats = LibrarySyncManager.SyncStats()
+        stats.albumsAdded = 5
+        stats.albumsUpdated = 3
+        stats.albumsRemoved = 1
+        stats.artistsAdded = 10
+        stats.artistsUpdated = 2
+        stats.artistsRemoved = 0
+        stats.songsAdded = 100
+        stats.songsUpdated = 20
+        stats.songsRemoved = 5
+        #expect(stats.totalChanges == 146)
+    }
+
+    @Test func syncStatsDuration() throws {
+        let stats = LibrarySyncManager.SyncStats()
+        // Duration is time since startTime, should be >= 0
+        #expect(stats.duration >= 0)
+    }
+
+    // MARK: - CachedAlbum Round-Trip
+
+    @Test func cachedAlbumRoundTripPreservesId() {
+        let album = makeAlbum(id: "alb-1")
+        let cached = CachedAlbum(from: album)
+        let restored = cached.toAlbum()
+        #expect(restored.id == "alb-1")
+    }
+
+    @Test func cachedAlbumRoundTripPreservesName() {
+        let album = makeAlbum(name: "OK Computer")
+        let cached = CachedAlbum(from: album)
+        let restored = cached.toAlbum()
+        #expect(restored.name == "OK Computer")
+    }
+
+    @Test func cachedAlbumRoundTripPreservesArtist() {
+        let album = makeAlbum(artist: "Radiohead")
+        let cached = CachedAlbum(from: album)
+        let restored = cached.toAlbum()
+        #expect(restored.artist == "Radiohead")
+    }
+
+    @Test func cachedAlbumRoundTripPreservesYear() {
+        let album = makeAlbum(year: 1997)
+        let cached = CachedAlbum(from: album)
+        let restored = cached.toAlbum()
+        #expect(restored.year == 1997)
+    }
+
+    @Test func cachedAlbumRoundTripPreservesGenre() {
+        let album = makeAlbum(genre: "Alternative Rock")
+        let cached = CachedAlbum(from: album)
+        let restored = cached.toAlbum()
+        #expect(restored.genre == "Alternative Rock")
+    }
+
+    @Test func cachedAlbumStarredConversion() {
+        let starred = makeAlbum(starred: "2024-01-01T00:00:00Z")
+        let cachedStarred = CachedAlbum(from: starred)
+        #expect(cachedStarred.isStarred == true)
+        #expect(cachedStarred.toAlbum().starred == "true")
+
+        let unstarred = makeAlbum(starred: nil)
+        let cachedUnstarred = CachedAlbum(from: unstarred)
+        #expect(cachedUnstarred.isStarred == false)
+        #expect(cachedUnstarred.toAlbum().starred == nil)
+    }
+
+    @Test func cachedAlbumRoundTripPreservesRating() {
+        let album = makeAlbum(userRating: 4)
+        let cached = CachedAlbum(from: album)
+        let restored = cached.toAlbum()
+        #expect(restored.userRating == 4)
+    }
+
+    @Test func cachedAlbumRoundTripNilRatingBecomesNil() {
+        let album = makeAlbum(userRating: nil)
+        let cached = CachedAlbum(from: album)
+        #expect(cached.userRating == 0)
+        let restored = cached.toAlbum()
+        #expect(restored.userRating == nil)
+    }
+
+    @Test func cachedAlbumRoundTripPreservesLabel() {
+        let album = makeAlbum(label: "XL Recordings")
+        let cached = CachedAlbum(from: album)
+        let restored = cached.toAlbum()
+        #expect(restored.label == "XL Recordings")
+    }
+
+    @Test func cachedAlbumUpdateAppliesChanges() {
+        let original = makeAlbum(id: "alb-1", name: "Old Name", year: 2020)
+        let cached = CachedAlbum(from: original)
+
+        let updated = makeAlbum(id: "alb-1", name: "New Name", year: 2024, genre: "Electronic")
+        cached.update(from: updated)
+
+        #expect(cached.name == "New Name")
+        #expect(cached.year == 2024)
+        #expect(cached.genre == "Electronic")
+    }
+
+    @Test func cachedAlbumUpdatePreservesIdOnMismatch() {
+        // update(from:) doesn't change ID — it's the caller's responsibility to match
+        let cached = CachedAlbum(from: makeAlbum(id: "alb-1"))
+        cached.update(from: makeAlbum(id: "alb-2", name: "Different"))
+        #expect(cached.id == "alb-1")
+        #expect(cached.name == "Different")
+    }
+
+    // MARK: - CachedArtist Round-Trip
+
+    @Test func cachedArtistRoundTripPreservesId() {
+        let artist = makeArtist(id: "art-1")
+        let cached = CachedArtist(from: artist)
+        let restored = cached.toArtist()
+        #expect(restored.id == "art-1")
+    }
+
+    @Test func cachedArtistRoundTripPreservesName() {
+        let artist = makeArtist(name: "Boards of Canada")
+        let cached = CachedArtist(from: artist)
+        let restored = cached.toArtist()
+        #expect(restored.name == "Boards of Canada")
+    }
+
+    @Test func cachedArtistRoundTripPreservesAlbumCount() {
+        let artist = makeArtist(albumCount: 7)
+        let cached = CachedArtist(from: artist)
+        let restored = cached.toArtist()
+        #expect(restored.albumCount == 7)
+    }
+
+    @Test func cachedArtistStarredConversion() {
+        let starred = makeArtist(starred: "2024-06-01T12:00:00Z")
+        let cached = CachedArtist(from: starred)
+        #expect(cached.isStarred == true)
+
+        let unstarred = makeArtist(starred: nil)
+        let cachedU = CachedArtist(from: unstarred)
+        #expect(cachedU.isStarred == false)
+    }
+
+    // MARK: - SyncHistory
+
+    @Test func syncHistoryTotalChanges() {
+        let history = SyncHistory(syncType: "full")
+        history.albumsAdded = 10
+        history.songsAdded = 100
+        history.artistsUpdated = 5
+        #expect(history.totalChanges == 115)
+    }
+
+    @Test func syncHistorySummaryNoChanges() {
+        let history = SyncHistory(syncType: "incremental")
+        #expect(history.summary == "No changes")
+    }
+
+    @Test func syncHistorySummaryWithChanges() {
+        let history = SyncHistory(syncType: "full")
+        history.albumsAdded = 5
+        history.songsUpdated = 10
+        history.artistsRemoved = 2
+        let summary = history.summary
+        #expect(summary.contains("+5"))
+        #expect(summary.contains("~10"))
+        #expect(summary.contains("-2"))
+    }
+
+    @Test func syncHistorySummaryOnFailure() {
+        let history = SyncHistory(syncType: "full")
+        history.succeeded = false
+        history.errorMessage = "Connection timeout"
+        #expect(history.summary == "Failed: Connection timeout")
+    }
+
+    // MARK: - Helpers
+
+    private func makeAlbum(
+        id: String = "test",
+        name: String = "Test Album",
+        artist: String? = nil,
+        artistId: String? = nil,
+        year: Int? = nil,
+        genre: String? = nil,
+        songCount: Int? = nil,
+        duration: Int? = nil,
+        starred: String? = nil,
+        userRating: Int? = nil,
+        label: String? = nil
+    ) -> Album {
+        Album(
+            id: id, name: name, artist: artist, artistId: artistId,
+            coverArt: nil, songCount: songCount, duration: duration,
+            year: year, genre: genre, starred: starred, created: nil,
+            userRating: userRating, song: nil, replayGain: nil,
+            musicBrainzId: nil,
+            recordLabels: label.map { [RecordLabel(name: $0)] }
+        )
+    }
+
+    private func makeArtist(
+        id: String = "test",
+        name: String = "Test Artist",
+        coverArt: String? = nil,
+        albumCount: Int? = nil,
+        starred: String? = nil
+    ) -> Artist {
+        Artist(
+            id: id, name: name, coverArt: coverArt,
+            albumCount: albumCount, starred: starred, album: nil
+        )
+    }
+}

--- a/VibrdromeTests/Core/LibrarySyncTests.swift
+++ b/VibrdromeTests/Core/LibrarySyncTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import Foundation
+import SwiftData
 @testable import Vibrdrome
 
 /// Tests for library sync infrastructure: SyncMode, SyncStats,
@@ -234,5 +235,70 @@ struct LibrarySyncTests {
             id: id, name: name, coverArt: coverArt,
             albumCount: albumCount, starred: starred, album: nil
         )
+    }
+
+    // MARK: - SwiftData Schema Migration
+
+    @Test func migrationFromBuild45SchemaSucceeds() throws {
+        // Use a temp file-backed store so data persists across containers
+        let storeURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("migration-test-\(UUID().uuidString).store")
+        defer { try? FileManager.default.removeItem(at: storeURL) }
+
+        // Build 45 schema — the entities that existed before 7a
+        let oldSchema = Schema([
+            DownloadedSong.self,
+            PlayHistory.self,
+            ServerConfig.self,
+            OfflinePlaylist.self,
+            PendingAction.self,
+            SavedQueue.self,
+            AlbumCollection.self,
+        ])
+        let oldConfig = ModelConfiguration(schema: oldSchema, url: storeURL)
+
+        // Phase 1: create store with old schema and seed data
+        do {
+            let oldContainer = try ModelContainer(for: oldSchema, configurations: [oldConfig])
+            let ctx = ModelContext(oldContainer)
+            let collection = AlbumCollection(name: "Test Collection", listType: .alphabeticalByName)
+            ctx.insert(collection)
+            try ctx.save()
+        }
+        // oldContainer deallocated — store is on disk
+
+        // Phase 2: reopen same store with expanded schema (7a)
+        let newSchema = Schema([
+            CachedArtist.self,
+            CachedAlbum.self,
+            CachedSong.self,
+            CachedPlaylist.self,
+            CachedPlaylistEntry.self,
+            DownloadedSong.self,
+            PlayHistory.self,
+            ServerConfig.self,
+            OfflinePlaylist.self,
+            PendingAction.self,
+            SavedQueue.self,
+            AlbumCollection.self,
+            SyncHistory.self,
+        ])
+        let newConfig = ModelConfiguration(schema: newSchema, url: storeURL)
+
+        // Lightweight migration: adding entities should not throw
+        let newContainer = try ModelContainer(for: newSchema, configurations: [newConfig])
+        let newCtx = ModelContext(newContainer)
+
+        // Verify old data survived the migration
+        let collections = try newCtx.fetch(FetchDescriptor<AlbumCollection>())
+        #expect(collections.count == 1)
+        #expect(collections.first?.name == "Test Collection")
+
+        // Verify new entities are accessible and empty
+        let albums = try newCtx.fetch(FetchDescriptor<CachedAlbum>())
+        #expect(albums.isEmpty)
+
+        let syncHistory = try newCtx.fetch(FetchDescriptor<SyncHistory>())
+        #expect(syncHistory.isEmpty)
     }
 }

--- a/VibrdromeTests/Core/OfflinePlaylistRemovalTests.swift
+++ b/VibrdromeTests/Core/OfflinePlaylistRemovalTests.swift
@@ -1,0 +1,111 @@
+import Testing
+@testable import Vibrdrome
+
+/// Tests for the orphan-detection logic that backs `removeOfflinePlaylist` and
+/// `refreshOfflinePlaylist`. Issue #5.
+struct OfflinePlaylistRemovalTests {
+
+    // MARK: - Removal
+
+    @Test func removalDeletesAllSongsWhenNoOtherPlaylists() {
+        let orphaned = DownloadManager.orphanedSongIds(
+            forRemovedPlaylistSongs: ["s1", "s2", "s3"],
+            otherPlaylistSongLists: []
+        )
+        #expect(Set(orphaned) == ["s1", "s2", "s3"])
+    }
+
+    @Test func removalPreservesSongsSharedWithOtherPlaylist() {
+        let orphaned = DownloadManager.orphanedSongIds(
+            forRemovedPlaylistSongs: ["s1", "s2", "s3"],
+            otherPlaylistSongLists: [["s2"]]
+        )
+        #expect(Set(orphaned) == ["s1", "s3"])
+    }
+
+    @Test func removalPreservesSongsAcrossMultipleOtherPlaylists() {
+        let orphaned = DownloadManager.orphanedSongIds(
+            forRemovedPlaylistSongs: ["s1", "s2", "s3", "s4"],
+            otherPlaylistSongLists: [["s1", "s2"], ["s3"]]
+        )
+        #expect(Set(orphaned) == ["s4"])
+    }
+
+    @Test func removalReturnsEmptyWhenAllSongsShared() {
+        let orphaned = DownloadManager.orphanedSongIds(
+            forRemovedPlaylistSongs: ["s1", "s2"],
+            otherPlaylistSongLists: [["s1", "s2", "s3"]]
+        )
+        #expect(orphaned.isEmpty)
+    }
+
+    @Test func removalHandlesEmptyRemovedList() {
+        let orphaned = DownloadManager.orphanedSongIds(
+            forRemovedPlaylistSongs: [],
+            otherPlaylistSongLists: [["s1"]]
+        )
+        #expect(orphaned.isEmpty)
+    }
+
+    // MARK: - Refresh
+
+    @Test func refreshOrphansSongsDroppedFromNewContent() {
+        // Playlist used to contain s1, s2, s3; rotated to s4, s5
+        let orphaned = DownloadManager.orphanedSongIds(
+            forRefreshOldSongs: ["s1", "s2", "s3"],
+            newSongs: ["s4", "s5"],
+            otherPlaylistSongLists: []
+        )
+        #expect(Set(orphaned) == ["s1", "s2", "s3"])
+    }
+
+    @Test func refreshKeepsSongsStillInNewContent() {
+        // Playlist contained s1, s2, s3; refreshed to s2, s3, s4 (s2/s3 retained)
+        let orphaned = DownloadManager.orphanedSongIds(
+            forRefreshOldSongs: ["s1", "s2", "s3"],
+            newSongs: ["s2", "s3", "s4"],
+            otherPlaylistSongLists: []
+        )
+        #expect(Set(orphaned) == ["s1"])
+    }
+
+    @Test func refreshKeepsSongsSharedWithOtherPlaylist() {
+        // Old: s1, s2, s3; new: s4 (none shared); other playlist still has s1
+        let orphaned = DownloadManager.orphanedSongIds(
+            forRefreshOldSongs: ["s1", "s2", "s3"],
+            newSongs: ["s4"],
+            otherPlaylistSongLists: [["s1"]]
+        )
+        #expect(Set(orphaned) == ["s2", "s3"])
+    }
+
+    @Test func refreshReturnsEmptyWhenContentUnchanged() {
+        let orphaned = DownloadManager.orphanedSongIds(
+            forRefreshOldSongs: ["s1", "s2", "s3"],
+            newSongs: ["s1", "s2", "s3"],
+            otherPlaylistSongLists: []
+        )
+        #expect(orphaned.isEmpty)
+    }
+
+    @Test func refreshHandlesEmptyOldSongs() {
+        // First-time download path: no old snapshot, nothing to orphan
+        let orphaned = DownloadManager.orphanedSongIds(
+            forRefreshOldSongs: [],
+            newSongs: ["s1", "s2"],
+            otherPlaylistSongLists: []
+        )
+        #expect(orphaned.isEmpty)
+    }
+
+    @Test func refreshHandlesEmptyNewSongs() {
+        // Server returned empty playlist on refresh; everything from old snapshot
+        // becomes orphaned (subject to other-playlist sharing)
+        let orphaned = DownloadManager.orphanedSongIds(
+            forRefreshOldSongs: ["s1", "s2"],
+            newSongs: [],
+            otherPlaylistSongLists: [["s2"]]
+        )
+        #expect(Set(orphaned) == ["s1"])
+    }
+}

--- a/VibrdromeTests/Core/SubsonicClientWebPTests.swift
+++ b/VibrdromeTests/Core/SubsonicClientWebPTests.swift
@@ -1,0 +1,68 @@
+import Testing
+import Foundation
+@testable import Vibrdrome
+
+@MainActor
+struct SubsonicClientWebPTests {
+
+    private func makeClient(serverVersion: String?) -> SubsonicClient {
+        let client = SubsonicClient(
+            baseURL: URL(string: "https://example.com")!,
+            username: "user",
+            password: "pass"
+        )
+        if let v = serverVersion {
+            client.setServerVersionForTesting(v)
+        }
+        return client
+    }
+
+    @Test func supportsWebP_nilVersion_returnsFalse() {
+        let client = makeClient(serverVersion: nil)
+        #expect(client.supportsWebP == false)
+    }
+
+    @Test func supportsWebP_below049_returnsFalse() {
+        for version in ["0.48.0", "0.48.9", "0.47.0", "0.1.0"] {
+            let client = makeClient(serverVersion: version)
+            #expect(client.supportsWebP == false, "Expected false for \(version)")
+        }
+    }
+
+    @Test func supportsWebP_exactly049_returnsTrue() {
+        let client = makeClient(serverVersion: "0.49.0")
+        #expect(client.supportsWebP == true)
+    }
+
+    @Test func supportsWebP_above049_returnsTrue() {
+        for version in ["0.49.1", "0.50.0", "0.52.5", "1.0.0"] {
+            let client = makeClient(serverVersion: version)
+            #expect(client.supportsWebP == true, "Expected true for \(version)")
+        }
+    }
+
+    @Test func supportsWebP_malformedVersion_returnsFalse() {
+        for version in ["", "notaversion", "0", "0."] {
+            let client = makeClient(serverVersion: version)
+            #expect(client.supportsWebP == false, "Expected false for malformed '\(version)'")
+        }
+    }
+
+    @Test func coverArtURL_withWebP_containsFormatParam() {
+        let client = makeClient(serverVersion: "0.52.5")
+        let url = client.coverArtURL(id: "abc", size: 300)
+        #expect(url.absoluteString.contains("format=webp"))
+    }
+
+    @Test func coverArtURL_withoutWebP_omitsFormatParam() {
+        let client = makeClient(serverVersion: "0.48.0")
+        let url = client.coverArtURL(id: "abc", size: 300)
+        #expect(!url.absoluteString.contains("format=webp"))
+    }
+
+    @Test func coverArtURL_nilVersion_omitsFormatParam() {
+        let client = makeClient(serverVersion: nil)
+        let url = client.coverArtURL(id: "abc", size: 300)
+        #expect(!url.absoluteString.contains("format=webp"))
+    }
+}

--- a/VibrdromeTests/Core/SubsonicModelsTests.swift
+++ b/VibrdromeTests/Core/SubsonicModelsTests.swift
@@ -142,6 +142,15 @@ struct SubsonicModelsTests {
         #expect(album.song?.count == 2)
         #expect(album.song?[0].title == "Airbag")
         #expect(album.song?[1].title == "Paranoid Android")
+        #expect(album.userRating == nil)
+    }
+
+    @Test func albumWithUserRating() throws {
+        let json = """
+        {"id":"al-r","name":"Rated Album","userRating":4}
+        """.data(using: .utf8)!
+        let album = try JSONDecoder().decode(Album.self, from: json)
+        #expect(album.userRating == 4)
     }
 
     @Test func albumWithSongArrayOmitted() throws {

--- a/VibrdromeTests/Features/LibraryFilterTests.swift
+++ b/VibrdromeTests/Features/LibraryFilterTests.swift
@@ -1,0 +1,150 @@
+import Testing
+@testable import Vibrdrome
+
+@MainActor
+struct LibraryFilterTests {
+
+    // MARK: - TriState
+
+    @Test func triStateAllCases() {
+        #expect(TriState.allCases == [.none, .yes, .no])
+    }
+
+    @Test func triStateRawValues() {
+        #expect(TriState.none.rawValue == "none")
+        #expect(TriState.yes.rawValue == "yes")
+        #expect(TriState.no.rawValue == "no")
+    }
+
+    // MARK: - TriState.matches
+
+    @Test func triStateNoneMatchesAnything() {
+        #expect(TriState.none.matches(true))
+        #expect(TriState.none.matches(false))
+    }
+
+    @Test func triStateYesMatchesTrueOnly() {
+        #expect(TriState.yes.matches(true))
+        #expect(!TriState.yes.matches(false))
+    }
+
+    @Test func triStateNoMatchesFalseOnly() {
+        #expect(TriState.no.matches(false))
+        #expect(!TriState.no.matches(true))
+    }
+
+    // MARK: - LibraryFilter initial state
+
+    @Test func initialStateIsInactive() {
+        let filter = LibraryFilter()
+        #expect(!filter.isActive)
+        #expect(filter.activeFilterCount == 0)
+        #expect(filter.isFavorited == .none)
+        #expect(filter.isRated == .none)
+        #expect(!filter.isRecentlyPlayed)
+        #expect(filter.selectedArtistIds.isEmpty)
+        #expect(filter.selectedGenres.isEmpty)
+        #expect(filter.selectedLabels.isEmpty)
+        #expect(filter.year == nil)
+    }
+
+    // MARK: - isActive detection
+
+    @Test func isActiveWhenFavoritedSet() {
+        let filter = LibraryFilter()
+        filter.isFavorited = .yes
+        #expect(filter.isActive)
+        #expect(filter.activeFilterCount == 1)
+    }
+
+    @Test func isActiveWhenRatedSet() {
+        let filter = LibraryFilter()
+        filter.isRated = .no
+        #expect(filter.isActive)
+        #expect(filter.activeFilterCount == 1)
+    }
+
+    @Test func isActiveWhenRecentlyPlayedSet() {
+        let filter = LibraryFilter()
+        filter.isRecentlyPlayed = true
+        #expect(filter.isActive)
+        #expect(filter.activeFilterCount == 1)
+    }
+
+    @Test func isActiveWhenArtistsSelected() {
+        let filter = LibraryFilter()
+        filter.selectedArtistIds = ["artist-1"]
+        #expect(filter.isActive)
+        #expect(filter.activeFilterCount == 1)
+    }
+
+    @Test func isActiveWhenGenresSelected() {
+        let filter = LibraryFilter()
+        filter.selectedGenres = ["Electronic", "Jazz"]
+        #expect(filter.isActive)
+        #expect(filter.activeFilterCount == 1)
+    }
+
+    @Test func isActiveWhenLabelsSelected() {
+        let filter = LibraryFilter()
+        filter.selectedLabels = ["Sony Music"]
+        #expect(filter.isActive)
+        #expect(filter.activeFilterCount == 1)
+    }
+
+    @Test func isActiveWhenYearSet() {
+        let filter = LibraryFilter()
+        filter.year = 2024
+        #expect(filter.isActive)
+        #expect(filter.activeFilterCount == 1)
+    }
+
+    // MARK: - activeFilterCount with multiple filters
+
+    @Test func multipleFiltersCountCorrectly() {
+        let filter = LibraryFilter()
+        filter.isFavorited = .yes
+        filter.isRated = .yes
+        filter.isRecentlyPlayed = true
+        filter.selectedArtistIds = ["a1"]
+        filter.selectedGenres = ["Rock"]
+        filter.selectedLabels = ["Atlantic"]
+        filter.year = 2020
+        #expect(filter.activeFilterCount == 7)
+    }
+
+    // MARK: - Reset
+
+    @Test func resetClearsAllFilters() {
+        let filter = LibraryFilter()
+        filter.isFavorited = .yes
+        filter.isRated = .no
+        filter.isRecentlyPlayed = true
+        filter.selectedArtistIds = ["a1", "a2"]
+        filter.selectedGenres = ["Rock"]
+        filter.selectedLabels = ["Def Jam"]
+        filter.year = 1997
+
+        filter.reset()
+
+        #expect(!filter.isActive)
+        #expect(filter.activeFilterCount == 0)
+        #expect(filter.isFavorited == .none)
+        #expect(filter.isRated == .none)
+        #expect(!filter.isRecentlyPlayed)
+        #expect(filter.selectedArtistIds.isEmpty)
+        #expect(filter.selectedGenres.isEmpty)
+        #expect(filter.selectedLabels.isEmpty)
+        #expect(filter.year == nil)
+    }
+
+    // MARK: - TriState none does not count as active
+
+    @Test func triStateNoneIsNotActive() {
+        let filter = LibraryFilter()
+        filter.isFavorited = .none
+        filter.isRated = .none
+        #expect(!filter.isActive)
+        #expect(filter.activeFilterCount == 0)
+    }
+}


### PR DESCRIPTION
## Summary

- **Race condition on startup**: `AlbumsView` and `ArtistsView` now watch `libraryCache.generation` so filters re-evaluate as soon as the cache finishes building, rather than running against an empty or partial cache (unlike `SongsView`, which already had this watcher)
- **Stale cache after polling sync**: `LibrarySyncManager` gains an `onSyncCompleted` callback (wired in `Vibrdrome.swift`) so the in-memory cache rebuilds after every incremental/polling sync, not just on app launch — new server content now appears in filters without a manual refresh
- **Multi-genre support (OpenSubsonic)**: `CachedAlbum.genre: String?` replaced with `genres: [String]`. `Album` model gains `ItemGenre` and `allGenres`, preferring the OpenSubsonic `genres[]` array (available on `getAlbum`) over the legacy single `genre` string from `getAlbumList`. Filter matching uses set intersection so an album matches if **any** of its genres is selected
- **Genre backfill**: Post-song-sync pass derives genres from song metadata for albums where `getAlbumList` returns no genre (no extra API calls)
- **Reset Cache button** added to Settings > Library section

## Root cause

Filters (genre, artist, label, year, etc.) showed fewer results than Navidrome's web UI because:
1. The filter ran against an empty cache before `rebuild()` finished on startup
2. The cache was never rebuilt after polling syncs updated SwiftData
3. Navidrome stores multiple genres per album (e.g. "Heroes" by David Bowie has 9 genres), but only the first was stored and matched

## Test plan

- [ ] Full library sync → open Albums sidebar → apply genre filter → confirm count matches Navidrome web UI
- [ ] Albums with multiple genres (e.g. "Heroes") appear when filtering by any of their genres
- [ ] Kill and reopen app → apply filter immediately → results are correct even before cache finishes rebuilding
- [ ] Add album to Navidrome → wait for poll → confirm it appears in filter results without manual refresh
- [ ] Settings > Library → "Reset Cache" button clears and rebuilds in-memory cache
- [ ] SwiftLint: 0 violations
- [ ] Build iOS + macOS: no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)