### PR TITLE
Fix library filter caching pipeline & add multi-genre support

### DIFF
--- a/Vibrdrome/Core/Networking/SubsonicModels.swift
+++ b/Vibrdrome/Core/Networking/SubsonicModels.swift
@@ -141,6 +141,11 @@ struct RecordLabel: Decodable, Sendable {
     let name: String
 }
 
+/// OpenSubsonic genre tag on an album or song (name-keyed, distinct from the library Genre type).
+struct ItemGenre: Decodable, Sendable {
+    let name: String
+}
+
 struct Album: Decodable, Identifiable, Sendable {
     let id: String
     let name: String
@@ -151,6 +156,7 @@ struct Album: Decodable, Identifiable, Sendable {
     let duration: Int?
     let year: Int?
     let genre: String?
+    let genres: [ItemGenre]?
     let starred: String?
     let created: String?
     let userRating: Int?
@@ -161,6 +167,15 @@ struct Album: Decodable, Identifiable, Sendable {
 
     /// First record label name, for convenience.
     var label: String? { recordLabels?.first?.name }
+
+    /// All genres for this album. Prefers the OpenSubsonic `genres` array when present;
+    /// falls back to the legacy single `genre` string.
+    var allGenres: [String] {
+        if let items = genres, !items.isEmpty {
+            return items.map(\.name)
+        }
+        return genre.map { [$0] } ?? []
+    }
 }
 
 struct AlbumList2Response: Decodable, Sendable {

--- a/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
+++ b/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
@@ -584,19 +584,16 @@ final class LibrarySyncManager {
         let context = ModelContext(container)
         context.autosaveEnabled = false
 
-        // Target albums where getAlbumList returned no genres
-        let emptyGenresDescriptor = FetchDescriptor<CachedAlbum>(
-            predicate: #Predicate<CachedAlbum> { $0.genres.isEmpty }
-        )
-        let albumsNeedingGenres = try context.fetch(emptyGenresDescriptor)
+        // SwiftData can't translate [String].isEmpty or optional != nil into SQL,
+        // so fetch all albums/songs and filter in memory.
+        let albumsNeedingGenres = try context.fetch(FetchDescriptor<CachedAlbum>())
+            .filter { $0.genres.isEmpty }
         guard !albumsNeedingGenres.isEmpty else { return }
 
         progress("Backfilling album genres…")
 
-        let songsDescriptor = FetchDescriptor<CachedSong>(
-            predicate: #Predicate<CachedSong> { $0.genre != nil && $0.albumId != nil }
-        )
-        let songsWithGenre = try context.fetch(songsDescriptor)
+        let songsWithGenre = try context.fetch(FetchDescriptor<CachedSong>())
+            .filter { $0.genre != nil && $0.albumId != nil }
 
         // Build albumId → Set<genre> from songs belonging to empty-genre albums
         let albumIds = Set(albumsNeedingGenres.map { $0.id })

--- a/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
+++ b/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
@@ -37,6 +37,10 @@ final class LibrarySyncManager {
     /// Stats from the most recent sync, updated live during sync.
     var lastSyncStats: SyncStats?
 
+    /// Called on MainActor after each successful sync completes. Wire this up in the app startup
+    /// task to trigger a library cache rebuild so filters see fresh data after polling syncs.
+    var onSyncCompleted: (@MainActor () -> Void)?
+
     /// Polling timer for change detection while app is active.
     private var pollingTask: Task<Void, Never>?
 
@@ -206,6 +210,7 @@ final class LibrarySyncManager {
                     stats: &working, incremental: incremental,
                     progress: updateProgress, publishStats: publishPartialStats
                 )
+                try Self.backfillAlbumGenresOffMain(container: container, progress: updateProgress)
                 try await Self.syncPlaylistsOffMain(
                     client: client, container: container,
                     stats: &working,
@@ -220,6 +225,7 @@ final class LibrarySyncManager {
 
             lastSyncDate = Date()
             lastSyncStats = stats
+            onSyncCompleted?()
 
             // Save sync history on a fresh context (the work context above is already gone).
             let historyContext = ModelContext(container)
@@ -365,7 +371,7 @@ final class LibrarySyncManager {
         cached.artistName != server.artist ||
         cached.artistId != server.artistId ||
         cached.year != server.year ||
-        cached.genre != server.genre ||
+        Set(cached.genres) != Set(server.allGenres) ||
         cached.songCount != server.songCount ||
         cached.duration != server.duration ||
         cached.isStarred != (server.starred != nil) ||
@@ -567,6 +573,51 @@ final class LibrarySyncManager {
         cached.isStarred = song.starred != nil
         cached.rating = song.userRating ?? 0
         cached.cachedAt = Date()
+    }
+
+    // MARK: - Genre Backfill
+
+    nonisolated static func backfillAlbumGenresOffMain(
+        container: ModelContainer,
+        progress: @Sendable (String) -> Void
+    ) throws {
+        let context = ModelContext(container)
+        context.autosaveEnabled = false
+
+        // Target albums where getAlbumList returned no genres
+        let emptyGenresDescriptor = FetchDescriptor<CachedAlbum>(
+            predicate: #Predicate<CachedAlbum> { $0.genres.isEmpty }
+        )
+        let albumsNeedingGenres = try context.fetch(emptyGenresDescriptor)
+        guard !albumsNeedingGenres.isEmpty else { return }
+
+        progress("Backfilling album genres…")
+
+        let songsDescriptor = FetchDescriptor<CachedSong>(
+            predicate: #Predicate<CachedSong> { $0.genre != nil && $0.albumId != nil }
+        )
+        let songsWithGenre = try context.fetch(songsDescriptor)
+
+        // Build albumId → Set<genre> from songs belonging to empty-genre albums
+        let albumIds = Set(albumsNeedingGenres.map { $0.id })
+        var albumGenres: [String: Set<String>] = [:]
+        for song in songsWithGenre {
+            guard let albumId = song.albumId, albumIds.contains(albumId),
+                  let genre = song.genre, !genre.isEmpty else { continue }
+            albumGenres[albumId, default: []].insert(genre)
+        }
+
+        var backfilledCount = 0
+        for album in albumsNeedingGenres {
+            guard let genres = albumGenres[album.id], !genres.isEmpty else { continue }
+            album.genres = genres.sorted()
+            backfilledCount += 1
+        }
+
+        if backfilledCount > 0 {
+            try context.save()
+            syncLog.info("Backfilled genres for \(backfilledCount) albums from song metadata")
+        }
     }
 
     // MARK: - Playlists

--- a/Vibrdrome/Core/Persistence/Models/CachedAlbum.swift
+++ b/Vibrdrome/Core/Persistence/Models/CachedAlbum.swift
@@ -9,7 +9,7 @@ final class CachedAlbum {
     var artistId: String?
     var coverArtId: String?
     var year: Int?
-    var genre: String?
+    var genres: [String] = []
     var songCount: Int?
     var duration: Int?
     var isStarred: Bool = false
@@ -27,7 +27,7 @@ final class CachedAlbum {
         self.artistId = album.artistId
         self.coverArtId = album.coverArt
         self.year = album.year
-        self.genre = album.genre
+        self.genres = album.allGenres
         self.songCount = album.songCount
         self.duration = album.duration
         self.isStarred = album.starred != nil
@@ -43,7 +43,7 @@ final class CachedAlbum {
         artistId = album.artistId
         coverArtId = album.coverArt
         year = album.year
-        genre = album.genre
+        genres = album.allGenres
         songCount = album.songCount
         duration = album.duration
         isStarred = album.starred != nil
@@ -64,7 +64,8 @@ final class CachedAlbum {
             songCount: songCount,
             duration: duration,
             year: year,
-            genre: genre,
+            genre: genres.first,
+            genres: genres.map { ItemGenre(name: $0) },
             starred: isStarred ? "true" : nil,
             created: created,
             userRating: userRating > 0 ? userRating : nil,

--- a/Vibrdrome/Features/Library/AlbumDetailView.swift
+++ b/Vibrdrome/Features/Library/AlbumDetailView.swift
@@ -634,10 +634,10 @@ struct AlbumDetailView: View {
                         id: preview.id, name: preview.name, artist: preview.artist,
                         artistId: preview.artistId, coverArt: preview.coverArt,
                         songCount: preview.songCount, duration: preview.duration,
-                        year: preview.year, genre: preview.genre, starred: preview.starred,
-                        created: preview.created, userRating: preview.userRating,
-                        song: songs, replayGain: nil, musicBrainzId: nil,
-                        recordLabels: nil
+                        year: preview.year, genre: preview.genre, genres: preview.genres,
+                        starred: preview.starred, created: preview.created,
+                        userRating: preview.userRating, song: songs,
+                        replayGain: nil, musicBrainzId: nil, recordLabels: nil
                     )
                 }
                 album = preview

--- a/Vibrdrome/Features/Library/AlbumsView.swift
+++ b/Vibrdrome/Features/Library/AlbumsView.swift
@@ -360,6 +360,7 @@ struct AlbumsView: View {
         .onChange(of: appState.albumFilter.selectedGenres) { debouncedApplyLocalFilters() }
         .onChange(of: appState.albumFilter.selectedLabels) { debouncedApplyLocalFilters() }
         .onChange(of: appState.albumFilter.year) { debouncedApplyLocalFilters() }
+        .onChange(of: appState.libraryCache.generation) { _, _ in debouncedApplyLocalFilters() }
         #endif
     }
 
@@ -815,9 +816,8 @@ struct AlbumsView: View {
             }
         }
         if !snapshot.selectedGenres.isEmpty {
-            guard let genre = album.genre, snapshot.selectedGenres.contains(genre) else {
-                return false
-            }
+            let albumGenres = Set(album.allGenres)
+            guard !albumGenres.isDisjoint(with: snapshot.selectedGenres) else { return false }
         }
         if !snapshot.selectedLabels.isEmpty {
             guard let albumLabel = album.label, snapshot.selectedLabels.contains(albumLabel) else {

--- a/Vibrdrome/Features/Library/ArtistsView.swift
+++ b/Vibrdrome/Features/Library/ArtistsView.swift
@@ -245,6 +245,7 @@ struct ArtistsView: View {
         #if os(macOS)
         .onChange(of: appState.artistFilter.isFavorited) { debouncedApplyLocalFilters() }
         .onChange(of: appState.artistFilter.selectedGenres) { debouncedApplyLocalFilters() }
+        .onChange(of: appState.libraryCache.generation) { _, _ in debouncedApplyLocalFilters() }
         #endif
     }
 
@@ -436,7 +437,8 @@ struct ArtistsView: View {
                 }
                 var ids = Set<String>()
                 for album in allAlbums {
-                    if let genre = album.genre, filter.selectedGenres.contains(genre),
+                    let albumGenres = Set(album.allGenres)
+                    if !albumGenres.isDisjoint(with: filter.selectedGenres),
                        let artistId = album.artistId {
                         ids.insert(artistId)
                     }

--- a/Vibrdrome/Features/Library/GenresView.swift
+++ b/Vibrdrome/Features/Library/GenresView.swift
@@ -258,9 +258,10 @@ struct GenresView: View {
         var genreSongCount: [String: Int] = [:]
 
         for album in allAlbums {
-            guard let genre = album.genre, !genre.isEmpty else { continue }
-            genreAlbumCount[genre, default: 0] += 1
-            genreSongCount[genre, default: 0] += album.songCount ?? 0
+            for genre in album.genres where !genre.isEmpty {
+                genreAlbumCount[genre, default: 0] += 1
+                genreSongCount[genre, default: 0] += album.songCount ?? 0
+            }
         }
 
         return genreAlbumCount.map { key, albumCount in

--- a/Vibrdrome/Features/Library/LibraryFilterSidebarView.swift
+++ b/Vibrdrome/Features/Library/LibraryFilterSidebarView.swift
@@ -330,12 +330,20 @@ struct LibraryFilterSidebarView: View {
         } else {
             let descriptor = FetchDescriptor<CachedAlbum>()
             let albums = (try? modelContext.fetch(descriptor)) ?? []
-            genreSet = Set(albums.compactMap(\.genre)).subtracting([""])
+            // Collect all genres from the multi-genre array on each album
+            var mutableGenreSet = Set(albums.flatMap(\.genres)).subtracting([""])
 
             if context == .album {
+                // Union in song genres so albums not yet backfilled still appear in the list
+                let songDescriptor = FetchDescriptor<CachedSong>()
+                let songs = (try? modelContext.fetch(songDescriptor)) ?? []
+                mutableGenreSet.formUnion(Set(songs.compactMap(\.genre)).subtracting([""]))
+
                 let labelSet = Set(albums.compactMap(\.label)).subtracting([""])
                 labels = labelSet.sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
             }
+
+            genreSet = mutableGenreSet
         }
         genres = genreSet.sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
     }

--- a/Vibrdrome/Features/Search/SearchView+Filters.swift
+++ b/Vibrdrome/Features/Search/SearchView+Filters.swift
@@ -188,7 +188,7 @@ extension SearchView {
     func loadGenres() async {
         // Try local SwiftData first — fetch album genres (much smaller than all songs)
         let albums = (try? modelContext.fetch(FetchDescriptor<CachedAlbum>())) ?? []
-        let localGenres = Set(albums.compactMap(\.genre).filter { !$0.isEmpty })
+        let localGenres = Set(albums.flatMap(\.genres).filter { !$0.isEmpty })
         if !localGenres.isEmpty {
             availableGenres = localGenres.sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
             return

--- a/Vibrdrome/Features/Settings/SettingsView.swift
+++ b/Vibrdrome/Features/Settings/SettingsView.swift
@@ -408,6 +408,15 @@ struct SettingsView: View {
                 .accessibilityIdentifier("incrementalSyncButton")
             }
 
+            Button {
+                appState.libraryCache.invalidate()
+                appState.libraryCache.rebuild(container: PersistenceController.shared.container)
+            } label: {
+                Label("Reset Cache", systemImage: "memorychip")
+            }
+            .disabled(appState.librarySyncManager.isSyncing)
+            .accessibilityIdentifier("resetCacheButton")
+
             NavigationLink {
                 SyncHistoryView()
             } label: {

--- a/Vibrdrome/Vibrdrome.swift
+++ b/Vibrdrome/Vibrdrome.swift
@@ -145,6 +145,9 @@ struct VibrdromeApp: App {
                     ImagePipeline.shared = ImagePipeline(configuration: .withDataCache(name: "com.vibrdrome.images"))
                     RemoteCommandManager.shared.setup()
                     DownloadManager.shared.resumeIncompleteDownloads()
+                    appState.librarySyncManager.onSyncCompleted = {
+                        appState.libraryCache.rebuild(container: persistenceController.container)
+                    }
                     Task {
                         appState.libraryCache.rebuild(container: persistenceController.container)
                         await appState.librarySyncManager.syncIfStale(
@@ -181,6 +184,9 @@ struct VibrdromeApp: App {
                     // submit the scheduled requests once credentials are confirmed loaded.
                     BackgroundSyncScheduler.shared.scheduleRefresh()
                     BackgroundSyncScheduler.shared.scheduleFullSync()
+                    appState.librarySyncManager.onSyncCompleted = {
+                        appState.libraryCache.rebuild(container: persistenceController.container)
+                    }
                     Task {
                         appState.libraryCache.rebuild(container: persistenceController.container)
                         await appState.librarySyncManager.syncIfStale(

--- a/VibrdromeTests/Core/LibrarySyncTests.swift
+++ b/VibrdromeTests/Core/LibrarySyncTests.swift
@@ -122,7 +122,7 @@ struct LibrarySyncTests {
 
         #expect(cached.name == "New Name")
         #expect(cached.year == 2024)
-        #expect(cached.genre == "Electronic")
+        #expect(cached.genres == ["Electronic"])
     }
 
     @Test func cachedAlbumUpdatePreservesIdOnMismatch() {
@@ -220,7 +220,8 @@ struct LibrarySyncTests {
             year: year, genre: genre, starred: starred, created: nil,
             userRating: userRating, song: nil, replayGain: nil,
             musicBrainzId: nil,
-            recordLabels: label.map { [RecordLabel(name: $0)] }
+            recordLabels: label.map { [RecordLabel(name: $0)] },
+            genres: nil
         )
     }
 

--- a/VibrdromeTests/Core/LibrarySyncTests.swift
+++ b/VibrdromeTests/Core/LibrarySyncTests.swift
@@ -217,11 +217,10 @@ struct LibrarySyncTests {
         Album(
             id: id, name: name, artist: artist, artistId: artistId,
             coverArt: nil, songCount: songCount, duration: duration,
-            year: year, genre: genre, starred: starred, created: nil,
+            year: year, genre: genre, genres: nil, starred: starred, created: nil,
             userRating: userRating, song: nil, replayGain: nil,
             musicBrainzId: nil,
-            recordLabels: label.map { [RecordLabel(name: $0)] },
-            genres: nil
+            recordLabels: label.map { [RecordLabel(name: $0)] }
         )
     }
 


### PR DESCRIPTION
## Summary

- **Race condition on startup**: `AlbumsView` and `ArtistsView` now watch `libraryCache.generation` so filters re-evaluate as soon as the cache finishes building, rather than running against an empty or partial cache (unlike `SongsView`, which already had this watcher)
- **Stale cache after polling sync**: `LibrarySyncManager` gains an `onSyncCompleted` callback (wired in `Vibrdrome.swift`) so the in-memory cache rebuilds after every incremental/polling sync, not just on app launch — new server content now appears in filters without a manual refresh
- **Multi-genre support (OpenSubsonic)**: `CachedAlbum.genre: String?` replaced with `genres: [String]`. `Album` model gains `ItemGenre` and `allGenres`, preferring the OpenSubsonic `genres[]` array (available on `getAlbum`) over the legacy single `genre` string from `getAlbumList`. Filter matching uses set intersection so an album matches if **any** of its genres is selected
- **Genre backfill**: Post-song-sync pass derives genres from song metadata for albums where `getAlbumList` returns no genre (no extra API calls)
- **Reset Cache button** added to Settings > Library section

## Root cause

Filters (genre, artist, label, year, etc.) showed fewer results than Navidrome's web UI because:
1. The filter ran against an empty cache before `rebuild()` finished on startup
2. The cache was never rebuilt after polling syncs updated SwiftData
3. Navidrome stores multiple genres per album (e.g. "Heroes" by David Bowie has 9 genres), but only the first was stored and matched

## Test plan

- [ ] Full library sync → open Albums sidebar → apply genre filter → confirm count matches Navidrome web UI
- [ ] Albums with multiple genres (e.g. "Heroes") appear when filtering by any of their genres
- [ ] Kill and reopen app → apply filter immediately → results are correct even before cache finishes rebuilding
- [ ] Add album to Navidrome → wait for poll → confirm it appears in filter results without a manual refresh
- [ ] Settings > Library → "Reset Cache" button clears and rebuilds in-memory cache
- [ ] SwiftLint: 0 violations
- [ ] Build iOS + macOS: no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)