### PR TITLE
feat(macOS): Add Labels sidebar tab

### DIFF
--- a/Vibrdrome/Core/Persistence/LibraryDataCache.swift
+++ b/Vibrdrome/Core/Persistence/LibraryDataCache.swift
@@ -15,6 +15,8 @@ final class LibraryDataCache {
     private(set) var songFilterYears: [Int]?
     private(set) var songFilterArtists: [String]?
     private(set) var songFilterGenres: [String]?
+    private(set) var labelCounts: [String: Int]?
+    private(set) var labelArt: [String: String]?
 
     /// Incremented after each successful rebuild so views can detect changes via `.onChange`.
     /// Intentionally in-session only (not persisted) — resets to 0 on launch. Views only need
@@ -41,6 +43,8 @@ final class LibraryDataCache {
             songFilterYears = result.years
             songFilterArtists = result.artistNames
             songFilterGenres = result.genres
+            labelCounts = result.labelCounts
+            labelArt = result.labelArt
             generation += 1
             isReady = true
             cacheLog.info("Library cache ready — \(result.songs.count) songs, \(result.artists.count) artists, \(result.albums.count) albums")
@@ -56,6 +60,8 @@ final class LibraryDataCache {
         songFilterYears = nil
         songFilterArtists = nil
         songFilterGenres = nil
+        labelCounts = nil
+        labelArt = nil
         isReady = false
     }
 
@@ -68,6 +74,8 @@ final class LibraryDataCache {
         let years: [Int]
         let artistNames: [String]
         let genres: [String]
+        let labelCounts: [String: Int]
+        let labelArt: [String: String]
     }
 
     nonisolated private static func buildCache(container: ModelContainer) -> CacheResult {
@@ -87,11 +95,17 @@ final class LibraryDataCache {
         // which would race if two contexts are running concurrently.
         var albumDescriptor = FetchDescriptor<CachedAlbum>(sortBy: [SortDescriptor<CachedAlbum>(\.name)])
         albumDescriptor.relationshipKeyPathsForPrefetching = [\.genreLinks]
-        let convertedAlbums: [Album]
-        if let cached = try? context.fetch(albumDescriptor) {
-            convertedAlbums = cached.map { $0.toAlbum() }
-        } else {
-            convertedAlbums = []
+        let cachedAlbums = (try? context.fetch(albumDescriptor)) ?? []
+        let convertedAlbums = cachedAlbums.map { $0.toAlbum() }
+
+        var labelCountsMap: [String: Int] = [:]
+        var labelArtMap: [String: String] = [:]
+        for album in cachedAlbums {
+            guard let label = album.label, !label.isEmpty else { continue }
+            labelCountsMap[label, default: 0] += 1
+            if labelArtMap[label] == nil, let artId = album.coverArtId {
+                labelArtMap[label] = artId
+            }
         }
 
         // Songs — single pass for conversion + year/artist extraction
@@ -130,7 +144,9 @@ final class LibraryDataCache {
             albums: convertedAlbums,
             years: sortedYears,
             artistNames: sortedArtists,
-            genres: sortedGenres
+            genres: sortedGenres,
+            labelCounts: labelCountsMap,
+            labelArt: labelArtMap
         )
     }
 }

--- a/Vibrdrome/Features/Library/LabelsView.swift
+++ b/Vibrdrome/Features/Library/LabelsView.swift
@@ -1,0 +1,231 @@
+import SwiftUI
+
+struct LabelsView: View {
+    @Environment(AppState.self) private var appState
+    @State private var labels: [LabelInfo] = []
+    @State private var isLoading = true
+    @State private var searchText = ""
+    @State private var sortBy: LabelSortOption = .name
+    @State private var labelArt: [String: String] = [:] // label → coverArtId
+    @AppStorage("labelsViewStyle") private var showAsList = true
+    @State private var cachedFilteredLabels: [LabelInfo] = []
+
+    struct LabelInfo: Identifiable, Hashable {
+        var id: String { name }
+        let name: String
+        let albumCount: Int
+    }
+
+    enum LabelSortOption: String, CaseIterable {
+        case name, albumCount
+        var label: String {
+            switch self {
+            case .name: "Name (A-Z)"
+            case .albumCount: "Album Count"
+            }
+        }
+    }
+
+    private func computeFilteredLabels() -> [LabelInfo] {
+        let base: [LabelInfo]
+        if searchText.isEmpty {
+            base = labels
+        } else {
+            base = labels.filter {
+                $0.name.localizedCaseInsensitiveContains(searchText)
+            }
+        }
+        switch sortBy {
+        case .name:
+            return base.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+        case .albumCount:
+            return base.sorted { $0.albumCount > $1.albumCount }
+        }
+    }
+
+    var body: some View {
+        Group {
+            if showAsList {
+                labelList
+            } else {
+                labelGrid
+            }
+        }
+        #if os(iOS)
+        .contentMargins(.bottom, 80)
+        #endif
+        .navigationTitle("Labels")
+        #if os(iOS)
+        .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .automatic), prompt: "Search Labels")
+        #else
+        .searchable(text: $searchText, prompt: "Search Labels")
+        #endif
+        #if os(iOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+        .overlay {
+            if isLoading && labels.isEmpty {
+                ProgressView("Loading labels...")
+            } else if !isLoading && labels.isEmpty {
+                ContentUnavailableView {
+                    Label("No Labels", systemImage: "tag")
+                } description: {
+                    Text("No record labels found. Sync your library to populate labels.")
+                }
+            }
+        }
+        .toolbar {
+            ToolbarItem(placement: .automatic) {
+                Button {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        showAsList.toggle()
+                    }
+                } label: {
+                    Image(systemName: showAsList ? "square.grid.2x2" : "list.bullet")
+                }
+                .accessibilityLabel(showAsList ? "Grid View" : "List View")
+                .accessibilityIdentifier("labelsViewToggle")
+            }
+            ToolbarItem(placement: .primaryAction) {
+                Menu {
+                    ForEach(LabelSortOption.allCases, id: \.self) { option in
+                        Button {
+                            sortBy = option
+                        } label: {
+                            HStack {
+                                Text(option.label)
+                                if sortBy == option {
+                                    Image(systemName: "checkmark")
+                                }
+                            }
+                        }
+                    }
+                    Divider()
+                    Button {
+                        loadLabels()
+                    } label: {
+                        Label("Refresh", systemImage: "arrow.clockwise")
+                    }
+                } label: {
+                    Image(systemName: "arrow.up.arrow.down")
+                }
+            }
+        }
+        .task { loadLabels() }
+        .onChange(of: appState.libraryCache.generation) { _, _ in loadLabels() }
+        .onChange(of: searchText) { recomputeFilteredLabels() }
+        .onChange(of: sortBy) { recomputeFilteredLabels() }
+        .refreshable { loadLabels() }
+    }
+
+    // MARK: - List view
+
+    private var labelList: some View {
+        List(cachedFilteredLabels) { labelInfo in
+            NavigationLink {
+                AlbumsView(listType: .alphabeticalByName, title: labelInfo.name, initialLabelFilter: labelInfo.name)
+            } label: {
+                HStack(spacing: 12) {
+                    LabelIconView(labelName: labelInfo.name, coverArtId: labelArt[labelInfo.name])
+                        .frame(width: 48, height: 48)
+                        .clipShape(RoundedRectangle(cornerRadius: 8))
+
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(labelInfo.name)
+                            .font(.body)
+                        Text(verbatim: "\(labelInfo.albumCount) albums")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                }
+            }
+            .accessibilityIdentifier("labelRow_\(labelInfo.name)")
+        }
+        .listStyle(.plain)
+    }
+
+    // MARK: - Grid view
+
+    private var labelGrid: some View {
+        ScrollView {
+            LazyVGrid(columns: [
+                GridItem(.adaptive(minimum: 160, maximum: 220), spacing: 16)
+            ], spacing: 20) {
+                ForEach(cachedFilteredLabels) { labelInfo in
+                    NavigationLink {
+                        AlbumsView(listType: .alphabeticalByName, title: labelInfo.name, initialLabelFilter: labelInfo.name)
+                    } label: {
+                        labelCard(labelInfo)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityIdentifier("labelCard_\(labelInfo.name)")
+                }
+            }
+            .padding(16)
+        }
+    }
+
+    private func labelCard(_ labelInfo: LabelInfo) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            LabelIconView(labelName: labelInfo.name, coverArtId: labelArt[labelInfo.name])
+                .aspectRatio(1, contentMode: .fit)
+                .clipShape(RoundedRectangle(cornerRadius: 10))
+                .shadow(color: .black.opacity(0.15), radius: 6, y: 3)
+
+            Text(labelInfo.name)
+                .font(.subheadline)
+                .fontWeight(.medium)
+                .foregroundColor(.primary)
+                .lineLimit(1)
+
+            Text(verbatim: "\(labelInfo.albumCount) albums")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+        }
+    }
+
+    private func recomputeFilteredLabels() {
+        cachedFilteredLabels = computeFilteredLabels()
+    }
+
+    private func loadLabels() {
+        let cache = appState.libraryCache
+        guard let counts = cache.labelCounts else {
+            // Cache not ready yet — wait for generation bump, nothing to show
+            isLoading = true
+            return
+        }
+        labels = counts
+            .map { LabelInfo(name: $0.key, albumCount: $0.value) }
+            .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+        labelArt = cache.labelArt ?? [:]
+        recomputeFilteredLabels()
+        isLoading = false
+    }
+}
+
+// MARK: - Label Icon View
+
+struct LabelIconView: View {
+    let labelName: String
+    let coverArtId: String?
+
+    var body: some View {
+        if let coverArtId {
+            AlbumArtView(coverArtId: coverArtId, size: 48, cornerRadius: 8)
+        } else {
+            ZStack {
+                LinearGradient(
+                    colors: [.init(red: 0.4, green: 0.5, blue: 0.7), .init(red: 0.2, green: 0.3, blue: 0.5)],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+                Image(systemName: "tag.fill")
+                    .font(.title2)
+                    .foregroundColor(.white.opacity(0.9))
+            }
+        }
+    }
+}

--- a/Vibrdrome/Features/Library/SidebarContentView.swift
+++ b/Vibrdrome/Features/Library/SidebarContentView.swift
@@ -50,7 +50,7 @@ struct SidebarContentView: View {
 
     enum SidebarItem: String, CaseIterable, Hashable {
         case home
-        case artists, albums, songs, genres, favorites, recentlyAdded, mostPlayed, recentlyPlayed
+        case artists, albums, songs, genres, labels, favorites, recentlyAdded, mostPlayed, recentlyPlayed
         case bookmarks, folders
         case search
         case playlists
@@ -87,6 +87,10 @@ struct SidebarContentView: View {
                         .tag(SidebarItem.songs.rawValue)
                     Label("Genres", systemImage: "guitars")
                         .tag(SidebarItem.genres.rawValue)
+                    #if os(macOS)
+                    Label("Labels", systemImage: "tag")
+                        .tag(SidebarItem.labels.rawValue)
+                    #endif
                     Label("Favorites", systemImage: "heart.fill")
                         .tag(SidebarItem.favorites.rawValue)
                     Label("Recently Added", systemImage: "clock")
@@ -315,6 +319,12 @@ struct SidebarContentView: View {
             SongsView()
         case .genres:
             GenresView()
+        case .labels:
+            #if os(macOS)
+            LabelsView()
+            #else
+            EmptyView()
+            #endif
         case .favorites:
             FavoritesView()
         case .recentlyAdded:


### PR DESCRIPTION
Supersedes #23 (rebased onto develop with only this commit).

Adds a "Labels" section to the macOS sidebar that lets users browse albums by record label.

## Changes
- **New**: `LabelsView.swift` — Displays all record labels derived from the SwiftData `CachedAlbum` cache, with list/grid toggle, search, and sort (name / album count). Each label shows a cover art thumbnail from one of its albums.
- **Modified**: `AlbumsView.swift` — Wires label filtering through the existing `initialLabelFilter` / `initialGenreFilter` pattern so label-filtered album views integrate cleanly with the filter panel and scroll snapshot machinery.
- **Modified**: `SidebarContentView.swift` — Added `labels` case to `SidebarItem` and a sidebar entry wrapped in `#if os(macOS)`.

## Scope
macOS only — no changes to the iOS tab bar, settings, or UserDefaults keys.
Requires a library sync to populate label data from album metadata.