### PR TITLE
fix: stop post-sync cover art prefetch bypassing all cache guards

### DIFF
--- a/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
+++ b/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
@@ -241,8 +241,7 @@ final class LibrarySyncManager {
             let artChanged = stats.albumsAdded > 0 || stats.artistsAdded > 0 ||
                 stats.albumsUpdated > 0 || stats.artistsUpdated > 0
             if artChanged {
-                let prefetchContext = ModelContext(container)
-                await prefetchCoverArt(client: client, context: prefetchContext)
+                await warmImageCache(client: client, container: container)
             }
         } catch {
             syncError = "Sync failed: \(error.localizedDescription)"


### PR DESCRIPTION
## Summary

- `performSync` called `prefetchCoverArt` directly after detecting album/artist changes, bypassing every guard in `warmImageCache`: the per-session dedup flag, the 24-hour cooldown, and the disk-cache filter
- On any sync that touched metadata (even a minor update), this triggered a full re-fetch of all cover art from the server
- Fix: replace the direct call with `warmImageCache`, so all three guard layers apply consistently

## Test plan

- [x] Run a sync — cover art prefetch should complete normally on first run
- [x] Run sync again immediately — prefetch should be skipped (`didPrefetchThisSession` guard)
- [x] Kill and relaunch app, run sync within 24h of last prefetch — prefetch should be skipped (24h cooldown)
- [x] Confirm log output shows "already cached" counts rather than re-fetching everything

🤖 Generated with [Claude Code](https://claude.com/claude-code)