### PR TITLE
feat(macOS): play/pause button on album grid card hover overlay

### DIFF
--- a/Vibrdrome/Shared/Components/AlbumGridCard.swift
+++ b/Vibrdrome/Shared/Components/AlbumGridCard.swift
@@ -8,6 +8,8 @@ struct AlbumGridCard: View {
     @State private var currentRating: Int
     #if os(macOS)
     @State private var isHovered = false
+    @State private var isLoadingPlay = false
+    @Environment(AppState.self) private var appState
     #endif
 
     init(album: Album, cellWidth: CGFloat = 180) {
@@ -53,6 +55,8 @@ struct AlbumGridCard: View {
                     #if os(macOS)
                     if isHovered {
                         hoverOverlay
+                        playButton
+                            .frame(maxWidth: .infinity, maxHeight: .infinity)
                     }
                     #endif
                 }
@@ -134,6 +138,51 @@ struct AlbumGridCard: View {
                 .accessibilityLabel("\(star) star\(star == 1 ? "" : "s")")
             }
         }
+    }
+
+    private var isThisAlbumPlaying: Bool {
+        AudioEngine.shared.isPlaying &&
+        AudioEngine.shared.currentSong?.albumId == album.id
+    }
+
+    private var playButton: some View {
+        Button {
+            guard !isLoadingPlay else { return }
+            if isThisAlbumPlaying {
+                AudioEngine.shared.pause()
+            } else if AudioEngine.shared.currentSong?.albumId == album.id {
+                AudioEngine.shared.togglePlayPause()
+            } else {
+                isLoadingPlay = true
+                Task {
+                    defer { isLoadingPlay = false }
+                    do {
+                        let detail = try await appState.subsonicClient.getAlbum(id: album.id)
+                        let songs = detail.song ?? []
+                        guard let first = songs.first else { return }
+                        AudioEngine.shared.play(song: first, from: songs, at: 0)
+                    } catch {}
+                }
+            }
+        } label: {
+            Group {
+                if isLoadingPlay {
+                    ProgressView()
+                        .controlSize(.small)
+                        .tint(.white)
+                } else {
+                    Image(systemName: isThisAlbumPlaying ? "pause.fill" : "play.fill")
+                        .font(.system(size: 22, weight: .medium))
+                        .foregroundStyle(.white)
+                }
+            }
+            .shadow(color: .black.opacity(0.9), radius: 6, y: 2)
+            .shadow(color: .black.opacity(0.7), radius: 2, y: 1)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(isThisAlbumPlaying ? "Pause" : "Play Album")
+        .transition(.opacity.combined(with: .scale(scale: 0.85)))
+        .animation(.easeInOut(duration: 0.15), value: isHovered)
     }
     #endif
 }


### PR DESCRIPTION
## Summary

- Adds a centered `play.fill` / `pause.fill` button to the `AlbumGridCard` hover overlay on macOS
- Fetches album songs via `getAlbum` on first tap, then starts playback from track 1
- Toggles to `pause.fill` and pauses when the album is already the active queue; resumes if paused
- Shows a `ProgressView` spinner while loading songs
- Matches the visual style of the existing heart and star buttons (white icon, dual drop-shadow, `.easeInOut(duration: 0.15)` fade + scale transition)
- macOS-only behind `#if os(macOS)` — no iOS/watchOS impact

## Test plan

- [x] Hover an album card — play button appears centered on the artwork alongside heart/stars
- [x] Click play — spinner shows briefly, then album starts playing from track 1
- [x] While playing, hover the same card — button shows `pause.fill`; click pauses playback
- [x] While paused on the same album, click — resumes playback
- [x] Click play on a different album card — switches queue and starts playing
- [x] Mouse-out and back in — button animates in/out cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)