### PR TITLE
feat(export): macOS playlist export with sync and ffmpeg transcode

### DIFF
--- a/Vibrdrome/App/AppState.swift
+++ b/Vibrdrome/App/AppState.swift
@@ -159,10 +159,13 @@ final class AppState {
         LibrarySyncManager.shared.client = subsonicClient
         LibrarySyncManager.shared.container = PersistenceController.shared.container
 
-        // Probe Navidrome native API in background — sets navidromeClient if available.
+        // Probe Navidrome native API in background — clears navidromeClient when not Navidrome.
         let ndClient = NavidromeNativeClient(baseURL: serverURL, username: username, password: password)
         navidromeClient = ndClient
-        Task { await ndClient.probe() }
+        Task {
+            let available = await ndClient.probe()
+            if !available { navidromeClient = nil }
+        }
     }
 
     func loadSavedCredentials() {

--- a/Vibrdrome/App/AppState.swift
+++ b/Vibrdrome/App/AppState.swift
@@ -25,6 +25,8 @@ final class AppState {
     static let shared = AppState()
 
     var subsonicClient: SubsonicClient
+    /// Non-nil when the active server is Navidrome and native API auth succeeded.
+    var navidromeClient: NavidromeNativeClient?
     var isConfigured: Bool = false
     var requiresReAuth: Bool = false
 
@@ -63,6 +65,9 @@ final class AppState {
         case queue, lyrics, artistInfo, albumFilters, artistFilters, songFilters
     }
     var activeSidePanel: SidePanel?
+
+    /// Context currently shown in the popped-out filter window.
+    var activeFilterWindowContext: FilterContext?
 
     /// Filter state for the macOS filter sidebars.
     var albumFilter = LibraryFilter()
@@ -115,6 +120,7 @@ final class AppState {
         )
         loadServers()
         loadSavedCredentials()
+        configureFilterPersistence()
 
         // UI testing: auto-login with credentials from environment variables
         // so XCUITest doesn't have to type them (avoids idle-wait SIGKILL).
@@ -126,6 +132,12 @@ final class AppState {
            !url.isEmpty {
             saveCredentials(url: url, username: user, password: pass)
         }
+    }
+
+    private func configureFilterPersistence() {
+        albumFilter.loadRuleSet(from: UserDefaultsKeys.albumFilterRuleSet)
+        artistFilter.loadRuleSet(from: UserDefaultsKeys.artistFilterRuleSet)
+        songFilter.loadRuleSet(from: UserDefaultsKeys.songFilterRuleSet)
     }
 
     func configure(url: String, username: String, password: String) {
@@ -146,6 +158,11 @@ final class AppState {
         #endif
         LibrarySyncManager.shared.client = subsonicClient
         LibrarySyncManager.shared.container = PersistenceController.shared.container
+
+        // Probe Navidrome native API in background — sets navidromeClient if available.
+        let ndClient = NavidromeNativeClient(baseURL: serverURL, username: username, password: password)
+        navidromeClient = ndClient
+        Task { await ndClient.probe() }
     }
 
     func loadSavedCredentials() {
@@ -239,6 +256,7 @@ final class AppState {
         artistFilter = LibraryFilter()
         songFilter = LibraryFilter()
         albumsViewSnapshots = [:]
+        configureFilterPersistence()
     }
 
     func clearCredentials() {
@@ -249,6 +267,7 @@ final class AppState {
         requiresReAuth = false
         serverURL = ""
         username = ""
+        navidromeClient = nil
         resetLibraryFilterState()
         // Reset the client so stale creds aren't used
         subsonicClient.updateCredentials(

--- a/Vibrdrome/Core/Constants/UserDefaultsKeys.swift
+++ b/Vibrdrome/Core/Constants/UserDefaultsKeys.swift
@@ -175,6 +175,15 @@ enum UserDefaultsKeys {
     static let songFilterRuleBuilderExpanded = "songFilterRuleBuilderExpanded"
     static let artistFilterRuleBuilderExpanded = "artistFilterRuleBuilderExpanded"
 
+    // MARK: - Playlist Export
+
+    static let exportDefaultFolderBookmark = "exportDefaultFolderBookmark"
+    static let exportDefaultSyncMode = "exportDefaultSyncMode"
+    static let exportDefaultTranscodeFormat = "exportDefaultTranscodeFormat"
+    static let exportDefaultTranscodeBitrate = "exportDefaultTranscodeBitrate"
+    static let exportFfmpegPath = "exportFfmpegPath"
+    static let exportAutoSyncOnForeground = "exportAutoSyncOnForeground"
+
     // MARK: - Library Sync
 
     static let lastLibrarySyncDate = "lastLibrarySyncDate"

--- a/Vibrdrome/Core/Constants/UserDefaultsKeys.swift
+++ b/Vibrdrome/Core/Constants/UserDefaultsKeys.swift
@@ -166,6 +166,15 @@ enum UserDefaultsKeys {
     static let macSidePanelWidth = "macSidePanelWidth"
     static let macMiniPlayerPanelTrigger = "macMiniPlayerPanelTrigger"
 
+    // MARK: - Advanced Filter Rule Sets
+
+    static let albumFilterRuleSet = "albumFilterRuleSet"
+    static let songFilterRuleSet = "songFilterRuleSet"
+    static let artistFilterRuleSet = "artistFilterRuleSet"
+    static let albumFilterRuleBuilderExpanded = "albumFilterRuleBuilderExpanded"
+    static let songFilterRuleBuilderExpanded = "songFilterRuleBuilderExpanded"
+    static let artistFilterRuleBuilderExpanded = "artistFilterRuleBuilderExpanded"
+
     // MARK: - Library Sync
 
     static let lastLibrarySyncDate = "lastLibrarySyncDate"

--- a/Vibrdrome/Core/Export/PlaylistExportManager.swift
+++ b/Vibrdrome/Core/Export/PlaylistExportManager.swift
@@ -1,0 +1,594 @@
+#if os(macOS)
+import AppKit
+import Foundation
+import SwiftData
+import os.log
+
+private let exportLog = Logger(subsystem: "com.vibrdrome.app", category: "PlaylistExport")
+
+@MainActor
+final class PlaylistExportManager: ObservableObject {
+    static let shared = PlaylistExportManager()
+
+    @Published var syncingPlaylistIds: Set<String> = []
+
+    private var syncTasksByKey: [String: Task<Void, Never>] = [:]
+
+    // MARK: - Folder Picker
+
+    func pickFolder() async -> URL? {
+        await withCheckedContinuation { continuation in
+            let panel = NSOpenPanel()
+            panel.canChooseFiles = false
+            panel.canChooseDirectories = true
+            panel.allowsMultipleSelection = false
+            panel.prompt = "Choose Export Folder"
+            panel.begin { response in
+                guard response == .OK, let url = panel.url else {
+                    continuation.resume(returning: nil)
+                    return
+                }
+                continuation.resume(returning: url)
+            }
+        }
+    }
+
+    func bookmarkData(for url: URL) throws -> Data {
+        try url.bookmarkData(
+            options: .withSecurityScope,
+            includingResourceValuesForKeys: nil,
+            relativeTo: nil
+        )
+    }
+
+    // MARK: - Bookmark Resolution
+
+    func resolveBookmark(_ data: Data) throws -> (URL, Bool) {
+        var isStale = false
+        let url = try URL(
+            resolvingBookmarkData: data,
+            options: .withSecurityScope,
+            relativeTo: nil,
+            bookmarkDataIsStale: &isStale
+        )
+        return (url, isStale)
+    }
+
+    // MARK: - Export Path
+
+    nonisolated static func exportPath(song: Song, playlistName: String, suffix: String) -> String {
+        let playlist = playlistName.sanitizedFileName
+        let artist = (song.artist ?? "Unknown Artist").sanitizedFileName
+        let title = song.title.sanitizedFileName
+        let safeName = title.isEmpty ? song.id : title
+        return "\(playlist)/\(artist) - \(safeName).\(suffix)"
+    }
+
+    // Returns the final on-disk suffix after optional transcoding.
+    nonisolated static func finalSuffix(originalSuffix: String, transcodeFormat: String?) -> String {
+        transcodeFormat ?? originalSuffix
+    }
+
+    // MARK: - Sync
+
+    func sync(export: ExportedPlaylist, client: SubsonicClient) async {
+        guard !syncingPlaylistIds.contains(export.compositeKey) else { return }
+        guard let bookmarkData = export.folderBookmarkData else {
+            export.lastSyncError = "No export folder configured."
+            try? PersistenceController.shared.container.mainContext.save()
+            return
+        }
+
+        let task = Task<Void, Never> {
+            await performSync(export: export, bookmarkData: bookmarkData, client: client)
+        }
+        syncTasksByKey[export.compositeKey] = task
+        syncingPlaylistIds.insert(export.compositeKey)
+        await task.value
+        syncingPlaylistIds.remove(export.compositeKey)
+        syncTasksByKey.removeValue(forKey: export.compositeKey)
+    }
+
+    private func performSync(export: ExportedPlaylist, bookmarkData: Data, client: SubsonicClient) async {
+        guard let folderURL = resolveAccessibleFolder(export: export, bookmarkData: bookmarkData) else { return }
+        defer { folderURL.stopAccessingSecurityScopedResource() }
+
+        let newSongs: [Song]
+        do {
+            let playlist = try await client.getPlaylist(id: export.playlistId)
+            newSongs = playlist.entry ?? []
+        } catch {
+            export.lastSyncError = "Failed to fetch playlist: \(error.localizedDescription)"
+            try? PersistenceController.shared.container.mainContext.save()
+            exportLog.error("Failed to fetch playlist \(export.playlistId): \(error)")
+            return
+        }
+
+        let formatChanged = export.transcodeFormat != export.appliedTranscodeFormat
+        let effectiveKnownIds: [String] = formatChanged ? [] : export.knownSongIds
+        let effectiveKnownPaths: [String: String] = formatChanged ? [:] : export.knownSongPaths
+        if formatChanged {
+            exportLog.info("Transcode format changed for \(export.playlistName), forcing full re-sync")
+        }
+
+        let newSongIds = newSongs.map(\.id)
+        let addedIds = Set(newSongIds).subtracting(Set(effectiveKnownIds))
+        let removedIds = Set(effectiveKnownIds).subtracting(Set(newSongIds))
+
+        let (downloadedPaths, failedSongs) = await downloadAddedSongs(
+            newSongs.filter { addedIds.contains($0.id) },
+            folderURL: folderURL,
+            export: export,
+            client: client
+        )
+
+        if export.syncModeEnum == .addAndRemove {
+            removeDeletedFiles(removedIds: removedIds, knownPaths: effectiveKnownPaths, folderURL: folderURL)
+        }
+
+        let diff = SyncDiff(
+            downloadedPaths: downloadedPaths,
+            removedIds: removedIds,
+            failedSongs: failedSongs,
+            formatChanged: formatChanged
+        )
+        saveUpdatedState(
+            export: export,
+            effectiveKnownIds: effectiveKnownIds,
+            effectiveKnownPaths: effectiveKnownPaths,
+            diff: diff
+        )
+    }
+
+    private func resolveAccessibleFolder(export: ExportedPlaylist, bookmarkData: Data) -> URL? {
+        let (folderURL, isStale): (URL, Bool)
+        do {
+            (folderURL, isStale) = try resolveBookmark(bookmarkData)
+        } catch {
+            export.lastSyncError = "Folder access lost. Please re-select the export folder."
+            export.isActive = false
+            try? PersistenceController.shared.container.mainContext.save()
+            exportLog.error("Bookmark resolution failed for \(export.playlistName): \(error)")
+            return nil
+        }
+        guard folderURL.startAccessingSecurityScopedResource() else {
+            export.lastSyncError = "Could not access the export folder."
+            try? PersistenceController.shared.container.mainContext.save()
+            return nil
+        }
+        if isStale, let newData = try? self.bookmarkData(for: folderURL) {
+            export.folderBookmarkData = newData
+        }
+        return folderURL
+    }
+
+    private func downloadAddedSongs(
+        _ songs: [Song],
+        folderURL: URL,
+        export: ExportedPlaylist,
+        client: SubsonicClient
+    ) async -> ([String: String], [(id: String, title: String)]) {
+        var downloadedPaths: [String: String] = [:]
+        var failedSongs: [(id: String, title: String)] = []
+
+        let playlistName = export.playlistName
+        let transcodeFormat = export.transcodeFormat
+        let transcodeBitrate = export.transcodeBitrate
+
+        await withTaskGroup(of: (String, String?, String).self) { group in
+            var songQueue = songs
+            var inFlight = 0
+
+            func launchNext() {
+                guard !songQueue.isEmpty else { return }
+                let song = songQueue.removeFirst()
+                inFlight += 1
+                let songId = song.id
+                let songTitle = song.title
+                let originalSuffix = song.suffix ?? "mp3"
+                let finalSuffix = PlaylistExportManager.finalSuffix(
+                    originalSuffix: originalSuffix, transcodeFormat: transcodeFormat)
+                // downloadSong writes the original then transcodes in-place, so the
+                // download destination uses the original suffix; the stored path
+                // uses the final suffix so re-syncs can detect the file correctly.
+                let downloadRelativePath = PlaylistExportManager.exportPath(
+                    song: song, playlistName: playlistName, suffix: originalSuffix)
+                let finalRelativePath = PlaylistExportManager.exportPath(
+                    song: song, playlistName: playlistName, suffix: finalSuffix)
+                let target = DownloadTarget(
+                    downloadURL: folderURL.appendingPathComponent(downloadRelativePath),
+                    finalURL: folderURL.appendingPathComponent(finalRelativePath)
+                )
+                group.addTask {
+                    do {
+                        try await PlaylistExportManager.shared.downloadSong(
+                            song: song, target: target,
+                            transcodeFormat: transcodeFormat,
+                            transcodeBitrate: transcodeBitrate,
+                            client: client
+                        )
+                        return (songId, finalRelativePath, songTitle)
+                    } catch {
+                        exportLog.error("Failed to download \(songTitle): \(error)")
+                        return (songId, nil, songTitle)
+                    }
+                }
+            }
+
+            for _ in 0..<min(3, songQueue.count) { launchNext() }
+            for await (songId, path, songTitle) in group {
+                inFlight -= 1
+                if let path {
+                    downloadedPaths[songId] = path
+                } else {
+                    failedSongs.append((id: songId, title: songTitle))
+                }
+                launchNext()
+                _ = inFlight
+            }
+        }
+
+        return (downloadedPaths, failedSongs)
+    }
+
+    private func removeDeletedFiles(removedIds: Set<String>, knownPaths: [String: String], folderURL: URL) {
+        for songId in removedIds {
+            guard let relativePath = knownPaths[songId] else { continue }
+            let fileURL = folderURL.appendingPathComponent(relativePath)
+            try? FileManager.default.removeItem(at: fileURL)
+            exportLog.info("Removed \(relativePath) from export")
+        }
+    }
+
+    private struct SyncDiff {
+        var downloadedPaths: [String: String]
+        var removedIds: Set<String>
+        var failedSongs: [(id: String, title: String)]
+        var formatChanged: Bool
+    }
+
+    private func saveUpdatedState(
+        export: ExportedPlaylist,
+        effectiveKnownIds: [String],
+        effectiveKnownPaths: [String: String],
+        diff: SyncDiff
+    ) {
+        var updatedPaths = effectiveKnownPaths
+        for removedId in diff.removedIds { updatedPaths.removeValue(forKey: removedId) }
+        for (id, path) in diff.downloadedPaths { updatedPaths[id] = path }
+
+        var updatedIds = effectiveKnownIds.filter { !diff.removedIds.contains($0) }
+        for id in diff.downloadedPaths.keys where !updatedIds.contains(id) { updatedIds.append(id) }
+
+        export.knownSongIds = updatedIds
+        export.knownSongPaths = updatedPaths
+        export.lastSyncedAt = Date()
+        export.failedSongIds = diff.failedSongs.map(\.id)
+        export.failedSongTitles = diff.failedSongs.map(\.title)
+        export.lastSyncError = diff.failedSongs.isEmpty ? nil : "\(diff.failedSongs.count) song(s) failed to download."
+        if diff.failedSongs.isEmpty {
+            export.appliedTranscodeFormat = export.transcodeFormat
+        }
+
+        do {
+            try PersistenceController.shared.container.mainContext.save()
+        } catch {
+            exportLog.error("Failed to save export state: \(error)")
+        }
+    }
+
+    private struct DownloadTarget {
+        let downloadURL: URL
+        let finalURL: URL
+    }
+
+    private func downloadSong(
+        song: Song,
+        target: DownloadTarget,
+        transcodeFormat: String?,
+        transcodeBitrate: Int?,
+        client: SubsonicClient
+    ) async throws {
+        // Skip if the final on-disk file already exists (handles transcoded re-syncs correctly).
+        if FileManager.default.fileExists(atPath: target.finalURL.path) {
+            return
+        }
+
+        let sourceURL = client.downloadURL(id: song.id)
+        let (tempURL, _) = try await URLSession.shared.download(from: sourceURL)
+
+        let dir = target.downloadURL.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        if FileManager.default.fileExists(atPath: target.downloadURL.path) {
+            try FileManager.default.removeItem(at: target.downloadURL)
+        }
+        try FileManager.default.moveItem(at: tempURL, to: target.downloadURL)
+
+        if let format = transcodeFormat {
+            try await transcodeFile(at: target.downloadURL, toFormat: format, bitrate: transcodeBitrate)
+        }
+
+        // The file is now at finalURL (transcode replaced downloadURL in-place, or they are the same).
+        // Embed tags from cache and cover art from server/cache.
+        await embedTagsAndArt(in: target.finalURL, song: song, client: client)
+    }
+
+    // MARK: - Tag and Cover Art Embedding
+
+    private func embedTagsAndArt(in fileURL: URL, song: Song, client: SubsonicClient) async {
+        guard let ffmpegPath = await resolveFfmpegPath() else { return }
+
+        let artData: Data? = await fetchCoverArt(for: song, client: client)
+        let cached = cachedSong(id: song.id)
+
+        var (args, artTempURL) = buildTagArgs(
+            song: song, cached: cached, ffmpegPath: ffmpegPath, fileURL: fileURL, artData: artData
+        )
+        defer { artTempURL.map { try? FileManager.default.removeItem(at: $0) } }
+        guard !args.isEmpty else { return }
+
+        let tempOut = fileURL.deletingPathExtension()
+            .appendingPathExtension("_tagged")
+            .appendingPathExtension(fileURL.pathExtension)
+
+        args.append(tempOut.path)
+
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: ffmpegPath)
+            process.arguments = args
+            process.standardOutput = FileHandle.nullDevice
+            process.standardError = FileHandle.nullDevice
+            process.terminationHandler = { proc in
+                if proc.terminationStatus == 0 {
+                    try? FileManager.default.removeItem(at: fileURL)
+                    try? FileManager.default.moveItem(at: tempOut, to: fileURL)
+                } else {
+                    try? FileManager.default.removeItem(at: tempOut)
+                    exportLog.warning("Tag embedding failed for \(fileURL.lastPathComponent), keeping untagged file")
+                }
+                continuation.resume()
+            }
+            do {
+                try process.run()
+            } catch {
+                try? FileManager.default.removeItem(at: tempOut)
+                continuation.resume()
+            }
+        }
+    }
+
+    private func buildTagArgs(
+        song: Song,
+        cached: CachedSong?,
+        ffmpegPath: String,
+        fileURL: URL,
+        artData: Data?
+    ) -> ([String], URL?) {
+        let title = cached?.title ?? song.title
+        let artist = cached?.artist ?? song.artist
+        let albumArtist = cached?.albumArtist ?? song.albumArtist
+        let album = cached?.albumName ?? song.album
+        let track = cached?.track ?? song.track
+        let disc = cached?.discNumber ?? song.discNumber
+        let year = cached?.year ?? song.year
+        let genre = cached?.genre ?? song.genre
+        let comment = cached?.comment ?? song.comment
+        let format = fileURL.pathExtension.lowercased()
+
+        var artTempURL: URL?
+        if let data = artData {
+            let tmp = FileManager.default.temporaryDirectory
+                .appendingPathComponent(UUID().uuidString)
+                .appendingPathExtension("jpg")
+            try? data.write(to: tmp)
+            artTempURL = tmp
+        }
+
+        var args: [String]
+        if let artURL = artTempURL {
+            args = ["-i", fileURL.path, "-i", artURL.path,
+                    "-map", "0:a", "-map", "1:0",
+                    "-map_metadata", "0",
+                    "-c:a", "copy", "-c:v", "copy", "-y"]
+            switch format {
+            case "mp3":
+                args += ["-id3v2_version", "3"]
+            case "aac", "m4a":
+                args += ["-disposition:v", "attached_pic"]
+            default:
+                break
+            }
+        } else {
+            args = ["-i", fileURL.path, "-map", "0",
+                    "-map_metadata", "0",
+                    "-c", "copy", "-y"]
+            if format == "mp3" { args += ["-id3v2_version", "3"] }
+        }
+
+        func meta(_ key: String, _ value: String?) {
+            guard let value, !value.isEmpty else { return }
+            args += ["-metadata", "\(key)=\(value)"]
+        }
+
+        meta("title", title)
+        meta("artist", artist)
+        meta("album_artist", albumArtist)
+        meta("album", album)
+        meta("genre", genre)
+        meta("comment", comment)
+        if let track { meta("track", "\(track)") }
+        if let disc { meta("disc", "\(disc)") }
+        if let year { meta("date", "\(year)") }
+
+        return (args, artTempURL)
+    }
+
+    private func fetchCoverArt(for song: Song, client: SubsonicClient) async -> Data? {
+        guard let coverArtId = song.coverArt else { return nil }
+
+        // Request JPEG explicitly — strip any webp param added by supportsWebP,
+        // as ffmpeg requires a raster format it can decode as a video stream.
+        var components = URLComponents(
+            url: client.coverArtURL(id: coverArtId),
+            resolvingAgainstBaseURL: false
+        )
+        var queryItems = (components?.queryItems ?? []).filter { $0.name != "format" }
+        queryItems.append(URLQueryItem(name: "format", value: "jpeg"))
+        components?.queryItems = queryItems
+        guard let artURL = components?.url else { return nil }
+
+        return try? await URLSession.shared.data(from: artURL).0
+    }
+
+    private func cachedSong(id: String) -> CachedSong? {
+        let context = PersistenceController.shared.container.mainContext
+        var descriptor = FetchDescriptor<CachedSong>(
+            predicate: #Predicate { $0.id == id }
+        )
+        descriptor.fetchLimit = 1
+        return try? context.fetch(descriptor).first
+    }
+
+    // MARK: - Transcoding
+
+    func transcodeFile(at fileURL: URL, toFormat format: String, bitrate: Int?) async throws {
+        let ffmpegPath = await resolveFfmpegPath()
+        guard let ffmpegPath else {
+            throw ExportError.ffmpegNotFound
+        }
+
+        // Always write to a temp path — ffmpeg refuses input == output, which happens
+        // when the source suffix already matches the target format (e.g. mp3 → mp3).
+        let tempOutputURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension(format)
+        let finalOutputURL = fileURL.deletingPathExtension().appendingPathExtension(format)
+
+        var args = ["-i", fileURL.path, "-map", "0", "-map_metadata", "0", "-c:v", "copy", "-y"]
+        if let bitrate {
+            args += ["-b:a", "\(bitrate)k"]
+        }
+        switch format {
+        case "mp3":
+            args += ["-id3v2_version", "3"]
+        case "aac", "m4a":
+            args += ["-disposition:v", "attached_pic"]
+        default:
+            break
+        }
+        args.append(tempOutputURL.path)
+
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: ffmpegPath)
+            process.arguments = args
+            process.standardOutput = FileHandle.nullDevice
+            process.standardError = FileHandle.nullDevice
+            process.terminationHandler = { proc in
+                if proc.terminationStatus == 0 {
+                    try? FileManager.default.removeItem(at: fileURL)
+                    try? FileManager.default.moveItem(at: tempOutputURL, to: finalOutputURL)
+                    continuation.resume()
+                } else {
+                    try? FileManager.default.removeItem(at: tempOutputURL)
+                    continuation.resume(throwing: ExportError.transcodeFailed(status: proc.terminationStatus))
+                }
+            }
+            do {
+                try process.run()
+            } catch {
+                try? FileManager.default.removeItem(at: tempOutputURL)
+                continuation.resume(throwing: error)
+            }
+        }
+    }
+
+    private func resolveFfmpegPath() async -> String? {
+        let stored = UserDefaults.standard.string(forKey: UserDefaultsKeys.exportFfmpegPath) ?? ""
+        if !stored.isEmpty && FileManager.default.fileExists(atPath: stored) {
+            return stored
+        }
+        let defaults = ["/usr/local/bin/ffmpeg", "/opt/homebrew/bin/ffmpeg", "/usr/bin/ffmpeg"]
+        for path in defaults where FileManager.default.fileExists(atPath: path) {
+            return path
+        }
+        // Try `which ffmpeg`
+        return await withCheckedContinuation { continuation in
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/which")
+            process.arguments = ["ffmpeg"]
+            let pipe = Pipe()
+            process.standardOutput = pipe
+            process.terminationHandler = { _ in
+                let data = pipe.fileHandleForReading.readDataToEndOfFile()
+                let path = String(data: data, encoding: .utf8)?
+                    .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+                continuation.resume(returning: path.isEmpty ? nil : path)
+            }
+            try? process.run()
+        }
+    }
+
+    // MARK: - Bulk Sync
+
+    func syncAllActive(client: SubsonicClient) async {
+        let context = PersistenceController.shared.container.mainContext
+        let descriptor = FetchDescriptor<ExportedPlaylist>(
+            predicate: #Predicate { $0.isActive == true }
+        )
+        guard let exports = try? context.fetch(descriptor) else { return }
+        for export in exports {
+            await sync(export: export, client: client)
+        }
+    }
+
+    // MARK: - Cancel
+
+    func cancelSync(for compositeKey: String) {
+        syncTasksByKey[compositeKey]?.cancel()
+        syncTasksByKey.removeValue(forKey: compositeKey)
+        syncingPlaylistIds.remove(compositeKey)
+    }
+
+    func removeExport(_ export: ExportedPlaylist) {
+        cancelSync(for: export.compositeKey)
+        let context = PersistenceController.shared.container.mainContext
+        context.delete(export)
+        try? context.save()
+    }
+
+    // MARK: - ffmpeg Test
+
+    func testFfmpeg(path: String) async -> Bool {
+        await withCheckedContinuation { continuation in
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: path)
+            process.arguments = ["-version"]
+            process.standardOutput = FileHandle.nullDevice
+            process.standardError = FileHandle.nullDevice
+            process.terminationHandler = { proc in
+                continuation.resume(returning: proc.terminationStatus == 0)
+            }
+            guard (try? process.run()) != nil else {
+                continuation.resume(returning: false)
+                return
+            }
+        }
+    }
+}
+
+enum ExportError: LocalizedError {
+    case ffmpegNotFound
+    case transcodeFailed(status: Int32)
+
+    var errorDescription: String? {
+        switch self {
+        case .ffmpegNotFound:
+            "ffmpeg not found. Configure the path in Settings → Playlist Export."
+        case .transcodeFailed(let status):
+            "Transcoding failed with exit code \(status)."
+        }
+    }
+}
+#endif

--- a/Vibrdrome/Core/Models/FilterRule.swift
+++ b/Vibrdrome/Core/Models/FilterRule.swift
@@ -145,7 +145,7 @@ enum FilterField: String, CaseIterable, Codable, Sendable {
         }
     }
 
-    enum FieldKind { case text, numeric, days, boolean, playlist }
+    enum FieldKind: Sendable { case text, numeric, days, boolean, playlist }
 }
 
 // MARK: - Operator
@@ -585,7 +585,8 @@ struct FilterRuleSet: Codable, Sendable, Equatable {
         init(album: Album) {
             title = album.name
             artist = album.artist
-            genre = album.allGenres.first
+            // Join all genres so text operators (contains / equals) match any genre, not just the first.
+            genre = album.allGenres.isEmpty ? nil : album.allGenres.joined(separator: ", ")
             label = album.label
             year = album.year
             duration = album.duration

--- a/Vibrdrome/Core/Models/FilterRule.swift
+++ b/Vibrdrome/Core/Models/FilterRule.swift
@@ -218,7 +218,15 @@ enum FilterOperator: String, CaseIterable, Codable, Sendable {
         case .before:          "before"
         case .after:           "after"
         case .isTrue:          "is"
-        case .isInPlaylist:    "in playlist"
+        case .isInPlaylist:    "is"
+        }
+    }
+
+    /// False for operators that have no Navidrome smart playlist equivalent and are silently dropped on save.
+    var nspSupported: Bool {
+        switch self {
+        case .matchesRegex, .isGreaterOrEqual, .isLessOrEqual: return false
+        default: return true
         }
     }
 
@@ -492,6 +500,8 @@ struct FilterRuleSet: Codable, Sendable, Equatable {
             .artistRating, .artistPlayCount, .artistFavorited,
             .bitDepth, .sampleRate, .size, .channels, .comment,
             .hasCoverArt, .isCompilation, .dateAdded,
+            .dateLoved, .albumLastPlayed, .albumDateLoved,
+            .mbzAlbumId,
         ]
         return rules.contains { !$0.isEffectivelyEmpty && cachedFields.contains($0.field) }
     }
@@ -555,7 +565,11 @@ struct FilterRuleSet: Codable, Sendable, Equatable {
         let size: Int?
         let channels: Int?
         let mbzRecordingId: String?
+        let mbzAlbumId: String?
         let dateAdded: Date?
+        let dateLoved: Date?
+        let albumLastPlayed: Date?
+        let albumDateLoved: Date?
 
         init(song: Song, extras: CachedSongExtras? = nil) {
             title = song.title
@@ -585,7 +599,11 @@ struct FilterRuleSet: Codable, Sendable, Equatable {
             size = song.size
             channels = extras?.channels
             mbzRecordingId = extras?.mbzRecordingId ?? song.musicBrainzId
+            mbzAlbumId = extras?.mbzAlbumId
             dateAdded = extras?.dateAdded
+            dateLoved = extras?.dateLoved
+            albumLastPlayed = extras?.albumLastPlayed
+            albumDateLoved = extras?.albumDateLoved
         }
     }
 
@@ -660,7 +678,11 @@ struct FilterRuleSet: Codable, Sendable, Equatable {
         let isCompilation: Bool
         let channels: Int?
         let mbzRecordingId: String?
+        let mbzAlbumId: String?
         let dateAdded: Date?
+        let dateLoved: Date?
+        let albumLastPlayed: Date?
+        let albumDateLoved: Date?
     }
 }
 
@@ -675,16 +697,17 @@ private protocol FilterTarget {
 extension FilterRuleSet.SongMeta: FilterTarget {
     func textValue(for field: FilterField) -> String? {
         switch field {
-        case .title:       return title
-        case .artist:      return artist
-        case .albumTitle:  return albumTitle
-        case .genre:       return genre
-        case .label:       return label
-        case .suffix:      return suffix
-        case .contentType: return contentType
-        case .comment:         return comment
-        case .mbzRecordingId:  return mbzRecordingId
-        default:               return nil
+        case .title:          return title
+        case .artist:         return artist
+        case .albumTitle:     return albumTitle
+        case .genre:          return genre
+        case .label:          return label
+        case .suffix:         return suffix
+        case .contentType:    return contentType
+        case .comment:        return comment
+        case .mbzRecordingId: return mbzRecordingId
+        case .mbzAlbumId:     return mbzAlbumId
+        default:              return nil
         }
     }
     func numericValue(for field: FilterField) -> Int? {

--- a/Vibrdrome/Core/Models/FilterRule.swift
+++ b/Vibrdrome/Core/Models/FilterRule.swift
@@ -14,6 +14,13 @@ enum FilterField: String, CaseIterable, Codable, Sendable {
     case contentType    // codec
     case comment
     case explicitStatus // explicit content flag string
+    case releaseType    // e.g. "Album", "Single", "EP"
+    case releaseCountry
+    case releaseStatus  // e.g. "Official", "Bootleg"
+    case mood
+    case grouping
+    case mediaType      // e.g. "CD", "Vinyl", "Digital Media"
+    case catalogNum
     case mbzRecordingId // MusicBrainz Recording ID
     case mbzAlbumId     // MusicBrainz Album ID
     case mbzArtistId    // MusicBrainz Artist ID
@@ -77,6 +84,13 @@ enum FilterField: String, CaseIterable, Codable, Sendable {
         case .contentType:     "Codec"
         case .comment:         "Comment"
         case .explicitStatus:  "Explicit Status"
+        case .releaseType:     "Release Type"
+        case .releaseCountry:  "Release Country"
+        case .releaseStatus:   "Release Status"
+        case .mood:            "Mood"
+        case .grouping:        "Grouping"
+        case .mediaType:       "Media Type"
+        case .catalogNum:      "Catalog Number"
         case .mbzRecordingId:  "MBZ Recording ID"
         case .mbzAlbumId:      "MBZ Album ID"
         case .mbzArtistId:     "MBZ Artist ID"
@@ -126,7 +140,9 @@ enum FilterField: String, CaseIterable, Codable, Sendable {
     var kind: FieldKind {
         switch self {
         case .title, .artist, .albumTitle, .genre, .label, .suffix, .contentType, .comment,
-             .explicitStatus, .mbzRecordingId, .mbzAlbumId, .mbzArtistId, .mbzAlbumArtistId,
+             .explicitStatus, .releaseType, .releaseCountry, .releaseStatus,
+             .mood, .grouping, .mediaType, .catalogNum,
+             .mbzRecordingId, .mbzAlbumId, .mbzArtistId, .mbzAlbumArtistId,
              .mbzReleaseTrackId, .mbzReleaseGroupId:
             return .text
         case .year, .duration, .size, .channels, .bitRate, .bitDepth, .sampleRate, .bpm,
@@ -425,6 +441,7 @@ extension FilterField {
     ]
     static let albumFields: [FilterField] = [
         .albumTitle, .artist, .genre, .label,
+        .releaseType, .releaseCountry, .releaseStatus, .mood, .grouping, .mediaType, .catalogNum,
         .year, .duration, .rating, .albumRating,
         .isFavorited, .isDownloaded,
     ]
@@ -437,7 +454,8 @@ extension FilterField {
     static let smartPlaylistFields: [FilterField] = [
         // Text
         .title, .artist, .albumTitle, .genre, .label, .suffix, .contentType, .comment,
-        .explicitStatus,
+        .explicitStatus, .releaseType, .releaseCountry, .releaseStatus,
+        .mood, .grouping, .mediaType, .catalogNum,
         .mbzRecordingId, .mbzAlbumId, .mbzArtistId, .mbzAlbumArtistId,
         .mbzReleaseTrackId, .mbzReleaseGroupId,
         // Numeric
@@ -581,8 +599,16 @@ struct FilterRuleSet: Codable, Sendable, Equatable {
         let rating: Int
         let isFavorited: Bool
         let isDownloaded: Bool = false
+        // ND-only tag fields
+        let releaseType: String?
+        let releaseCountry: String?
+        let releaseStatus: String?
+        let mood: String?
+        let grouping: String?
+        let mediaType: String?
+        let catalogNum: String?
 
-        init(album: Album) {
+        init(album: Album, extras: CachedAlbumExtras? = nil) {
             title = album.name
             artist = album.artist
             // Join all genres so text operators (contains / equals) match any genre, not just the first.
@@ -592,7 +618,24 @@ struct FilterRuleSet: Codable, Sendable, Equatable {
             duration = album.duration
             rating = album.userRating ?? 0
             isFavorited = album.starred != nil
+            releaseType = extras?.releaseType
+            releaseCountry = extras?.releaseCountry
+            releaseStatus = extras?.releaseStatus
+            mood = extras?.mood
+            grouping = extras?.grouping
+            mediaType = extras?.mediaType
+            catalogNum = extras?.catalogNum
         }
+    }
+
+    struct CachedAlbumExtras {
+        let releaseType: String?
+        let releaseCountry: String?
+        let releaseStatus: String?
+        let mood: String?
+        let grouping: String?
+        let mediaType: String?
+        let catalogNum: String?
     }
 
     struct ArtistMeta {
@@ -681,6 +724,13 @@ extension FilterRuleSet.AlbumMeta: FilterTarget {
         case .artist:             return artist
         case .genre:              return genre
         case .label:              return label
+        case .releaseType:        return releaseType
+        case .releaseCountry:     return releaseCountry
+        case .releaseStatus:      return releaseStatus
+        case .mood:               return mood
+        case .grouping:           return grouping
+        case .mediaType:          return mediaType
+        case .catalogNum:         return catalogNum
         default:                  return nil
         }
     }

--- a/Vibrdrome/Core/Models/FilterRule.swift
+++ b/Vibrdrome/Core/Models/FilterRule.swift
@@ -1,0 +1,719 @@
+import Foundation
+
+// MARK: - Field
+
+/// Metadata fields that can be targeted by a filter rule.
+enum FilterField: String, CaseIterable, Codable, Sendable {
+    // Text fields
+    case title
+    case artist
+    case albumTitle
+    case genre
+    case label
+    case suffix         // file extension
+    case contentType    // codec
+    case comment
+    case explicitStatus // explicit content flag string
+    case mbzRecordingId // MusicBrainz Recording ID
+    case mbzAlbumId     // MusicBrainz Album ID
+    case mbzArtistId    // MusicBrainz Artist ID
+    case mbzAlbumArtistId
+    case mbzReleaseTrackId
+    case mbzReleaseGroupId
+
+    // Numeric fields
+    case year
+    case duration       // seconds
+    case size           // bytes
+    case channels       // audio channels
+    case bitRate        // kbps
+    case bitDepth
+    case sampleRate
+    case bpm
+    case playCount
+    case rating         // 1-5 stars (0 = unrated)
+    case averageRating  // average across all users
+    case albumRating
+    case albumPlayCount
+    case artistRating
+    case artistPlayCount
+    case trackNumber
+    case discNumber
+
+    // Date-relative fields (value = number of days for inTheLast/notInTheLast)
+    case lastPlayed
+    case dateLoved      // track loved date
+    case dateRated      // track rated date
+    case dateAdded
+    case dateModified
+    case albumLastPlayed
+    case albumDateLoved
+    case albumDateRated
+    case artistLastPlayed
+    case artistDateLoved
+    case artistDateRated
+
+    // Boolean fields
+    case isFavorited
+    case albumFavorited
+    case artistFavorited
+    case hasCoverArt
+    case isCompilation
+    case isMissing
+    case isDownloaded
+
+    // Playlist membership (value = playlist ID string)
+    case inPlaylist
+    case notInPlaylist
+
+    var displayName: String {
+        switch self {
+        case .title:           "Title"
+        case .artist:          "Artist"
+        case .albumTitle:      "Album"
+        case .genre:           "Genre"
+        case .label:           "Label"
+        case .suffix:          "Format"
+        case .contentType:     "Codec"
+        case .comment:         "Comment"
+        case .explicitStatus:  "Explicit Status"
+        case .mbzRecordingId:  "MBZ Recording ID"
+        case .mbzAlbumId:      "MBZ Album ID"
+        case .mbzArtistId:     "MBZ Artist ID"
+        case .mbzAlbumArtistId: "MBZ Album Artist ID"
+        case .mbzReleaseTrackId: "MBZ Release Track ID"
+        case .mbzReleaseGroupId: "MBZ Release Group ID"
+        case .year:            "Year"
+        case .duration:        "Duration (s)"
+        case .size:            "File Size"
+        case .channels:        "Channels"
+        case .bitRate:         "Bit Rate (kbps)"
+        case .bitDepth:        "Bit Depth"
+        case .sampleRate:      "Sample Rate"
+        case .bpm:             "BPM"
+        case .playCount:       "Play Count"
+        case .averageRating:   "Avg Rating"
+        case .rating:          "Rating"
+        case .albumRating:     "Album Rating"
+        case .albumPlayCount:  "Album Play Count"
+        case .artistRating:    "Artist Rating"
+        case .artistPlayCount: "Artist Play Count"
+        case .trackNumber:     "Track #"
+        case .discNumber:      "Disc #"
+        case .lastPlayed:      "Last Played"
+        case .dateLoved:       "Date Loved"
+        case .dateRated:       "Date Rated"
+        case .dateAdded:       "Date Added"
+        case .dateModified:    "Date Modified"
+        case .albumLastPlayed: "Album Last Played"
+        case .albumDateLoved:  "Album Date Loved"
+        case .albumDateRated:  "Album Date Rated"
+        case .artistLastPlayed: "Artist Last Played"
+        case .artistDateLoved: "Artist Date Loved"
+        case .artistDateRated: "Artist Date Rated"
+        case .isFavorited:     "Loved"
+        case .albumFavorited:  "Album Loved"
+        case .artistFavorited: "Artist Loved"
+        case .hasCoverArt:     "Has Cover Art"
+        case .isCompilation:   "Compilation"
+        case .isMissing:       "File Missing"
+        case .isDownloaded:    "Is Downloaded"
+        case .inPlaylist:      "In Playlist"
+        case .notInPlaylist:   "Not In Playlist"
+        }
+    }
+
+    var kind: FieldKind {
+        switch self {
+        case .title, .artist, .albumTitle, .genre, .label, .suffix, .contentType, .comment,
+             .explicitStatus, .mbzRecordingId, .mbzAlbumId, .mbzArtistId, .mbzAlbumArtistId,
+             .mbzReleaseTrackId, .mbzReleaseGroupId:
+            return .text
+        case .year, .duration, .size, .channels, .bitRate, .bitDepth, .sampleRate, .bpm,
+             .playCount, .rating, .averageRating, .albumRating, .albumPlayCount,
+             .artistRating, .artistPlayCount, .trackNumber, .discNumber:
+            return .numeric
+        case .lastPlayed, .dateLoved, .dateRated, .dateAdded, .dateModified,
+             .albumLastPlayed, .albumDateLoved, .albumDateRated,
+             .artistLastPlayed, .artistDateLoved, .artistDateRated:
+            return .days
+        case .isFavorited, .albumFavorited, .artistFavorited,
+             .hasCoverArt, .isCompilation, .isMissing, .isDownloaded:
+            return .boolean
+        case .inPlaylist, .notInPlaylist:
+            return .playlist
+        }
+    }
+
+    enum FieldKind { case text, numeric, days, boolean, playlist }
+}
+
+// MARK: - Operator
+
+enum FilterOperator: String, CaseIterable, Codable, Sendable {
+    // Text operators
+    case contains
+    case notContains
+    case equals
+    case notEquals
+    case startsWith
+    case endsWith
+    case matchesRegex
+
+    // Numeric operators
+    case isEqualTo
+    case isNotEqualTo
+    case isGreaterThan
+    case isLessThan
+    case isGreaterOrEqual
+    case isLessOrEqual
+    case isBetween
+
+    // Days-ago operators (for date fields)
+    case inTheLast
+    case notInTheLast
+    case before         // absolute date "YYYY-MM-DD"
+    case after          // absolute date "YYYY-MM-DD"
+
+    // Boolean operator
+    case isTrue
+
+    // Playlist membership (no argument — field holds the playlist ID)
+    case isInPlaylist
+
+    var displayName: String {
+        switch self {
+        case .contains:        "contains"
+        case .notContains:     "does not contain"
+        case .equals:          "is"
+        case .notEquals:       "is not"
+        case .startsWith:      "starts with"
+        case .endsWith:        "ends with"
+        case .matchesRegex:    "matches regex"
+        case .isEqualTo:       "="
+        case .isNotEqualTo:    "≠"
+        case .isGreaterThan:   ">"
+        case .isLessThan:      "<"
+        case .isGreaterOrEqual: "≥"
+        case .isLessOrEqual:   "≤"
+        case .isBetween:       "between"
+        case .inTheLast:       "in the last"
+        case .notInTheLast:    "not in the last"
+        case .before:          "before"
+        case .after:           "after"
+        case .isTrue:          "is"
+        case .isInPlaylist:    "in playlist"
+        }
+    }
+
+    static func allowed(for kind: FilterField.FieldKind) -> [FilterOperator] {
+        switch kind {
+        case .text:
+            return [.contains, .notContains, .equals, .notEquals, .startsWith, .endsWith, .matchesRegex]
+        case .numeric:
+            return [.isEqualTo, .isNotEqualTo, .isGreaterThan, .isLessThan, .isGreaterOrEqual, .isLessOrEqual, .isBetween]
+        case .days:
+            return [.inTheLast, .notInTheLast, .before, .after]
+        case .boolean:
+            return [.isTrue]
+        case .playlist:
+            return [.isInPlaylist]
+        }
+    }
+}
+
+// MARK: - Value
+
+enum FilterValue: Codable, Sendable, Equatable {
+    case text(String)
+    case number(Int)
+    case range(Int, Int)
+    case boolean(Bool)
+
+    private enum CodingKeys: String, CodingKey { case type, text, number, low, high, boolean }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try c.decode(String.self, forKey: .type)
+        switch type {
+        case "text":    self = .text(try c.decode(String.self, forKey: .text))
+        case "number":  self = .number(try c.decode(Int.self, forKey: .number))
+        case "range":   self = .range(try c.decode(Int.self, forKey: .low), try c.decode(Int.self, forKey: .high))
+        case "boolean": self = .boolean(try c.decode(Bool.self, forKey: .boolean))
+        default:        self = .text("")
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .text(let s):
+            try c.encode("text", forKey: .type); try c.encode(s, forKey: .text)
+        case .number(let n):
+            try c.encode("number", forKey: .type); try c.encode(n, forKey: .number)
+        case .range(let lo, let hi):
+            try c.encode("range", forKey: .type); try c.encode(lo, forKey: .low); try c.encode(hi, forKey: .high)
+        case .boolean(let b):
+            try c.encode("boolean", forKey: .type); try c.encode(b, forKey: .boolean)
+        }
+    }
+
+    static func defaultValue(for kind: FilterField.FieldKind) -> FilterValue {
+        switch kind {
+        case .text:     return .text("")
+        case .numeric:  return .number(0)
+        case .days:     return .number(30)
+        case .boolean:  return .boolean(true)
+        case .playlist: return .text("")
+        }
+    }
+}
+
+// MARK: - Rule
+
+struct FilterRule: Identifiable, Codable, Sendable, Equatable {
+    var id: UUID
+    var field: FilterField
+    var `operator`: FilterOperator
+    var value: FilterValue
+
+    init(id: UUID = UUID(), field: FilterField = .title, operator op: FilterOperator = .contains, value: FilterValue = .text("")) {
+        self.id = id
+        self.field = field
+        self.operator = op
+        self.value = value
+    }
+
+    /// True when the rule has no meaningful value and should be treated as a no-op.
+    /// An empty text pattern or a boolean rule (which always has a value) is never empty.
+    var isEffectivelyEmpty: Bool {
+        switch value {
+        case .text(let s):  return s.isEmpty
+        case .number:       return false
+        case .range:        return false
+        case .boolean:      return false
+        }
+    }
+
+    /// Returns true when the rule passes for the given metadata values.
+    func matches(song: FilterRuleSet.SongMeta) -> Bool {
+        evaluate(against: song)
+    }
+
+    func matches(album: FilterRuleSet.AlbumMeta) -> Bool {
+        evaluate(against: album)
+    }
+
+    func matches(artist: FilterRuleSet.ArtistMeta) -> Bool {
+        evaluate(against: artist)
+    }
+
+    // MARK: Private evaluation
+
+    private func evaluate(against target: any FilterTarget) -> Bool {
+        switch field.kind {
+        case .text:
+            guard case .text(let pattern) = value, !pattern.isEmpty else { return true }
+            let haystack = target.textValue(for: field) ?? ""
+            return matchText(haystack: haystack, pattern: pattern)
+
+        case .numeric:
+            let actual = target.numericValue(for: field)
+            return matchNumeric(actual: actual)
+
+        case .days:
+            // Local evaluation not meaningful for date fields — server handles it.
+            return true
+
+        case .boolean:
+            guard case .boolean(let expected) = value else { return true }
+            return target.boolValue(for: field) == expected
+
+        case .playlist:
+            // Playlist membership cannot be evaluated locally — server handles it.
+            return true
+        }
+    }
+
+    private func matchText(haystack: String, pattern: String) -> Bool {
+        switch `operator` {
+        case .contains:
+            return haystack.localizedCaseInsensitiveContains(pattern)
+        case .notContains:
+            return !haystack.localizedCaseInsensitiveContains(pattern)
+        case .equals:
+            return haystack.localizedCaseInsensitiveCompare(pattern) == .orderedSame
+        case .notEquals:
+            return haystack.localizedCaseInsensitiveCompare(pattern) != .orderedSame
+        case .startsWith:
+            return haystack.lowercased().hasPrefix(pattern.lowercased())
+        case .endsWith:
+            return haystack.lowercased().hasSuffix(pattern.lowercased())
+        case .matchesRegex:
+            let (rawPattern, options) = Self.parseRegexLiteral(pattern)
+            return (try? NSRegularExpression(pattern: rawPattern, options: options))
+                .map { $0.firstMatch(in: haystack, range: NSRange(haystack.startIndex..., in: haystack)) != nil } ?? false
+        default:
+            return true
+        }
+    }
+
+    /// Parses an optional `/pattern/flags` regex literal, returning the raw pattern and options.
+    /// If the input doesn't start with `/`, it is returned as-is with no options (plain pattern).
+    /// Supported flags: i (caseInsensitive), s (dotMatchesLineSeparators), m (anchorsMatchLines).
+    static func parseRegexLiteral(_ input: String) -> (pattern: String, options: NSRegularExpression.Options) {
+        guard input.hasPrefix("/") else { return (input, []) }
+        // Find the closing slash — search from the second character onwards
+        let afterOpen = input.index(after: input.startIndex)
+        guard let closingSlash = input[afterOpen...].lastIndex(of: "/"), closingSlash != input.startIndex else {
+            // Malformed (no closing slash) — treat the whole string as a plain pattern
+            return (input, [])
+        }
+        let rawPattern = String(input[afterOpen..<closingSlash])
+        let flagString = String(input[input.index(after: closingSlash)...])
+        var options: NSRegularExpression.Options = []
+        for flag in flagString {
+            switch flag {
+            case "i": options.insert(.caseInsensitive)
+            case "s": options.insert(.dotMatchesLineSeparators)
+            case "m": options.insert(.anchorsMatchLines)
+            default: break
+            }
+        }
+        return (rawPattern, options)
+    }
+
+    private func matchNumeric(actual: Int?) -> Bool {
+        switch value {
+        case .number(let n):
+            guard let a = actual else { return false }
+            switch `operator` {
+            case .isEqualTo:       return a == n
+            case .isNotEqualTo:    return a != n
+            case .isGreaterThan:   return a > n
+            case .isLessThan:      return a < n
+            case .isGreaterOrEqual: return a >= n
+            case .isLessOrEqual: return a <= n
+            default: return true
+            }
+        case .range(let lo, let hi):
+            guard `operator` == .isBetween, let a = actual else { return false }
+            return a >= lo && a <= hi
+        default:
+            return true
+        }
+    }
+}
+
+// MARK: - Field Sets
+
+extension FilterField {
+    static let songFields: [FilterField] = [
+        // Text
+        .title, .artist, .albumTitle, .genre, .label, .suffix, .contentType, .comment,
+        // Numeric
+        .year, .duration, .size, .channels, .bitRate, .bitDepth, .sampleRate, .bpm,
+        .playCount, .rating, .averageRating, .albumRating, .albumPlayCount,
+        .artistRating, .artistPlayCount, .trackNumber, .discNumber,
+        // Date-relative
+        .lastPlayed, .dateLoved, .dateRated, .dateAdded, .dateModified,
+        .albumLastPlayed, .albumDateLoved, .albumDateRated,
+        .artistLastPlayed, .artistDateLoved, .artistDateRated,
+        // Boolean
+        .isFavorited, .albumFavorited, .artistFavorited,
+        .hasCoverArt, .isCompilation, .isMissing, .isDownloaded,
+    ]
+    static let albumFields: [FilterField] = [
+        .albumTitle, .artist, .genre, .label,
+        .year, .duration, .rating, .albumRating,
+        .isFavorited, .isDownloaded,
+    ]
+    static let artistFields: [FilterField] = [
+        .artist, .genre,
+        .isFavorited,
+    ]
+
+    /// Fields available in the smart playlist editor (server-evaluated; excludes local-only fields).
+    static let smartPlaylistFields: [FilterField] = [
+        // Text
+        .title, .artist, .albumTitle, .genre, .label, .suffix, .contentType, .comment,
+        .explicitStatus,
+        .mbzRecordingId, .mbzAlbumId, .mbzArtistId, .mbzAlbumArtistId,
+        .mbzReleaseTrackId, .mbzReleaseGroupId,
+        // Numeric
+        .year, .duration, .size, .channels, .bitRate, .bitDepth, .sampleRate, .bpm,
+        .playCount, .rating, .averageRating, .albumRating, .albumPlayCount,
+        .artistRating, .artistPlayCount, .trackNumber, .discNumber,
+        // Date-relative
+        .lastPlayed, .dateLoved, .dateRated, .dateAdded, .dateModified,
+        .albumLastPlayed, .albumDateLoved, .albumDateRated,
+        .artistLastPlayed, .artistDateLoved, .artistDateRated,
+        // Boolean
+        .isFavorited, .albumFavorited, .artistFavorited,
+        .hasCoverArt, .isCompilation, .isMissing,
+        // Playlist membership
+        .inPlaylist, .notInPlaylist,
+    ]
+}
+
+// MARK: - Rule Set
+
+struct FilterRuleSet: Codable, Sendable, Equatable {
+    enum Combinator: String, Codable, Sendable { case all, any }
+
+    var combinator: Combinator = .all
+    var rules: [FilterRule] = []
+
+    var isEmpty: Bool { rules.allSatisfy(\.isEffectivelyEmpty) }
+
+    /// True when any active rule targets a field that requires CachedSong lookup
+    /// (fields not carried on the Song value type — stored in CachedSong or its album relationship).
+    var needsCachedSong: Bool {
+        let cachedFields: Set<FilterField> = [
+            .playCount, .rating, .albumRating, .albumFavorited, .albumPlayCount,
+            .artistRating, .artistPlayCount, .artistFavorited,
+            .bitDepth, .sampleRate, .size, .channels, .comment,
+            .hasCoverArt, .isCompilation, .dateAdded,
+        ]
+        return rules.contains { !$0.isEffectivelyEmpty && cachedFields.contains($0.field) }
+    }
+
+    private var activeRules: [FilterRule] { rules.filter { !$0.isEffectivelyEmpty } }
+
+    func matches(song: SongMeta) -> Bool {
+        let active = activeRules
+        guard !active.isEmpty else { return true }
+        switch combinator {
+        case .all: return active.allSatisfy { $0.matches(song: song) }
+        case .any: return active.contains { $0.matches(song: song) }
+        }
+    }
+
+    func matches(album: AlbumMeta) -> Bool {
+        let active = activeRules
+        guard !active.isEmpty else { return true }
+        switch combinator {
+        case .all: return active.allSatisfy { $0.matches(album: album) }
+        case .any: return active.contains { $0.matches(album: album) }
+        }
+    }
+
+    func matches(artist: ArtistMeta) -> Bool {
+        let active = activeRules
+        guard !active.isEmpty else { return true }
+        switch combinator {
+        case .all: return active.allSatisfy { $0.matches(artist: artist) }
+        case .any: return active.contains { $0.matches(artist: artist) }
+        }
+    }
+
+    // MARK: Metadata structs
+
+    struct SongMeta {
+        let title: String
+        let artist: String?
+        let albumTitle: String?
+        let genre: String?
+        let label: String?
+        let suffix: String?
+        let contentType: String?
+        let comment: String?
+        let year: Int?
+        let duration: Int?
+        let bitRate: Int?
+        let bitDepth: Int?
+        let samplingRate: Int?
+        let bpm: Int?
+        let playCount: Int
+        let rating: Int
+        let albumRating: Int
+        let trackNumber: Int?
+        let discNumber: Int?
+        let isFavorited: Bool
+        let albumFavorited: Bool
+        let isDownloaded: Bool
+        let hasCoverArt: Bool
+        let isCompilation: Bool
+        let size: Int?
+        let channels: Int?
+        let mbzRecordingId: String?
+        let dateAdded: Date?
+
+        init(song: Song, extras: CachedSongExtras? = nil) {
+            title = song.title
+            artist = song.artist
+            albumTitle = song.album
+            genre = song.genre
+            label = nil
+            suffix = song.suffix
+            contentType = song.contentType
+            comment = song.comment
+            year = song.year
+            duration = song.duration
+            bitRate = song.bitRate
+            bitDepth = song.bitDepth
+            samplingRate = song.samplingRate
+            bpm = song.bpm
+            playCount = extras?.playCount ?? 0
+            rating = song.userRating ?? 0
+            albumRating = extras?.albumRating ?? 0
+            trackNumber = song.track
+            discNumber = song.discNumber
+            isFavorited = song.starred != nil
+            albumFavorited = extras?.albumFavorited ?? false
+            isDownloaded = false
+            hasCoverArt = extras?.hasCoverArt ?? (song.coverArt != nil)
+            isCompilation = extras?.isCompilation ?? false
+            size = song.size
+            channels = extras?.channels
+            mbzRecordingId = extras?.mbzRecordingId ?? song.musicBrainzId
+            dateAdded = extras?.dateAdded
+        }
+    }
+
+    struct AlbumMeta {
+        let title: String
+        let artist: String?
+        let genre: String?
+        let label: String?
+        let year: Int?
+        let duration: Int?
+        let rating: Int
+        let isFavorited: Bool
+        let isDownloaded: Bool = false
+
+        init(album: Album) {
+            title = album.name
+            artist = album.artist
+            genre = album.allGenres.first
+            label = album.label
+            year = album.year
+            duration = album.duration
+            rating = album.userRating ?? 0
+            isFavorited = album.starred != nil
+        }
+    }
+
+    struct ArtistMeta {
+        let name: String
+        let genre: String?
+        let isFavorited: Bool
+        let isDownloaded: Bool = false
+
+        init(artist: Artist) {
+            name = artist.name
+            genre = nil
+            isFavorited = artist.starred != nil
+        }
+    }
+
+    /// Extended song fields sourced from SwiftData (not available on the Subsonic `Song` value type).
+    struct CachedSongExtras {
+        let playCount: Int
+        let albumRating: Int
+        let albumFavorited: Bool
+        let hasCoverArt: Bool
+        let isCompilation: Bool
+        let channels: Int?
+        let mbzRecordingId: String?
+        let dateAdded: Date?
+    }
+}
+
+// MARK: - FilterTarget protocol (private)
+
+private protocol FilterTarget {
+    func textValue(for field: FilterField) -> String?
+    func numericValue(for field: FilterField) -> Int?
+    func boolValue(for field: FilterField) -> Bool
+}
+
+extension FilterRuleSet.SongMeta: FilterTarget {
+    func textValue(for field: FilterField) -> String? {
+        switch field {
+        case .title:       return title
+        case .artist:      return artist
+        case .albumTitle:  return albumTitle
+        case .genre:       return genre
+        case .label:       return label
+        case .suffix:      return suffix
+        case .contentType: return contentType
+        case .comment:         return comment
+        case .mbzRecordingId:  return mbzRecordingId
+        default:               return nil
+        }
+    }
+    func numericValue(for field: FilterField) -> Int? {
+        switch field {
+        case .year:        return year
+        case .duration:    return duration
+        case .bitRate:     return bitRate
+        case .bitDepth:    return bitDepth
+        case .sampleRate:  return samplingRate
+        case .bpm:         return bpm
+        case .playCount:   return playCount
+        case .rating:      return rating
+        case .albumRating: return albumRating
+        case .trackNumber: return trackNumber
+        case .discNumber:  return discNumber
+        case .size:        return size
+        case .channels:    return channels
+        default:           return nil
+        }
+    }
+    func boolValue(for field: FilterField) -> Bool {
+        switch field {
+        case .isFavorited:    return isFavorited
+        case .albumFavorited: return albumFavorited
+        case .isDownloaded:   return isDownloaded
+        case .hasCoverArt:    return hasCoverArt
+        case .isCompilation:  return isCompilation
+        default:              return false
+        }
+    }
+}
+
+extension FilterRuleSet.AlbumMeta: FilterTarget {
+    func textValue(for field: FilterField) -> String? {
+        switch field {
+        case .title, .albumTitle: return title
+        case .artist:             return artist
+        case .genre:              return genre
+        case .label:              return label
+        default:                  return nil
+        }
+    }
+    func numericValue(for field: FilterField) -> Int? {
+        switch field {
+        case .year:               return year
+        case .duration:           return duration
+        case .rating, .albumRating: return rating
+        default:                  return nil
+        }
+    }
+    func boolValue(for field: FilterField) -> Bool {
+        switch field {
+        case .isFavorited:  return isFavorited
+        case .isDownloaded: return isDownloaded
+        default:            return false
+        }
+    }
+}
+
+extension FilterRuleSet.ArtistMeta: FilterTarget {
+    func textValue(for field: FilterField) -> String? {
+        switch field {
+        case .artist, .title: return name
+        case .genre:          return genre
+        default:              return nil
+        }
+    }
+    func numericValue(for field: FilterField) -> Int? { nil }
+    func boolValue(for field: FilterField) -> Bool {
+        switch field {
+        case .isFavorited:  return isFavorited
+        case .isDownloaded: return isDownloaded
+        default:            return false
+        }
+    }
+}

--- a/Vibrdrome/Core/Models/LibraryFilter.swift
+++ b/Vibrdrome/Core/Models/LibraryFilter.swift
@@ -27,6 +27,9 @@ final class LibraryFilter {
     var selectedGenres: Set<String> = []
     var selectedLabels: Set<String> = []
     var year: Int?
+    var ruleSet: FilterRuleSet = FilterRuleSet() { didSet { persistRuleSet() } }
+    var matchCount: Int?
+    var ruleSetPersistenceKey: String?
 
     var isActive: Bool {
         isFavorited != .none ||
@@ -35,7 +38,8 @@ final class LibraryFilter {
         !selectedArtistIds.isEmpty ||
         !selectedGenres.isEmpty ||
         !selectedLabels.isEmpty ||
-        year != nil
+        year != nil ||
+        !ruleSet.isEmpty
     }
 
     var activeFilterCount: Int {
@@ -47,6 +51,7 @@ final class LibraryFilter {
         if !selectedGenres.isEmpty { count += 1 }
         if !selectedLabels.isEmpty { count += 1 }
         if year != nil { count += 1 }
+        if !ruleSet.isEmpty { count += 1 }
         return count
     }
 
@@ -58,5 +63,20 @@ final class LibraryFilter {
         selectedGenres = []
         selectedLabels = []
         year = nil
+        ruleSet = FilterRuleSet()
+        matchCount = nil
+    }
+
+    func loadRuleSet(from key: String) {
+        ruleSetPersistenceKey = key
+        guard let data = UserDefaults.standard.data(forKey: key),
+              let decoded = try? JSONDecoder().decode(FilterRuleSet.self, from: data) else { return }
+        ruleSet = decoded
+    }
+
+    private func persistRuleSet() {
+        guard let key = ruleSetPersistenceKey,
+              let data = try? JSONEncoder().encode(ruleSet) else { return }
+        UserDefaults.standard.set(data, forKey: key)
     }
 }

--- a/Vibrdrome/Core/Models/NSPCriteria.swift
+++ b/Vibrdrome/Core/Models/NSPCriteria.swift
@@ -370,6 +370,14 @@ private extension FilterField {
         case .hasCoverArt:        return "hascoverart"
         case .isCompilation:      return "compilation"
         case .isMissing:          return "missing"
+        // ND tag fields
+        case .releaseType:        return "releasetype"
+        case .releaseCountry:     return "releasecountry"
+        case .releaseStatus:      return "releasestatus"
+        case .mood:               return "mood"
+        case .grouping:           return "grouping"
+        case .mediaType:          return "media"
+        case .catalogNum:         return "catalognumber"
         // Local-only — no server mapping
         case .isDownloaded:       return nil
         // Playlist membership — handled specially in playlistNSP(), not via nspField

--- a/Vibrdrome/Core/Models/NSPCriteria.swift
+++ b/Vibrdrome/Core/Models/NSPCriteria.swift
@@ -1,0 +1,466 @@
+import Foundation
+
+// MARK: - NSP Criteria
+
+/// Navidrome Smart Playlist criteria, matching the .nsp JSON format.
+/// Sent as the `rules` field in the Navidrome native REST API.
+///
+/// Format mirrors the Navidrome `model/criteria` package:
+///   { "all": [ { "contains": { "title": "love" } }, … ], "sort": "rating", "order": "desc", "limit": 100 }
+struct NSPCriteria: Codable, Sendable {
+    enum Combinator: String, Codable, Sendable { case all, any }
+
+    var combinator: Combinator
+    var expressions: [NSPExpression]
+    var sort: String?
+    var order: String?
+    var limit: Int?
+    var limitPercent: Int?
+
+    // MARK: Codable
+
+    enum CodingKeys: String, CodingKey { case all, any, sort, order, limit, limitPercent }
+
+    init(combinator: Combinator = .all, expressions: [NSPExpression] = [],
+         sort: String? = nil, order: String? = nil, limit: Int? = nil, limitPercent: Int? = nil) {
+        self.combinator = combinator
+        self.expressions = expressions
+        self.sort = sort
+        self.order = order
+        self.limit = limit
+        self.limitPercent = limitPercent
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        sort = try c.decodeIfPresent(String.self, forKey: .sort)
+        order = try c.decodeIfPresent(String.self, forKey: .order)
+        limit = try c.decodeIfPresent(Int.self, forKey: .limit)
+        limitPercent = try c.decodeIfPresent(Int.self, forKey: .limitPercent)
+        if let all = try c.decodeIfPresent([NSPExpression].self, forKey: .all) {
+            combinator = .all; expressions = all
+        } else if let any = try c.decodeIfPresent([NSPExpression].self, forKey: .any) {
+            combinator = .any; expressions = any
+        } else {
+            // Mirror Navidrome: criteria must have an 'all' or 'any' key.
+            throw DecodingError.dataCorruptedError(
+                forKey: .all,
+                in: c,
+                debugDescription: "NSPCriteria missing required 'all' or 'any' key"
+            )
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encodeIfPresent(sort, forKey: .sort)
+        try c.encodeIfPresent(order, forKey: .order)
+        try c.encodeIfPresent(limit, forKey: .limit)
+        try c.encodeIfPresent(limitPercent, forKey: .limitPercent)
+        switch combinator {
+        case .all: try c.encode(expressions, forKey: .all)
+        case .any: try c.encode(expressions, forKey: .any)
+        }
+    }
+
+    /// Serialize to a plain `[String: Any]` dictionary for embedding in an API request body.
+    func toJSON() -> [String: Any]? {
+        guard let data = try? JSONEncoder().encode(self) else { return nil }
+        return try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+    }
+}
+
+// MARK: - NSP Expression
+
+/// One rule node in the NSP format: `{ "<operator>": { "<field>": <value> } }`.
+/// Also handles nested `all`/`any` conjunctions.
+indirect enum NSPExpression: Codable, Sendable {
+    case leaf(operator: String, field: String, value: NSPValue)
+    case conjunction(NSPCriteria)
+
+    // Operator names recognised by Navidrome (lowercased for comparison).
+    private static let leafOperators: Set<String> = [
+        "is", "isnot", "gt", "lt", "contains", "notcontains",
+        "startswith", "endswith", "intherange",
+        "before", "after", "inthelast", "notinthelast",
+        "inplaylist", "notinplaylist", "ismissing", "ispresent",
+    ]
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        // Decode as a raw single-key dict to inspect the operator name first,
+        // mirroring Navidrome's unmarshalConjunctionType logic exactly:
+        // known leaf operators → leaf; "all"/"any" → nested conjunction.
+        let raw = try container.decode([String: NSPRawValue].self)
+        guard let (key, rawValue) = raw.first else {
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "Empty NSP expression")
+        }
+        let lowerKey = key.lowercased()
+        if NSPExpression.leafOperators.contains(lowerKey) {
+            // Leaf: { "<op>": { "<field>": <value> } }
+            guard case .object(let fieldMap) = rawValue,
+                  let (field, nspVal) = fieldMap.first else {
+                throw DecodingError.dataCorruptedError(in: container, debugDescription: "Invalid leaf expression for op '\(key)'")
+            }
+            self = .leaf(operator: key, field: field, value: nspVal)
+        } else if lowerKey == "all" || lowerKey == "any" {
+            // Nested conjunction: { "all": [...] } or { "any": [...] }
+            let nested = try container.decode(NSPCriteria.self)
+            self = .conjunction(nested)
+        } else {
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "Unknown NSP expression key '\(key)'")
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .conjunction(let crit):
+            try container.encode(crit)
+        case .leaf(let op, let field, let value):
+            try container.encode([op: [field: value]])
+        }
+    }
+}
+
+// MARK: - NSP Raw Value (expression decoding helper)
+
+/// Intermediate decoded shape for one side of an NSP expression dict.
+/// Used by `NSPExpression.init(from:)` to inspect the key before committing to a type.
+private enum NSPRawValue: Decodable {
+    case object([String: NSPValue])
+    case array([NSPExpression])
+    case other
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.singleValueContainer()
+        if let obj = try? c.decode([String: NSPValue].self) { self = .object(obj); return }
+        if let arr = try? c.decode([NSPExpression].self)    { self = .array(arr);  return }
+        self = .other
+    }
+}
+
+// MARK: - NSP Value
+
+/// A value in an NSP expression. Can be a string, int, bool, float, or a two-element range array.
+indirect enum NSPValue: Codable, Sendable {
+    case string(String)
+    case int(Int)
+    case bool(Bool)
+    case double(Double)
+    case range(NSPValue, NSPValue)
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.singleValueContainer()
+        if let b = try? c.decode(Bool.self)   { self = .bool(b);   return }
+        if let i = try? c.decode(Int.self)    { self = .int(i);    return }
+        if let d = try? c.decode(Double.self) { self = .double(d); return }
+        if let s = try? c.decode(String.self) { self = .string(s); return }
+        if let arr = try? c.decode([NSPValue].self), arr.count == 2 {
+            self = .range(arr[0], arr[1]); return
+        }
+        throw DecodingError.dataCorruptedError(in: c, debugDescription: "Unsupported NSPValue")
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.singleValueContainer()
+        switch self {
+        case .string(let s): try c.encode(s)
+        case .int(let i):    try c.encode(i)
+        case .bool(let b):   try c.encode(b)
+        case .double(let d): try c.encode(d)
+        case .range(let lo, let hi): try c.encode([lo, hi])
+        }
+    }
+}
+
+// MARK: - FilterRuleSet → NSPCriteria mapping
+
+extension NSPCriteria {
+
+    /// Convert a `FilterRuleSet` (local filter model) to an `NSPCriteria` (Navidrome native format).
+    init(from ruleSet: FilterRuleSet, sort: String? = nil, order: String? = nil, limit: Int? = nil) {
+        let expressions = ruleSet.rules
+            .filter { !$0.isEffectivelyEmpty }
+            .compactMap { NSPExpression(from: $0) }
+
+        self.init(
+            combinator: ruleSet.combinator == .all ? .all : .any,
+            expressions: expressions,
+            sort: sort,
+            order: order,
+            limit: limit
+        )
+    }
+}
+
+extension NSPExpression {
+
+    /// Map a single `FilterRule` to an `NSPExpression`.
+    /// Returns nil for rules that have no valid NSP mapping.
+    init?(from rule: FilterRule) {
+        guard !rule.isEffectivelyEmpty else { return nil }
+        guard let (op, field, value) = rule.toNSP() else { return nil }
+        self = .leaf(operator: op, field: field, value: value)
+    }
+}
+
+// MARK: - FilterRule → (operator, field, value)
+
+private extension FilterRule {
+
+    func toNSP() -> (op: String, field: String, value: NSPValue)? {
+        switch self.field.kind {
+        case .playlist: return playlistNSP()
+        default:
+            guard let field = self.field.nspField else { return nil }
+            switch self.field.kind {
+            case .text:    return textNSP(field: field)
+            case .numeric: return numericNSP(field: field)
+            case .days:    return daysNSP(field: field)
+            case .boolean: return booleanNSP(field: field)
+            case .playlist: return nil  // handled above
+            }
+        }
+    }
+
+    // MARK: Text
+
+    private func textNSP(field: String) -> (String, String, NSPValue)? {
+        guard case .text(let pattern) = value else { return nil }
+        switch `operator` {
+        case .contains:     return ("contains", field, .string(pattern))
+        case .notContains:  return ("notContains", field, .string(pattern))
+        case .equals:       return ("is", field, .string(pattern))
+        case .notEquals:    return ("isNot", field, .string(pattern))
+        case .startsWith:   return ("startsWith", field, .string(pattern))
+        case .endsWith:     return ("endsWith", field, .string(pattern))
+        case .matchesRegex:
+            // NSP doesn't have a regex operator; skip silently.
+            return nil
+        default:            return nil
+        }
+    }
+
+    // MARK: Numeric
+
+    private func numericNSP(field: String) -> (String, String, NSPValue)? {
+        switch value {
+        case .number(let n):
+            switch `operator` {
+            case .isEqualTo:       return ("is", field, .int(n))
+            case .isNotEqualTo:    return ("isNot", field, .int(n))
+            case .isGreaterThan:   return ("gt", field, .int(n))
+            case .isLessThan:      return ("lt", field, .int(n))
+            case .isGreaterOrEqual:
+                // NSP has no ≥; emulate with gt(n-1) for integer fields.
+                return ("gt", field, .int(n - 1))
+            case .isLessOrEqual:
+                // NSP has no ≤; emulate with lt(n+1) for integer fields.
+                return ("lt", field, .int(n + 1))
+            default: return nil
+            }
+        case .range(let lo, let hi):
+            guard `operator` == .isBetween else { return nil }
+            return ("inTheRange", field, .range(.int(lo), .int(hi)))
+        default:
+            return nil
+        }
+    }
+
+    // MARK: Days (inTheLast / notInTheLast / before / after)
+
+    private func daysNSP(field: String) -> (String, String, NSPValue)? {
+        switch `operator` {
+        case .inTheLast:
+            guard case .number(let n) = value else { return nil }
+            return ("inTheLast", field, .int(n))
+        case .notInTheLast:
+            guard case .number(let n) = value else { return nil }
+            return ("notInTheLast", field, .int(n))
+        case .before:
+            guard case .text(let date) = value, !date.isEmpty else { return nil }
+            return ("before", field, .string(date))
+        case .after:
+            guard case .text(let date) = value, !date.isEmpty else { return nil }
+            return ("after", field, .string(date))
+        default: return nil
+        }
+    }
+
+    // MARK: Boolean
+
+    private func booleanNSP(field: String) -> (String, String, NSPValue)? {
+        guard case .boolean(let flag) = value else { return nil }
+        // NSP uses `is` for booleans: { "is": { "loved": true } }
+        return ("is", field, .bool(flag))
+    }
+
+    // MARK: Playlist membership
+    // NSP format: { "inPlaylist": { "id": "<playlistId>" } }
+    // The "field" key inside inPlaylist/notInPlaylist is always "id".
+
+    private func playlistNSP() -> (String, String, NSPValue)? {
+        guard case .text(let playlistId) = value, !playlistId.isEmpty else { return nil }
+        switch self.field {
+        case .inPlaylist:    return ("inPlaylist", "id", .string(playlistId))
+        case .notInPlaylist: return ("notInPlaylist", "id", .string(playlistId))
+        default:             return nil
+        }
+    }
+}
+
+// MARK: - FilterField → NSP field name
+
+private extension FilterField {
+    /// Maps a Vibrdrome filter field to the corresponding Navidrome NSP field name.
+    /// Returns nil for fields that have no valid NSP mapping (local-only fields).
+    var nspField: String? {
+        switch self {
+        // Text
+        case .title:              return "title"
+        case .artist:             return "artist"
+        case .albumTitle:         return "album"
+        case .genre:              return "genre"
+        case .label:              return "recordlabel"
+        case .suffix:             return "filetype"
+        case .contentType:        return "codec"
+        case .comment:            return "comment"
+        case .explicitStatus:     return "explicitstatus"
+        case .mbzRecordingId:     return "mbz_recording_id"
+        case .mbzAlbumId:         return "mbz_album_id"
+        case .mbzArtistId:        return "mbz_artist_id"
+        case .mbzAlbumArtistId:   return "mbz_album_artist_id"
+        case .mbzReleaseTrackId:  return "mbz_release_track_id"
+        case .mbzReleaseGroupId:  return "mbz_release_group_id"
+        // Numeric
+        case .year:               return "year"
+        case .duration:           return "duration"
+        case .size:               return "size"
+        case .channels:           return "channels"
+        case .bitRate:            return "bitrate"
+        case .bitDepth:           return "bitdepth"
+        case .sampleRate:         return "samplerate"
+        case .bpm:                return "bpm"
+        case .playCount:          return "playcount"
+        case .rating:             return "rating"
+        case .averageRating:      return "averagerating"
+        case .albumRating:        return "albumrating"
+        case .albumPlayCount:     return "albumplaycount"
+        case .artistRating:       return "artistrating"
+        case .artistPlayCount:    return "artistplaycount"
+        case .trackNumber:        return "tracknumber"
+        case .discNumber:         return "discnumber"
+        // Date-relative
+        case .lastPlayed:         return "lastplayed"
+        case .dateLoved:          return "dateloved"
+        case .dateRated:          return "daterated"
+        case .dateAdded:          return "dateadded"
+        case .dateModified:       return "datemodified"
+        case .albumLastPlayed:    return "albumlastplayed"
+        case .albumDateLoved:     return "albumdateloved"
+        case .albumDateRated:     return "albumdaterated"
+        case .artistLastPlayed:   return "artistlastplayed"
+        case .artistDateLoved:    return "artistdateloved"
+        case .artistDateRated:    return "artistdaterated"
+        // Boolean
+        case .isFavorited:        return "loved"
+        case .albumFavorited:     return "albumloved"
+        case .artistFavorited:    return "artistloved"
+        case .hasCoverArt:        return "hascoverart"
+        case .isCompilation:      return "compilation"
+        case .isMissing:          return "missing"
+        // Local-only — no server mapping
+        case .isDownloaded:       return nil
+        // Playlist membership — handled specially in playlistNSP(), not via nspField
+        case .inPlaylist, .notInPlaylist: return nil
+        }
+    }
+}
+
+// MARK: - NSPCriteria → FilterRuleSet (best-effort round-trip)
+
+extension FilterRuleSet {
+    /// Reconstruct a `FilterRuleSet` from an `NSPCriteria` for display in the rule editor.
+    /// This is a best-effort reverse mapping; operators not supported locally are skipped.
+    init(from criteria: NSPCriteria) {
+        let combinator: Combinator = criteria.combinator == .all ? .all : .any
+        var rules: [FilterRule] = []
+        for expr in criteria.expressions {
+            if let rule = FilterRule(from: expr) {
+                rules.append(rule)
+            }
+        }
+        self.init(combinator: combinator, rules: rules)
+    }
+}
+
+private extension FilterRule {
+    init?(from expr: NSPExpression) {
+        guard case .leaf(let op, let nspFieldName, let value) = expr else { return nil }
+        guard let field = FilterField.allCases.first(where: { $0.nspField == nspFieldName }) else { return nil }
+        guard let pair = Self.decode(op: op, value: value, kind: field.kind) else { return nil }
+        self.init(id: UUID(), field: field, operator: pair.op, value: pair.value)
+    }
+
+    private static func decode(
+        op: String, value: NSPValue, kind: FilterField.FieldKind
+    ) -> (op: FilterOperator, value: FilterValue)? {
+        switch kind {
+        case .text:    return decodeText(op: op, value: value)
+        case .numeric: return decodeNumeric(op: op, value: value)
+        case .boolean: return decodeBoolean(value: value)
+        case .days:    return decodeDays(op: op, value: value)
+        case .playlist: return nil
+        }
+    }
+
+    private static func decodeText(op: String, value: NSPValue) -> (op: FilterOperator, value: FilterValue)? {
+        let filterOp: FilterOperator
+        switch op {
+        case "contains":    filterOp = .contains
+        case "notContains": filterOp = .notContains
+        case "is":          filterOp = .equals
+        case "isNot":       filterOp = .notEquals
+        case "startsWith":  filterOp = .startsWith
+        case "endsWith":    filterOp = .endsWith
+        default:            return nil
+        }
+        guard case .string(let s) = value else { return nil }
+        return (filterOp, .text(s))
+    }
+
+    private static func decodeNumeric(op: String, value: NSPValue) -> (op: FilterOperator, value: FilterValue)? {
+        if op == "inTheRange" {
+            guard case .range(let lo, let hi) = value,
+                  case .int(let loInt) = lo, case .int(let hiInt) = hi else { return nil }
+            return (.isBetween, .range(loInt, hiInt))
+        }
+        let filterOp: FilterOperator
+        switch op {
+        case "is":    filterOp = .isEqualTo
+        case "isNot": filterOp = .isNotEqualTo
+        case "gt":    filterOp = .isGreaterThan
+        case "lt":    filterOp = .isLessThan
+        default:      return nil
+        }
+        guard case .int(let n) = value else { return nil }
+        return (filterOp, .number(n))
+    }
+
+    private static func decodeBoolean(value: NSPValue) -> (op: FilterOperator, value: FilterValue)? {
+        if case .bool(let b) = value { return (.isTrue, .boolean(b)) }
+        return (.isTrue, .boolean(true))
+    }
+
+    private static func decodeDays(op: String, value: NSPValue) -> (op: FilterOperator, value: FilterValue)? {
+        let filterOp: FilterOperator
+        switch op {
+        case "gt": filterOp = .isGreaterThan
+        case "lt": filterOp = .isLessThan
+        default:   return nil
+        }
+        guard case .int(let n) = value else { return nil }
+        return (filterOp, .number(n))
+    }
+}

--- a/Vibrdrome/Core/Models/NSPCriteria.swift
+++ b/Vibrdrome/Core/Models/NSPCriteria.swift
@@ -454,13 +454,21 @@ private extension FilterRule {
     }
 
     private static func decodeDays(op: String, value: NSPValue) -> (op: FilterOperator, value: FilterValue)? {
-        let filterOp: FilterOperator
         switch op {
-        case "gt": filterOp = .isGreaterThan
-        case "lt": filterOp = .isLessThan
-        default:   return nil
+        case "inTheLast":
+            guard case .int(let n) = value else { return nil }
+            return (.inTheLast, .number(n))
+        case "notInTheLast":
+            guard case .int(let n) = value else { return nil }
+            return (.notInTheLast, .number(n))
+        case "before":
+            guard case .string(let date) = value else { return nil }
+            return (.before, .text(date))
+        case "after":
+            guard case .string(let date) = value else { return nil }
+            return (.after, .text(date))
+        default:
+            return nil
         }
-        guard case .int(let n) = value else { return nil }
-        return (filterOp, .number(n))
     }
 }

--- a/Vibrdrome/Core/Models/NSPCriteria.swift
+++ b/Vibrdrome/Core/Models/NSPCriteria.swift
@@ -248,16 +248,10 @@ private extension FilterRule {
         switch value {
         case .number(let n):
             switch `operator` {
-            case .isEqualTo:       return ("is", field, .int(n))
-            case .isNotEqualTo:    return ("isNot", field, .int(n))
-            case .isGreaterThan:   return ("gt", field, .int(n))
-            case .isLessThan:      return ("lt", field, .int(n))
-            case .isGreaterOrEqual:
-                // NSP has no ≥; emulate with gt(n-1) for integer fields.
-                return ("gt", field, .int(n - 1))
-            case .isLessOrEqual:
-                // NSP has no ≤; emulate with lt(n+1) for integer fields.
-                return ("lt", field, .int(n + 1))
+            case .isEqualTo:     return ("is", field, .int(n))
+            case .isNotEqualTo:  return ("isNot", field, .int(n))
+            case .isGreaterThan: return ("gt", field, .int(n))
+            case .isLessThan:    return ("lt", field, .int(n))
             default: return nil
             }
         case .range(let lo, let hi):
@@ -425,13 +419,13 @@ private extension FilterRule {
 
     private static func decodeText(op: String, value: NSPValue) -> (op: FilterOperator, value: FilterValue)? {
         let filterOp: FilterOperator
-        switch op {
+        switch op.lowercased() {
         case "contains":    filterOp = .contains
-        case "notContains": filterOp = .notContains
+        case "notcontains": filterOp = .notContains
         case "is":          filterOp = .equals
-        case "isNot":       filterOp = .notEquals
-        case "startsWith":  filterOp = .startsWith
-        case "endsWith":    filterOp = .endsWith
+        case "isnot":       filterOp = .notEquals
+        case "startswith":  filterOp = .startsWith
+        case "endswith":    filterOp = .endsWith
         default:            return nil
         }
         guard case .string(let s) = value else { return nil }
@@ -439,15 +433,15 @@ private extension FilterRule {
     }
 
     private static func decodeNumeric(op: String, value: NSPValue) -> (op: FilterOperator, value: FilterValue)? {
-        if op == "inTheRange" {
+        if op.lowercased() == "intherange" {
             guard case .range(let lo, let hi) = value,
                   case .int(let loInt) = lo, case .int(let hiInt) = hi else { return nil }
             return (.isBetween, .range(loInt, hiInt))
         }
         let filterOp: FilterOperator
-        switch op {
+        switch op.lowercased() {
         case "is":    filterOp = .isEqualTo
-        case "isNot": filterOp = .isNotEqualTo
+        case "isnot": filterOp = .isNotEqualTo
         case "gt":    filterOp = .isGreaterThan
         case "lt":    filterOp = .isLessThan
         default:      return nil
@@ -462,11 +456,11 @@ private extension FilterRule {
     }
 
     private static func decodeDays(op: String, value: NSPValue) -> (op: FilterOperator, value: FilterValue)? {
-        switch op {
-        case "inTheLast":
+        switch op.lowercased() {
+        case "inthelast":
             guard case .int(let n) = value else { return nil }
             return (.inTheLast, .number(n))
-        case "notInTheLast":
+        case "notinthelast":
             guard case .int(let n) = value else { return nil }
             return (.notInTheLast, .number(n))
         case "before":

--- a/Vibrdrome/Core/Networking/NavidromeNativeClient.swift
+++ b/Vibrdrome/Core/Networking/NavidromeNativeClient.swift
@@ -212,13 +212,16 @@ final class NavidromeNativeClient {
 
     /// Probe the server to confirm it is Navidrome, and authenticate.
     /// Safe to call repeatedly — returns quickly if already available.
-    func probe() async {
-        guard !isAvailable else { return }
+    /// Returns `true` when authentication succeeded, `false` otherwise.
+    func probe() async -> Bool {
+        guard !isAvailable else { return true }
         do {
             try await login()
+            return true
         } catch {
             isAvailable = false
             ndLog.info("Navidrome native API not available: \(error.localizedDescription)")
+            return false
         }
     }
 
@@ -254,6 +257,7 @@ final class NavidromeNativeClient {
     }
 
     /// Fetch all playlists (both smart and regular).
+    /// Hard-capped at 500; users with more playlists will see incomplete smart-playlist detection.
     func getPlaylists() async throws -> [NDSmartPlaylist] {
         let data = try await nativeRequest(method: "GET", path: "api/playlist?_end=500&_start=0", body: nil)
         do {

--- a/Vibrdrome/Core/Networking/NavidromeNativeClient.swift
+++ b/Vibrdrome/Core/Networking/NavidromeNativeClient.swift
@@ -112,7 +112,8 @@ struct NDSong: Decodable, Sendable {
 struct NDAlbum: Decodable, Sendable {
     let id: String
     let name: String
-    let artist: String?
+    /// Display name of the album artist (Navidrome field: `albumArtist`).
+    let albumArtist: String?
     let artistId: String?
     let albumArtistId: String?
     let genre: String?
@@ -140,12 +141,30 @@ struct NDAlbum: Decodable, Sendable {
     let smallImageUrl: String?
     let largeImageUrl: String?
     let comment: String?
+    let catalogNum: String?
+    let mbzAlbumType: String?
+    let mbzAlbumComment: String?
+    let sortAlbumName: String?
+    let sortAlbumArtistName: String?
+    let minYear: Int?
+    let maxYear: Int?
+    /// All imported tags, e.g. `{"recordlabel": ["Warp Records"], "releasetype": ["Album"], ...}`.
+    let tags: [String: [String]]?
+
+    var recordLabel: String? { tags?["recordlabel"]?.first }
+    var releaseType: String? { tags?["releasetype"]?.first }
+    var releaseCountry: String? { tags?["releasecountry"]?.first }
+    var releaseStatus: String? { tags?["releasestatus"]?.first }
+    var mood: String? { tags?["mood"]?.first }
+    var grouping: String? { tags?["grouping"]?.first }
+    var mediaType: String? { tags?["media"]?.first }
 
     enum CodingKeys: String, CodingKey {
-        case id, name, artist, artistId, albumArtistId, genre, genres, year, songCount, duration, size
+        case id, name, albumArtist, artistId, albumArtistId, genre, genres, year, songCount, duration, size
         case starred, starredAt, rating, playCount, playDate, createdAt, compilation
-        case mbzAlbumId, mbzAlbumArtistId, mbzReleaseGroupId
-        case smallImageUrl, largeImageUrl, comment
+        case mbzAlbumId, mbzAlbumArtistId, mbzReleaseGroupId, mbzAlbumType, mbzAlbumComment
+        case smallImageUrl, largeImageUrl, comment, catalogNum, tags
+        case sortAlbumName, sortAlbumArtistName, minYear, maxYear
     }
 }
 

--- a/Vibrdrome/Core/Networking/NavidromeNativeClient.swift
+++ b/Vibrdrome/Core/Networking/NavidromeNativeClient.swift
@@ -1,0 +1,367 @@
+import Foundation
+import os.log
+
+private let ndLog = Logger(subsystem: "com.vibrdrome.app", category: "NavidromeNative")
+
+// MARK: - Errors
+
+enum NavidromeNativeError: LocalizedError {
+    case notNavidrome
+    case authFailed(String)
+    case httpError(Int)
+    case decodingError(Error)
+    case invalidURL
+
+    var errorDescription: String? {
+        switch self {
+        case .notNavidrome:       return "Server does not appear to be Navidrome"
+        case .authFailed(let m):  return "Navidrome authentication failed: \(m)"
+        case .httpError(let c):   return "HTTP \(c)"
+        case .decodingError(let e): return "Decode error: \(e.localizedDescription)"
+        case .invalidURL:         return "Invalid URL"
+        }
+    }
+}
+
+// MARK: - Response models
+
+private struct NDLoginResponse: Decodable {
+    let token: String
+    let id: String?
+}
+
+struct NDSmartPlaylist: Decodable, Sendable {
+    let id: String
+    let name: String
+    let comment: String?
+    let rules: NSPCriteria?
+    let sync: Bool?
+}
+
+// MARK: - Song / Album response models
+
+struct NDGenre: Decodable, Sendable {
+    let id: String?
+    let name: String
+}
+
+struct NDSong: Decodable, Sendable {
+    let id: String
+    let title: String
+    let album: String?
+    let albumId: String?
+    let artist: String?
+    let albumArtist: String?
+    let artistId: String?
+    let albumArtistId: String?
+    let trackNumber: Int?
+    let discNumber: Int?
+    let year: Int?
+    let genre: String?
+    let genres: [NDGenre]?
+
+    /// All genre names. Prefers the `genres` array; falls back to single `genre`.
+    var allGenres: [String] {
+        if let arr = genres, !arr.isEmpty { return arr.map(\.name) }
+        return genre.map { [$0] } ?? []
+    }
+    let size: Int?
+    let suffix: String?
+    let contentType: String?          // maps to `suffix` mime — not present, use `suffix`
+    let duration: Double?
+    let bitRate: Int?
+    let bitDepth: Int?
+    let sampleRate: Int?
+    let channels: Int?
+    let bpm: Int?
+    let comment: String?
+    let path: String?
+    let compilation: Bool?
+    let hasCoverArt: Bool?
+    let starred: Bool?
+    let starredAt: String?
+    let rating: Int?
+    let playCount: Int?
+    let playDate: String?
+    let createdAt: String?
+    let mbzRecordingId: String?       // not in ND API directly — use mbzReleaseTrackId
+    let mbzReleaseTrackId: String?
+    let mbzAlbumId: String?
+    let mbzArtistId: String?
+    let mbzAlbumArtistId: String?
+    let rgTrackGain: Double?
+    let rgTrackPeak: Double?
+    let rgAlbumGain: Double?
+    let rgAlbumPeak: Double?
+    let smallImageUrl: String?
+    let largeImageUrl: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id, title, album, albumId, artist, albumArtist, artistId, albumArtistId
+        case trackNumber, discNumber, year, genre, genres, size, suffix, duration
+        case bitRate, bitDepth, sampleRate, channels, bpm, comment, path
+        case compilation, hasCoverArt, starred, starredAt, rating, playCount, playDate, createdAt
+        case mbzReleaseTrackId, mbzAlbumId, mbzArtistId, mbzAlbumArtistId
+        case rgTrackGain, rgTrackPeak, rgAlbumGain, rgAlbumPeak
+        case smallImageUrl, largeImageUrl
+        case contentType
+        case mbzRecordingId
+    }
+}
+
+struct NDAlbum: Decodable, Sendable {
+    let id: String
+    let name: String
+    let artist: String?
+    let artistId: String?
+    let albumArtistId: String?
+    let genre: String?
+    let genres: [NDGenre]?
+    let year: Int?
+
+    /// All genre names. Prefers the `genres` array; falls back to single `genre`.
+    var allGenres: [String] {
+        if let arr = genres, !arr.isEmpty { return arr.map(\.name) }
+        return genre.map { [$0] } ?? []
+    }
+    let songCount: Int?
+    let duration: Double?
+    let size: Int?
+    let starred: Bool?
+    let starredAt: String?
+    let rating: Int?
+    let playCount: Int?
+    let playDate: String?
+    let createdAt: String?
+    let compilation: Bool?
+    let mbzAlbumId: String?
+    let mbzAlbumArtistId: String?
+    let mbzReleaseGroupId: String?
+    let smallImageUrl: String?
+    let largeImageUrl: String?
+    let comment: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id, name, artist, artistId, albumArtistId, genre, genres, year, songCount, duration, size
+        case starred, starredAt, rating, playCount, playDate, createdAt, compilation
+        case mbzAlbumId, mbzAlbumArtistId, mbzReleaseGroupId
+        case smallImageUrl, largeImageUrl, comment
+    }
+}
+
+// MARK: - NavidromeNativeClient
+
+/// Thin client for Navidrome's own REST API (`/api/…`), used for smart-playlist
+/// create/update/delete with embedded NSP criteria rules.
+///
+/// Auth flow: POST /auth/login → JWT → X-ND-Authorization: Bearer <token>
+/// The JWT is cached in memory until invalidated.
+@Observable
+@MainActor
+final class NavidromeNativeClient {
+
+    private let baseURL: URL
+    private let username: String
+    private let password: String
+    private let session: URLSession
+
+    /// Cached JWT token. Nil until first login; cleared on 401.
+    private var token: String?
+
+    var isAvailable: Bool = false
+
+    init(baseURL: URL, username: String, password: String) {
+        self.baseURL = baseURL
+        self.username = username
+        self.password = password
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = 30
+        config.httpShouldSetCookies = false
+        config.httpCookieAcceptPolicy = .never
+        config.httpCookieStorage = nil
+        config.urlCredentialStorage = nil
+        self.session = URLSession(configuration: config)
+    }
+
+    // MARK: - Auth
+
+    /// Authenticate and cache the JWT. Throws NavidromeNativeError.authFailed on bad credentials.
+    func login() async throws {
+        let url = baseURL.appendingPathComponent("auth/login")
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        let body = ["username": username, "password": password]
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        let (data, response) = try await session.data(for: request)
+        let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
+        guard statusCode == 200 else {
+            throw NavidromeNativeError.authFailed("HTTP \(statusCode)")
+        }
+
+        do {
+            let decoded = try JSONDecoder().decode(NDLoginResponse.self, from: data)
+            token = decoded.token
+            isAvailable = true
+            ndLog.info("Navidrome native auth OK (user: \(self.username))")
+        } catch {
+            throw NavidromeNativeError.authFailed("Could not decode login response")
+        }
+    }
+
+    /// Probe the server to confirm it is Navidrome, and authenticate.
+    /// Safe to call repeatedly — returns quickly if already available.
+    func probe() async {
+        guard !isAvailable else { return }
+        do {
+            try await login()
+        } catch {
+            isAvailable = false
+            ndLog.info("Navidrome native API not available: \(error.localizedDescription)")
+        }
+    }
+
+    // MARK: - Playlist CRUD
+
+    /// Create a new smart playlist on the server. Returns the new playlist ID.
+    @discardableResult
+    func createSmartPlaylist(name: String, comment: String = "", rules: NSPCriteria) async throws -> String {
+        let body = buildPlaylistBody(name: name, comment: comment, rules: rules)
+        let data = try await nativeRequest(method: "POST", path: "api/playlist", body: body)
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let id = json["id"] as? String else {
+            throw NavidromeNativeError.decodingError(
+                NSError(domain: "NavidromeNative", code: -1,
+                        userInfo: [NSLocalizedDescriptionKey: "Missing id in createPlaylist response"])
+            )
+        }
+        ndLog.info("Created smart playlist '\(name)' (id: \(id))")
+        return id
+    }
+
+    /// Update rules (and optionally name/comment) of an existing playlist.
+    func updateSmartPlaylist(id: String, name: String, comment: String = "", rules: NSPCriteria) async throws {
+        let body = buildPlaylistBody(name: name, comment: comment, rules: rules)
+        _ = try await nativeRequest(method: "PUT", path: "api/playlist/\(id)", body: body)
+        ndLog.info("Updated smart playlist '\(name)' (id: \(id))")
+    }
+
+    /// Delete a playlist.
+    func deletePlaylist(id: String) async throws {
+        _ = try await nativeRequest(method: "DELETE", path: "api/playlist/\(id)", body: nil)
+        ndLog.info("Deleted playlist id: \(id)")
+    }
+
+    /// Fetch all playlists (both smart and regular).
+    func getPlaylists() async throws -> [NDSmartPlaylist] {
+        let data = try await nativeRequest(method: "GET", path: "api/playlist?_end=500&_start=0", body: nil)
+        do {
+            return try JSONDecoder().decode([NDSmartPlaylist].self, from: data)
+        } catch {
+            throw NavidromeNativeError.decodingError(error)
+        }
+    }
+
+    // MARK: - Song / Album fetch
+
+    /// Fetch a page of songs from the Navidrome native API.
+    /// Returns `(items, totalCount)` where totalCount comes from the `x-total-count` header.
+    func getSongs(start: Int, end: Int) async throws -> (items: [NDSong], total: Int) {
+        let path = "api/song?_start=\(start)&_end=\(end)&_sort=title&_order=ASC"
+        let (data, response) = try await nativeRequestWithResponse(method: "GET", path: path, body: nil)
+        let total = (response as? HTTPURLResponse)
+            .flatMap { $0.value(forHTTPHeaderField: "x-total-count") }
+            .flatMap { Int($0) } ?? 0
+        do {
+            let items = try JSONDecoder().decode([NDSong].self, from: data)
+            return (items, total)
+        } catch {
+            throw NavidromeNativeError.decodingError(error)
+        }
+    }
+
+    /// Fetch a page of albums from the Navidrome native API.
+    func getAlbums(start: Int, end: Int) async throws -> (items: [NDAlbum], total: Int) {
+        let path = "api/album?_start=\(start)&_end=\(end)&_sort=name&_order=ASC"
+        let (data, response) = try await nativeRequestWithResponse(method: "GET", path: path, body: nil)
+        let total = (response as? HTTPURLResponse)
+            .flatMap { $0.value(forHTTPHeaderField: "x-total-count") }
+            .flatMap { Int($0) } ?? 0
+        do {
+            let items = try JSONDecoder().decode([NDAlbum].self, from: data)
+            return (items, total)
+        } catch {
+            throw NavidromeNativeError.decodingError(error)
+        }
+    }
+
+    // MARK: - Private helpers
+
+    private func buildPlaylistBody(name: String, comment: String, rules: NSPCriteria) -> [String: Any] {
+        var body: [String: Any] = [
+            "name": name,
+            "comment": comment,
+            "sync": true,
+        ]
+        if let rulesJSON = rules.toJSON() {
+            body["rules"] = rulesJSON
+        }
+        return body
+    }
+
+    private func nativeRequest(method: String, path: String, body: [String: Any]?) async throws -> Data {
+        let (data, _) = try await nativeRequestWithResponse(method: method, path: path, body: body)
+        return data
+    }
+
+    private func nativeRequestWithResponse(method: String, path: String, body: [String: Any]?) async throws -> (Data, URLResponse) {
+        // Ensure we have a token
+        if token == nil {
+            try await login()
+        }
+
+        guard let tok = token else {
+            throw NavidromeNativeError.authFailed("No token after login")
+        }
+
+        guard let url = URL(string: path, relativeTo: baseURL) else {
+            throw NavidromeNativeError.invalidURL
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        request.setValue("Bearer \(tok)", forHTTPHeaderField: "X-ND-Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        if let body {
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        }
+
+        let (data, response) = try await session.data(for: request)
+        let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
+
+        if statusCode == 401 {
+            // Token expired — clear and retry once
+            token = nil
+            isAvailable = false
+            try await login()
+            guard let newTok = token else {
+                throw NavidromeNativeError.authFailed("Re-login failed")
+            }
+            request.setValue("Bearer \(newTok)", forHTTPHeaderField: "X-ND-Authorization")
+            let (retryData, retryResponse) = try await session.data(for: request)
+            let retryStatus = (retryResponse as? HTTPURLResponse)?.statusCode ?? 0
+            guard (200...299).contains(retryStatus) else {
+                throw NavidromeNativeError.httpError(retryStatus)
+            }
+            return (retryData, retryResponse)
+        }
+
+        guard (200...299).contains(statusCode) else {
+            throw NavidromeNativeError.httpError(statusCode)
+        }
+
+        return (data, response)
+    }
+}

--- a/Vibrdrome/Core/Networking/SubsonicModels.swift
+++ b/Vibrdrome/Core/Networking/SubsonicModels.swift
@@ -214,6 +214,9 @@ struct Song: Decodable, Identifiable, Sendable, Equatable {
     let suffix: String?
     let duration: Int?
     let bitRate: Int?
+    let bitDepth: Int?
+    let samplingRate: Int?
+    let comment: String?
     let path: String?
     let discNumber: Int?
     let created: String?
@@ -230,8 +233,9 @@ struct Song: Decodable, Identifiable, Sendable, Equatable {
         track: Int? = nil, year: Int? = nil, genre: String? = nil,
         coverArt: String? = nil, size: Int? = nil,
         contentType: String? = nil, suffix: String? = nil,
-        duration: Int? = nil, bitRate: Int? = nil, path: String? = nil,
-        discNumber: Int? = nil, created: String? = nil,
+        duration: Int? = nil, bitRate: Int? = nil,
+        bitDepth: Int? = nil, samplingRate: Int? = nil, comment: String? = nil,
+        path: String? = nil, discNumber: Int? = nil, created: String? = nil,
         starred: String? = nil, userRating: Int? = nil,
         bpm: Int? = nil, replayGain: ReplayGain? = nil, musicBrainzId: String? = nil
     ) {
@@ -241,8 +245,9 @@ struct Song: Decodable, Identifiable, Sendable, Equatable {
         self.track = track; self.year = year; self.genre = genre
         self.coverArt = coverArt; self.size = size
         self.contentType = contentType; self.suffix = suffix
-        self.duration = duration; self.bitRate = bitRate; self.path = path
-        self.discNumber = discNumber; self.created = created
+        self.duration = duration; self.bitRate = bitRate
+        self.bitDepth = bitDepth; self.samplingRate = samplingRate; self.comment = comment
+        self.path = path; self.discNumber = discNumber; self.created = created
         self.starred = starred; self.userRating = userRating
         self.bpm = bpm; self.replayGain = replayGain; self.musicBrainzId = musicBrainzId
     }
@@ -255,8 +260,9 @@ struct Song: Decodable, Identifiable, Sendable, Equatable {
             track: track, year: year, genre: genre,
             coverArt: coverArt, size: size,
             contentType: contentType, suffix: suffix,
-            duration: duration, bitRate: bitRate, path: path,
-            discNumber: discNumber, created: created,
+            duration: duration, bitRate: bitRate,
+            bitDepth: bitDepth, samplingRate: samplingRate, comment: comment,
+            path: path, discNumber: discNumber, created: created,
             starred: starred, userRating: userRating,
             bpm: bpm, replayGain: replayGain, musicBrainzId: musicBrainzId
         )
@@ -270,8 +276,9 @@ struct Song: Decodable, Identifiable, Sendable, Equatable {
             track: track, year: year, genre: genre,
             coverArt: coverArt, size: size,
             contentType: contentType, suffix: suffix,
-            duration: duration, bitRate: bitRate, path: path,
-            discNumber: discNumber, created: created,
+            duration: duration, bitRate: bitRate,
+            bitDepth: bitDepth, samplingRate: samplingRate, comment: comment,
+            path: path, discNumber: discNumber, created: created,
             starred: starred, userRating: rating,
             bpm: bpm, replayGain: replayGain, musicBrainzId: musicBrainzId
         )

--- a/Vibrdrome/Core/Persistence/BackgroundSyncScheduler.swift
+++ b/Vibrdrome/Core/Persistence/BackgroundSyncScheduler.swift
@@ -121,6 +121,7 @@ final class BackgroundSyncScheduler {
         let syncTask = Task {
             await appState.librarySyncManager.incrementalSync(
                 client: appState.subsonicClient,
+                ndClient: appState.navidromeClient,
                 container: PersistenceController.shared.container
             )
         }
@@ -150,6 +151,7 @@ final class BackgroundSyncScheduler {
         let syncTask = Task {
             await appState.librarySyncManager.sync(
                 client: appState.subsonicClient,
+                ndClient: appState.navidromeClient,
                 container: PersistenceController.shared.container
             )
         }

--- a/Vibrdrome/Core/Persistence/LibrarySyncManager+ND.swift
+++ b/Vibrdrome/Core/Persistence/LibrarySyncManager+ND.swift
@@ -1,0 +1,113 @@
+import SwiftData
+
+// MARK: - Navidrome-native sync helpers (extracted to keep LibrarySyncManager within size limits)
+
+extension LibrarySyncManager {
+
+    // swiftlint:disable:next function_parameter_count
+    nonisolated static func syncAlbumsND(
+        ndClient: NavidromeNativeClient, context: ModelContext, allLocal: [CachedAlbum],
+        localMap: inout [String: CachedAlbum], serverIds: inout Set<String>,
+        stats: inout SyncStats, progress: @Sendable (String) -> Void
+    ) async throws -> Int {
+        var start = 0
+        var totalFetched = 0
+        while true {
+            let (page, total) = try await ndClient.getAlbums(start: start, end: start + albumPageSize)
+            if page.isEmpty { break }
+            for ndAlbum in page {
+                serverIds.insert(ndAlbum.id)
+                if let existing = localMap[ndAlbum.id] {
+                    if hasNDAlbumChanged(existing, ndAlbum) { existing.update(from: ndAlbum); stats.albumsUpdated += 1 }
+                } else {
+                    let cached = CachedAlbum(from: ndAlbum)
+                    context.insert(cached); localMap[ndAlbum.id] = cached; stats.albumsAdded += 1
+                }
+            }
+            totalFetched += page.count
+            progress("Syncing albums… \(totalFetched)/\(total)")
+            start += page.count
+            if totalFetched >= total || page.count < albumPageSize { break }
+        }
+        for local in allLocal where !serverIds.contains(local.id) { context.delete(local); stats.albumsRemoved += 1 }
+        return totalFetched
+    }
+
+    nonisolated static func hasNDAlbumChanged(_ cached: CachedAlbum, _ server: NDAlbum) -> Bool {
+        cached.name != server.name ||
+        cached.artistId != server.artistId ||
+        cached.year != server.year ||
+        cached.songCount != server.songCount ||
+        cached.duration != server.duration.map({ Int($0) }) ||
+        cached.isStarred != (server.starred ?? false) ||
+        cached.userRating != (server.rating ?? 0) ||
+        cached.musicBrainzId != server.mbzAlbumId ||
+        cached.mbzAlbumArtistId != server.mbzAlbumArtistId ||
+        cached.mbzReleaseGroupId != server.mbzReleaseGroupId ||
+        cached.playCount != (server.playCount ?? 0) ||
+        cached.isCompilation != (server.compilation ?? false) ||
+        Set(cached.genres) != Set(server.allGenres)
+    }
+
+    // swiftlint:disable:next function_parameter_count
+    nonisolated static func syncSongsND(
+        ndClient: NavidromeNativeClient, context: ModelContext,
+        allLocal: [CachedSong], albumMap: [String: CachedAlbum],
+        localMap: inout [String: CachedSong], serverIds: inout Set<String>,
+        stats: inout SyncStats,
+        progress: @Sendable (String) -> Void,
+        publishStats: @Sendable (SyncStats) -> Void
+    ) async throws -> Int {
+        var start = 0
+        var totalFetched = 0
+        while true {
+            let (page, total) = try await ndClient.getSongs(start: start, end: start + songPageSize)
+            if page.isEmpty { break }
+            for ndSong in page {
+                serverIds.insert(ndSong.id)
+                if let existing = localMap[ndSong.id] {
+                    if hasNDSongChanged(existing, ndSong) {
+                        existing.update(from: ndSong)
+                        if let albumId = ndSong.albumId { existing.album = albumMap[albumId] }
+                        stats.songsUpdated += 1
+                    }
+                } else {
+                    let cached = CachedSong(from: ndSong)
+                    if let albumId = ndSong.albumId { cached.album = albumMap[albumId] }
+                    context.insert(cached); localMap[ndSong.id] = cached; stats.songsAdded += 1
+                }
+            }
+            totalFetched += page.count
+            progress("Syncing songs… \(totalFetched)/\(total)")
+            start += page.count
+            if totalFetched % 2000 == 0 { try context.save(); publishStats(stats) }
+            if totalFetched >= total || page.count < songPageSize { break }
+        }
+        for local in allLocal where !serverIds.contains(local.id) && local.download == nil {
+            context.delete(local); stats.songsRemoved += 1
+        }
+        return totalFetched
+    }
+
+    nonisolated static func hasNDSongChanged(_ cached: CachedSong, _ server: NDSong) -> Bool {
+        cached.title != server.title ||
+        cached.artist != server.artist ||
+        cached.albumName != server.album ||
+        cached.track != server.trackNumber ||
+        cached.year != server.year ||
+        cached.genre != server.allGenres.first ||
+        cached.duration != server.duration.map({ Int($0) }) ||
+        cached.isStarred != (server.starred ?? false) ||
+        cached.bitRate != server.bitRate ||
+        cached.bitDepth != server.bitDepth ||
+        cached.samplingRate != server.sampleRate ||
+        cached.channels != server.channels ||
+        cached.comment != server.comment ||
+        cached.bpm != server.bpm ||
+        cached.mbzRecordingId != server.mbzReleaseTrackId ||
+        cached.rating != (server.rating ?? 0) ||
+        cached.playCount != (server.playCount ?? 0) ||
+        cached.isCompilation != (server.compilation ?? false) ||
+        cached.hasCoverArt != (server.hasCoverArt ?? false)
+    }
+}

--- a/Vibrdrome/Core/Persistence/LibrarySyncManager+ND.swift
+++ b/Vibrdrome/Core/Persistence/LibrarySyncManager+ND.swift
@@ -35,17 +35,32 @@ extension LibrarySyncManager {
 
     nonisolated static func hasNDAlbumChanged(_ cached: CachedAlbum, _ server: NDAlbum) -> Bool {
         cached.name != server.name ||
-        cached.artistId != server.artistId ||
-        cached.year != server.year ||
+        cached.artistName != server.albumArtist ||
+        cached.artistId != server.albumArtistId ||
+        cached.year != (server.minYear ?? server.year) ||
+        cached.minYear != server.minYear ||
+        cached.maxYear != server.maxYear ||
         cached.songCount != server.songCount ||
         cached.duration != server.duration.map({ Int($0) }) ||
         cached.isStarred != (server.starred ?? false) ||
         cached.userRating != (server.rating ?? 0) ||
+        cached.playCount != (server.playCount ?? 0) ||
+        cached.isCompilation != (server.compilation ?? false) ||
+        cached.label != server.recordLabel ||
+        cached.catalogNum != server.catalogNum ||
+        cached.releaseType != server.releaseType ||
+        cached.releaseCountry != server.releaseCountry ||
+        cached.releaseStatus != server.releaseStatus ||
+        cached.mood != server.mood ||
+        cached.grouping != server.grouping ||
+        cached.mediaType != server.mediaType ||
+        cached.sortAlbumName != server.sortAlbumName ||
+        cached.sortAlbumArtistName != server.sortAlbumArtistName ||
         cached.musicBrainzId != server.mbzAlbumId ||
         cached.mbzAlbumArtistId != server.mbzAlbumArtistId ||
         cached.mbzReleaseGroupId != server.mbzReleaseGroupId ||
-        cached.playCount != (server.playCount ?? 0) ||
-        cached.isCompilation != (server.compilation ?? false) ||
+        cached.mbzAlbumType != server.mbzAlbumType ||
+        cached.mbzAlbumComment != server.mbzAlbumComment ||
         Set(cached.genres) != Set(server.allGenres)
     }
 
@@ -108,6 +123,8 @@ extension LibrarySyncManager {
         cached.rating != (server.rating ?? 0) ||
         cached.playCount != (server.playCount ?? 0) ||
         cached.isCompilation != (server.compilation ?? false) ||
-        cached.hasCoverArt != (server.hasCoverArt ?? false)
+        cached.hasCoverArt != (server.hasCoverArt ?? false) ||
+        cached.rgTrackGain != server.rgTrackGain ||
+        cached.rgAlbumGain != server.rgAlbumGain
     }
 }

--- a/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
+++ b/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
@@ -4,7 +4,7 @@ import SwiftData
 import os.log
 
 private let syncLog = Logger(subsystem: "com.vibrdrome.app", category: "LibrarySync")
-private let syncISO8601 = ISO8601DateFormatter()
+nonisolated(unsafe) private let syncISO8601 = ISO8601DateFormatter()
 
 /// Sync mode determines the depth of library synchronization.
 enum SyncMode: String, Sendable {
@@ -571,13 +571,15 @@ final class LibrarySyncManager {
         cached.genre != server.genre ||
         cached.duration != server.duration ||
         cached.isStarred != (server.starred != nil) ||
+        cached.rating != (server.userRating ?? 0) ||
         cached.coverArtId != server.coverArt ||
         cached.bitRate != server.bitRate ||
         cached.bitDepth != server.bitDepth ||
         cached.samplingRate != server.samplingRate ||
         cached.comment != server.comment ||
         cached.bpm != server.bpm ||
-        cached.mbzRecordingId != server.musicBrainzId
+        cached.mbzRecordingId != server.musicBrainzId ||
+        cached.rgTrackGain != server.replayGain?.trackGain || cached.rgAlbumGain != server.replayGain?.albumGain
     }
 
     nonisolated static func updateSongFields(_ cached: CachedSong, from song: Song) {
@@ -605,6 +607,8 @@ final class LibrarySyncManager {
         cached.mbzRecordingId = song.musicBrainzId
         cached.isStarred = song.starred != nil
         cached.rating = song.userRating ?? 0
+        cached.rgTrackGain = song.replayGain?.trackGain; cached.rgTrackPeak = song.replayGain?.trackPeak
+        cached.rgAlbumGain = song.replayGain?.albumGain; cached.rgAlbumPeak = song.replayGain?.albumPeak
         cached.cachedAt = Date()
     }
 

--- a/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
+++ b/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
@@ -4,6 +4,7 @@ import SwiftData
 import os.log
 
 private let syncLog = Logger(subsystem: "com.vibrdrome.app", category: "LibrarySync")
+private let syncISO8601 = ISO8601DateFormatter()
 
 /// Sync mode determines the depth of library synchronization.
 enum SyncMode: String, Sendable {
@@ -600,7 +601,7 @@ final class LibrarySyncManager {
         cached.contentType = song.contentType
         cached.size = song.size
         cached.bpm = song.bpm
-        cached.dateAdded = song.created.flatMap { ISO8601DateFormatter().date(from: $0) }
+        cached.dateAdded = song.created.flatMap { syncISO8601.date(from: $0) }
         cached.mbzRecordingId = song.musicBrainzId
         cached.isStarred = song.starred != nil
         cached.rating = song.userRating ?? 0

--- a/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
+++ b/Vibrdrome/Core/Persistence/LibrarySyncManager.swift
@@ -87,13 +87,13 @@ final class LibrarySyncManager {
     // MARK: - Public API
 
     /// Run a full library sync: albums, artists, songs, then playlists.
-    func sync(client: SubsonicClient, container: ModelContainer) async {
-        await performSync(mode: .full, client: client, container: container)
+    func sync(client: SubsonicClient, ndClient: NavidromeNativeClient? = nil, container: ModelContainer) async {
+        await performSync(mode: .full, client: client, ndClient: ndClient, container: container)
     }
 
     /// Run an incremental sync — only fetches changes since last sync.
-    func incrementalSync(client: SubsonicClient, container: ModelContainer) async {
-        await performSync(mode: .incremental, client: client, container: container)
+    func incrementalSync(client: SubsonicClient, ndClient: NavidromeNativeClient? = nil, container: ModelContainer) async {
+        await performSync(mode: .incremental, client: client, ndClient: ndClient, container: container)
     }
 
     /// Convenience: sync using the configured client and container.
@@ -103,9 +103,9 @@ final class LibrarySyncManager {
     }
 
     /// Check if sync is stale and trigger the appropriate sync mode.
-    func syncIfStale(client: SubsonicClient, container: ModelContainer) async {
+    func syncIfStale(client: SubsonicClient, ndClient: NavidromeNativeClient? = nil, container: ModelContainer) async {
         guard let last = lastSyncDate else {
-            await performSync(mode: .full, client: client, container: container)
+            await performSync(mode: .full, client: client, ndClient: ndClient, container: container)
             return
         }
         let elapsed = Date().timeIntervalSince(last)
@@ -119,7 +119,7 @@ final class LibrarySyncManager {
             let lastFull = UserDefaults.standard.object(forKey: UserDefaultsKeys.lastFullSyncDate) as? Date
             let needsFullSync = lastFull == nil || Date().timeIntervalSince(lastFull!) > fullSyncInterval
             let mode: SyncMode = needsFullSync ? .full : .incremental
-            await performSync(mode: mode, client: client, container: container)
+            await performSync(mode: mode, client: client, ndClient: ndClient, container: container)
         } else {
             // Server unchanged — just update the stale check timestamp
             lastSyncDate = Date()
@@ -130,7 +130,7 @@ final class LibrarySyncManager {
     // MARK: - Change Detection Polling
 
     /// Start periodic polling for server changes while the app is active.
-    func startPolling(client: SubsonicClient, container: ModelContainer) {
+    func startPolling(client: SubsonicClient, ndClient: NavidromeNativeClient? = nil, container: ModelContainer) {
         stopPolling()
         let intervalMinutes = UserDefaults.standard.integer(forKey: UserDefaultsKeys.syncPollingInterval)
         let interval = max(TimeInterval(intervalMinutes > 0 ? intervalMinutes : 15) * 60, 300)
@@ -143,7 +143,7 @@ final class LibrarySyncManager {
                 let changed = await self.hasServerChanged(client: client)
                 if changed {
                     syncLog.info("Polling detected server changes, triggering incremental sync (trigger: auto-poll)")
-                    await self.performSync(mode: .incremental, client: client, container: container)
+                    await self.performSync(mode: .incremental, client: client, ndClient: ndClient, container: container)
                 }
             }
         }
@@ -159,7 +159,7 @@ final class LibrarySyncManager {
     // MARK: - Core Sync Engine
 
     // swiftlint:disable:next function_body_length
-    private func performSync(mode: SyncMode, client: SubsonicClient, container: ModelContainer) async {
+    private func performSync(mode: SyncMode, client: SubsonicClient, ndClient: NavidromeNativeClient? = nil, container: ModelContainer) async {
         guard !isSyncing else { return }
         isSyncing = true
         syncError = nil
@@ -196,7 +196,7 @@ final class LibrarySyncManager {
                 var working = SyncStats()
 
                 try await Self.syncAlbumsOffMain(
-                    client: client, container: container,
+                    client: client, ndClient: ndClient, container: container,
                     stats: &working, incremental: incremental,
                     progress: updateProgress, publishStats: publishPartialStats
                 )
@@ -206,7 +206,7 @@ final class LibrarySyncManager {
                     progress: updateProgress, publishStats: publishPartialStats
                 )
                 try await Self.syncSongsOffMain(
-                    client: client, container: container,
+                    client: client, ndClient: ndClient, container: container,
                     stats: &working, incremental: incremental,
                     progress: updateProgress, publishStats: publishPartialStats
                 )
@@ -280,9 +280,10 @@ final class LibrarySyncManager {
 
     // MARK: - Albums
 
-    // swiftlint:disable:next function_body_length function_parameter_count
+    // swiftlint:disable:next function_parameter_count
     nonisolated static func syncAlbumsOffMain(
         client: SubsonicClient,
+        ndClient: NavidromeNativeClient?,
         container: ModelContainer,
         stats: inout SyncStats,
         incremental: Bool,
@@ -294,67 +295,26 @@ final class LibrarySyncManager {
         let context = ModelContext(container)
         context.autosaveEnabled = false
 
-        // Build lookup dictionary of existing albums for O(1) access
         let allLocal = try context.fetch(FetchDescriptor<CachedAlbum>())
         var localMap = Dictionary(uniqueKeysWithValues: allLocal.map { ($0.id, $0) })
-
-        var offset = 0
         var serverAlbumIds = Set<String>()
         var totalFetched = 0
 
-        if incremental {
-            // Fetch only newest albums (added/modified recently)
-            let newestAlbums = try await client.getAlbumList(type: .newest, size: albumPageSize)
-            for album in newestAlbums {
-                serverAlbumIds.insert(album.id)
-                if let existing = localMap[album.id] {
-                    if hasAlbumChanged(existing, album) {
-                        existing.update(from: album)
-                        stats.albumsUpdated += 1
-                    }
-                } else {
-                    let cached = CachedAlbum(from: album)
-                    context.insert(cached)
-                    localMap[album.id] = cached
-                    stats.albumsAdded += 1
-                }
-            }
-            totalFetched = newestAlbums.count
+        if let ndClient, await ndClient.isAvailable {
+            totalFetched = try await LibrarySyncManager.syncAlbumsND(
+                ndClient: ndClient, context: context, allLocal: allLocal,
+                localMap: &localMap, serverIds: &serverAlbumIds, stats: &stats, progress: progress
+            )
+        } else if incremental {
+            totalFetched = try await syncAlbumsIncremental(
+                client: client, context: context,
+                localMap: &localMap, serverIds: &serverAlbumIds, stats: &stats
+            )
         } else {
-            // Full sync: fetch all albums
-            while true {
-                let page = try await client.getAlbumList(
-                    type: .alphabeticalByName, size: albumPageSize, offset: offset
-                )
-                if page.isEmpty { break }
-
-                for album in page {
-                    serverAlbumIds.insert(album.id)
-                    if let existing = localMap[album.id] {
-                        if hasAlbumChanged(existing, album) {
-                            existing.update(from: album)
-                            stats.albumsUpdated += 1
-                        }
-                    } else {
-                        let cached = CachedAlbum(from: album)
-                        context.insert(cached)
-                        localMap[album.id] = cached
-                        stats.albumsAdded += 1
-                    }
-                }
-
-                totalFetched += page.count
-                progress("Syncing albums… \(totalFetched)")
-                offset += page.count
-
-                if page.count < albumPageSize { break }
-            }
-
-            // Remove albums no longer on server
-            for local in allLocal where !serverAlbumIds.contains(local.id) {
-                context.delete(local)
-                stats.albumsRemoved += 1
-            }
+            totalFetched = try await syncAlbumsSubsonic(
+                client: client, context: context, allLocal: allLocal,
+                localMap: &localMap, serverIds: &serverAlbumIds, stats: &stats, progress: progress
+            )
         }
 
         try context.save()
@@ -363,6 +323,57 @@ final class LibrarySyncManager {
         let updated = stats.albumsUpdated
         let removed = stats.albumsRemoved
         syncLog.info("Synced \(totalFetched) albums (+\(added) ~\(updated) -\(removed))")
+    }
+
+    nonisolated private static func syncAlbumsIncremental(
+        client: SubsonicClient, context: ModelContext,
+        localMap: inout [String: CachedAlbum], serverIds: inout Set<String>,
+        stats: inout SyncStats
+    ) async throws -> Int {
+        let newestAlbums = try await client.getAlbumList(type: .newest, size: albumPageSize)
+        for album in newestAlbums {
+            serverIds.insert(album.id)
+            if let existing = localMap[album.id] {
+                if hasAlbumChanged(existing, album) { existing.update(from: album); stats.albumsUpdated += 1 }
+            } else {
+                let cached = CachedAlbum(from: album)
+                context.insert(cached); localMap[album.id] = cached; stats.albumsAdded += 1
+            }
+        }
+        return newestAlbums.count
+    }
+
+    // swiftlint:disable:next function_parameter_count
+    nonisolated private static func syncAlbumsSubsonic(
+        client: SubsonicClient, context: ModelContext, allLocal: [CachedAlbum],
+        localMap: inout [String: CachedAlbum], serverIds: inout Set<String>,
+        stats: inout SyncStats, progress: @Sendable (String) -> Void
+    ) async throws -> Int {
+        var offset = 0
+        var totalFetched = 0
+        while true {
+            let page = try await client.getAlbumList(
+                type: .alphabeticalByName, size: albumPageSize, offset: offset
+            )
+            if page.isEmpty { break }
+            for album in page {
+                serverIds.insert(album.id)
+                if let existing = localMap[album.id] {
+                    if hasAlbumChanged(existing, album) { existing.update(from: album); stats.albumsUpdated += 1 }
+                } else {
+                    let cached = CachedAlbum(from: album)
+                    context.insert(cached); localMap[album.id] = cached; stats.albumsAdded += 1
+                }
+            }
+            totalFetched += page.count
+            progress("Syncing albums… \(totalFetched)")
+            offset += page.count
+            if page.count < albumPageSize { break }
+        }
+        for local in allLocal where !serverIds.contains(local.id) {
+            context.delete(local); stats.albumsRemoved += 1
+        }
+        return totalFetched
     }
 
     nonisolated static func hasAlbumChanged(_ cached: CachedAlbum, _ server: Album) -> Bool {
@@ -453,6 +464,7 @@ final class LibrarySyncManager {
     // swiftlint:disable:next function_parameter_count
     nonisolated static func syncSongsOffMain(
         client: SubsonicClient,
+        ndClient: NavidromeNativeClient?,
         container: ModelContainer,
         stats: inout SyncStats,
         incremental: Bool,
@@ -464,62 +476,26 @@ final class LibrarySyncManager {
         let context = ModelContext(container)
         context.autosaveEnabled = false
 
-        // Build lookup dictionary for O(1) access
         let allLocal = try context.fetch(FetchDescriptor<CachedSong>())
         var localMap = Dictionary(uniqueKeysWithValues: allLocal.map { ($0.id, $0) })
-
-        // Pre-fetch album map for linking
-        let allAlbums = try context.fetch(FetchDescriptor<CachedAlbum>())
-        let albumMap = Dictionary(uniqueKeysWithValues: allAlbums.map { ($0.id, $0) })
-
-        var offset = 0
+        let albumMap = Dictionary(
+            uniqueKeysWithValues: (try context.fetch(FetchDescriptor<CachedAlbum>())).map { ($0.id, $0) }
+        )
         var serverSongIds = Set<String>()
-        var totalFetched = 0
 
-        while true {
-            let result = try await client.search(
-                query: "", artistCount: 0, albumCount: 0,
-                songCount: songPageSize, songOffset: offset
+        let totalFetched: Int
+        if let ndClient, await ndClient.isAvailable {
+            totalFetched = try await LibrarySyncManager.syncSongsND(
+                ndClient: ndClient, context: context, allLocal: allLocal, albumMap: albumMap,
+                localMap: &localMap, serverIds: &serverSongIds, stats: &stats,
+                progress: progress, publishStats: publishStats
             )
-            let songs = result.song ?? []
-            if songs.isEmpty { break }
-
-            for song in songs {
-                serverSongIds.insert(song.id)
-                if let existing = localMap[song.id] {
-                    if hasSongChanged(existing, song) {
-                        updateSongFields(existing, from: song)
-                        stats.songsUpdated += 1
-                    }
-                } else {
-                    let cached = CachedSong(from: song)
-                    if let albumId = song.albumId {
-                        cached.album = albumMap[albumId]
-                    }
-                    context.insert(cached)
-                    localMap[song.id] = cached
-                    stats.songsAdded += 1
-                }
-            }
-
-            totalFetched += songs.count
-            progress("Syncing songs… \(totalFetched)")
-            offset += songs.count
-
-            if totalFetched % 2000 == 0 {
-                try context.save()
-                publishStats(stats)
-            }
-
-            if songs.count < songPageSize { break }
-        }
-
-        // Remove songs no longer on server (only on full sync, preserve downloads)
-        if !incremental {
-            for local in allLocal where !serverSongIds.contains(local.id) && local.download == nil {
-                context.delete(local)
-                stats.songsRemoved += 1
-            }
+        } else {
+            totalFetched = try await syncSongsSubsonic(
+                client: client, context: context, allLocal: allLocal, albumMap: albumMap,
+                localMap: &localMap, serverIds: &serverSongIds, stats: &stats,
+                incremental: incremental, progress: progress, publishStats: publishStats
+            )
         }
 
         try context.save()
@@ -529,6 +505,48 @@ final class LibrarySyncManager {
         let songUpdated = stats.songsUpdated
         let songRemoved = stats.songsRemoved
         syncLog.info("Synced \(totalFetched) songs (+\(songAdded) ~\(songUpdated) -\(songRemoved))")
+    }
+
+    // swiftlint:disable:next function_parameter_count
+    nonisolated private static func syncSongsSubsonic(
+        client: SubsonicClient, context: ModelContext,
+        allLocal: [CachedSong], albumMap: [String: CachedAlbum],
+        localMap: inout [String: CachedSong], serverIds: inout Set<String>,
+        stats: inout SyncStats, incremental: Bool,
+        progress: @Sendable (String) -> Void,
+        publishStats: @Sendable (SyncStats) -> Void
+    ) async throws -> Int {
+        var offset = 0
+        var totalFetched = 0
+        while true {
+            let result = try await client.search(
+                query: "", artistCount: 0, albumCount: 0,
+                songCount: songPageSize, songOffset: offset
+            )
+            let songs = result.song ?? []
+            if songs.isEmpty { break }
+            for song in songs {
+                serverIds.insert(song.id)
+                if let existing = localMap[song.id] {
+                    if hasSongChanged(existing, song) { updateSongFields(existing, from: song); stats.songsUpdated += 1 }
+                } else {
+                    let cached = CachedSong(from: song)
+                    if let albumId = song.albumId { cached.album = albumMap[albumId] }
+                    context.insert(cached); localMap[song.id] = cached; stats.songsAdded += 1
+                }
+            }
+            totalFetched += songs.count
+            progress("Syncing songs… \(totalFetched)")
+            offset += songs.count
+            if totalFetched % 2000 == 0 { try context.save(); publishStats(stats) }
+            if songs.count < songPageSize { break }
+        }
+        if !incremental {
+            for local in allLocal where !serverIds.contains(local.id) && local.download == nil {
+                context.delete(local); stats.songsRemoved += 1
+            }
+        }
+        return totalFetched
     }
 
     /// Nonisolated so songs sync (off MainActor) can call it directly.
@@ -553,7 +571,12 @@ final class LibrarySyncManager {
         cached.duration != server.duration ||
         cached.isStarred != (server.starred != nil) ||
         cached.coverArtId != server.coverArt ||
-        cached.bitRate != server.bitRate
+        cached.bitRate != server.bitRate ||
+        cached.bitDepth != server.bitDepth ||
+        cached.samplingRate != server.samplingRate ||
+        cached.comment != server.comment ||
+        cached.bpm != server.bpm ||
+        cached.mbzRecordingId != server.musicBrainzId
     }
 
     nonisolated static func updateSongFields(_ cached: CachedSong, from song: Song) {
@@ -570,9 +593,15 @@ final class LibrarySyncManager {
         cached.genre = song.genre
         cached.duration = song.duration
         cached.bitRate = song.bitRate
+        cached.bitDepth = song.bitDepth
+        cached.samplingRate = song.samplingRate
+        cached.comment = song.comment
         cached.suffix = song.suffix
         cached.contentType = song.contentType
         cached.size = song.size
+        cached.bpm = song.bpm
+        cached.dateAdded = song.created.flatMap { ISO8601DateFormatter().date(from: $0) }
+        cached.mbzRecordingId = song.musicBrainzId
         cached.isStarred = song.starred != nil
         cached.rating = song.userRating ?? 0
         cached.cachedAt = Date()

--- a/Vibrdrome/Core/Persistence/Models/CachedAlbum.swift
+++ b/Vibrdrome/Core/Persistence/Models/CachedAlbum.swift
@@ -1,6 +1,8 @@
 import Foundation
 import SwiftData
 
+nonisolated(unsafe) private let iso8601Album = ISO8601DateFormatter()
+
 @Model
 final class CachedAlbum {
     #Index<CachedAlbum>([\.name], [\.artistId], [\.year], [\.isStarred], [\.userRating], [\.label], [\.releaseType], [\.mood], [\.releaseCountry])
@@ -14,6 +16,8 @@ final class CachedAlbum {
     var songCount: Int?
     var duration: Int?
     var isStarred: Bool = false
+    var starredAt: Date?
+    var lastPlayed: Date?
     var created: String?
     var userRating: Int = 0
     var label: String?
@@ -84,6 +88,8 @@ final class CachedAlbum {
         self.songCount = ndAlbum.songCount
         self.duration = ndAlbum.duration.map { Int($0) }
         self.isStarred = ndAlbum.starred ?? false
+        if let at = ndAlbum.starredAt { self.starredAt = iso8601Album.date(from: at) }
+        if let pd = ndAlbum.playDate { self.lastPlayed = iso8601Album.date(from: pd) }
         self.userRating = ndAlbum.rating ?? 0
         self.label = ndAlbum.recordLabel
         self.catalogNum = ndAlbum.catalogNum
@@ -116,6 +122,8 @@ final class CachedAlbum {
         songCount = ndAlbum.songCount
         duration = ndAlbum.duration.map { Int($0) }
         isStarred = ndAlbum.starred ?? false
+        starredAt = ndAlbum.starredAt.flatMap { iso8601Album.date(from: $0) }
+        lastPlayed = ndAlbum.playDate.flatMap { iso8601Album.date(from: $0) }
         userRating = ndAlbum.rating ?? 0
         label = ndAlbum.recordLabel
         catalogNum = ndAlbum.catalogNum

--- a/Vibrdrome/Core/Persistence/Models/CachedAlbum.swift
+++ b/Vibrdrome/Core/Persistence/Models/CachedAlbum.swift
@@ -3,7 +3,7 @@ import SwiftData
 
 @Model
 final class CachedAlbum {
-    #Index<CachedAlbum>([\.name], [\.artistId], [\.year], [\.isStarred], [\.userRating], [\.label])
+    #Index<CachedAlbum>([\.name], [\.artistId], [\.year], [\.isStarred], [\.userRating], [\.label], [\.releaseType], [\.mood], [\.releaseCountry])
 
     @Attribute(.unique) var id: String
     var name: String
@@ -27,8 +27,23 @@ final class CachedAlbum {
     var musicBrainzId: String?
     var mbzAlbumArtistId: String?
     var mbzReleaseGroupId: String?
+    var mbzAlbumType: String?
+    var mbzAlbumComment: String?
     var playCount: Int = 0
     var isCompilation: Bool = false
+
+    // ND native API tag fields (album: true in mappings.yml)
+    var catalogNum: String?
+    var releaseType: String?
+    var releaseCountry: String?
+    var releaseStatus: String?
+    var mood: String?
+    var grouping: String?
+    var mediaType: String?
+    var sortAlbumName: String?
+    var sortAlbumArtistName: String?
+    var minYear: Int?
+    var maxYear: Int?
 
     var songs: [CachedSong] = []
     @Relationship(deleteRule: .cascade, inverse: \AlbumGenre.album) var genreLinks: [AlbumGenre] = []
@@ -60,17 +75,31 @@ final class CachedAlbum {
     init(from ndAlbum: NDAlbum) {
         self.id = ndAlbum.id
         self.name = ndAlbum.name
-        self.artistName = ndAlbum.artist
-        self.artistId = ndAlbum.artistId
+        self.artistName = ndAlbum.albumArtist
+        self.artistId = ndAlbum.albumArtistId
         self.coverArtId = ndAlbum.id
-        self.year = ndAlbum.year
+        self.year = ndAlbum.minYear ?? ndAlbum.year
+        self.minYear = ndAlbum.minYear
+        self.maxYear = ndAlbum.maxYear
         self.songCount = ndAlbum.songCount
         self.duration = ndAlbum.duration.map { Int($0) }
         self.isStarred = ndAlbum.starred ?? false
         self.userRating = ndAlbum.rating ?? 0
+        self.label = ndAlbum.recordLabel
+        self.catalogNum = ndAlbum.catalogNum
+        self.releaseType = ndAlbum.releaseType
+        self.releaseCountry = ndAlbum.releaseCountry
+        self.releaseStatus = ndAlbum.releaseStatus
+        self.mood = ndAlbum.mood
+        self.grouping = ndAlbum.grouping
+        self.mediaType = ndAlbum.mediaType
+        self.sortAlbumName = ndAlbum.sortAlbumName
+        self.sortAlbumArtistName = ndAlbum.sortAlbumArtistName
         self.musicBrainzId = ndAlbum.mbzAlbumId
         self.mbzAlbumArtistId = ndAlbum.mbzAlbumArtistId
         self.mbzReleaseGroupId = ndAlbum.mbzReleaseGroupId
+        self.mbzAlbumType = ndAlbum.mbzAlbumType
+        self.mbzAlbumComment = ndAlbum.mbzAlbumComment
         self.playCount = ndAlbum.playCount ?? 0
         self.isCompilation = ndAlbum.compilation ?? false
         self.genreLinks = ndAlbum.allGenres.map { AlbumGenre(name: $0) }
@@ -78,15 +107,31 @@ final class CachedAlbum {
 
     func update(from ndAlbum: NDAlbum) {
         name = ndAlbum.name
-        artistId = ndAlbum.artistId
-        year = ndAlbum.year
+        artistName = ndAlbum.albumArtist
+        artistId = ndAlbum.albumArtistId
+        coverArtId = ndAlbum.id
+        year = ndAlbum.minYear ?? ndAlbum.year
+        minYear = ndAlbum.minYear
+        maxYear = ndAlbum.maxYear
         songCount = ndAlbum.songCount
         duration = ndAlbum.duration.map { Int($0) }
         isStarred = ndAlbum.starred ?? false
         userRating = ndAlbum.rating ?? 0
+        label = ndAlbum.recordLabel
+        catalogNum = ndAlbum.catalogNum
+        releaseType = ndAlbum.releaseType
+        releaseCountry = ndAlbum.releaseCountry
+        releaseStatus = ndAlbum.releaseStatus
+        mood = ndAlbum.mood
+        grouping = ndAlbum.grouping
+        mediaType = ndAlbum.mediaType
+        sortAlbumName = ndAlbum.sortAlbumName
+        sortAlbumArtistName = ndAlbum.sortAlbumArtistName
         musicBrainzId = ndAlbum.mbzAlbumId
         mbzAlbumArtistId = ndAlbum.mbzAlbumArtistId
         mbzReleaseGroupId = ndAlbum.mbzReleaseGroupId
+        mbzAlbumType = ndAlbum.mbzAlbumType
+        mbzAlbumComment = ndAlbum.mbzAlbumComment
         playCount = ndAlbum.playCount ?? 0
         isCompilation = ndAlbum.compilation ?? false
         let incoming = Set(ndAlbum.allGenres)

--- a/Vibrdrome/Core/Persistence/Models/CachedAlbum.swift
+++ b/Vibrdrome/Core/Persistence/Models/CachedAlbum.swift
@@ -25,6 +25,10 @@ final class CachedAlbum {
     var replayGainTrackGain: Double?
     var replayGainBaseGain: Double?
     var musicBrainzId: String?
+    var mbzAlbumArtistId: String?
+    var mbzReleaseGroupId: String?
+    var playCount: Int = 0
+    var isCompilation: Bool = false
 
     var songs: [CachedSong] = []
     @Relationship(deleteRule: .cascade, inverse: \AlbumGenre.album) var genreLinks: [AlbumGenre] = []
@@ -51,6 +55,49 @@ final class CachedAlbum {
         self.replayGainBaseGain = album.replayGain?.baseGain
         self.musicBrainzId = album.musicBrainzId
         self.genreLinks = album.allGenres.map { AlbumGenre(name: $0) }
+    }
+
+    init(from ndAlbum: NDAlbum) {
+        self.id = ndAlbum.id
+        self.name = ndAlbum.name
+        self.artistName = ndAlbum.artist
+        self.artistId = ndAlbum.artistId
+        self.coverArtId = ndAlbum.id
+        self.year = ndAlbum.year
+        self.songCount = ndAlbum.songCount
+        self.duration = ndAlbum.duration.map { Int($0) }
+        self.isStarred = ndAlbum.starred ?? false
+        self.userRating = ndAlbum.rating ?? 0
+        self.musicBrainzId = ndAlbum.mbzAlbumId
+        self.mbzAlbumArtistId = ndAlbum.mbzAlbumArtistId
+        self.mbzReleaseGroupId = ndAlbum.mbzReleaseGroupId
+        self.playCount = ndAlbum.playCount ?? 0
+        self.isCompilation = ndAlbum.compilation ?? false
+        self.genreLinks = ndAlbum.allGenres.map { AlbumGenre(name: $0) }
+    }
+
+    func update(from ndAlbum: NDAlbum) {
+        name = ndAlbum.name
+        artistId = ndAlbum.artistId
+        year = ndAlbum.year
+        songCount = ndAlbum.songCount
+        duration = ndAlbum.duration.map { Int($0) }
+        isStarred = ndAlbum.starred ?? false
+        userRating = ndAlbum.rating ?? 0
+        musicBrainzId = ndAlbum.mbzAlbumId
+        mbzAlbumArtistId = ndAlbum.mbzAlbumArtistId
+        mbzReleaseGroupId = ndAlbum.mbzReleaseGroupId
+        playCount = ndAlbum.playCount ?? 0
+        isCompilation = ndAlbum.compilation ?? false
+        let incoming = Set(ndAlbum.allGenres)
+        let existing = Set(genreLinks.map(\.name))
+        for removed in existing.subtracting(incoming) {
+            genreLinks.removeAll { $0.name == removed }
+        }
+        for added in incoming.subtracting(existing) {
+            genreLinks.append(AlbumGenre(name: added))
+        }
+        cachedAt = Date()
     }
 
     /// Update existing record with fresh server data.

--- a/Vibrdrome/Core/Persistence/Models/CachedSong.swift
+++ b/Vibrdrome/Core/Persistence/Models/CachedSong.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SwiftData
 
-private let iso8601 = ISO8601DateFormatter()
+nonisolated(unsafe) private let iso8601 = ISO8601DateFormatter()
 
 @Model
 final class CachedSong {
@@ -35,6 +35,10 @@ final class CachedSong {
     var mbzRecordingId: String?
     var mbzArtistId: String?
     var mbzAlbumArtistId: String?
+    var rgTrackGain: Double?
+    var rgTrackPeak: Double?
+    var rgAlbumGain: Double?
+    var rgAlbumPeak: Double?
     var isStarred: Bool = false
     var rating: Int = 0
     var lastPlayed: Date?
@@ -69,6 +73,10 @@ final class CachedSong {
         self.dateAdded = song.created.flatMap { iso8601.date(from: $0) }
         self.mbzRecordingId = song.musicBrainzId
         self.isStarred = song.starred != nil
+        self.rgTrackGain = song.replayGain?.trackGain
+        self.rgTrackPeak = song.replayGain?.trackPeak
+        self.rgAlbumGain = song.replayGain?.albumGain
+        self.rgAlbumPeak = song.replayGain?.albumPeak
     }
 
     convenience init(from ndSong: NDSong) {
@@ -77,6 +85,7 @@ final class CachedSong {
             artist: ndSong.artist, albumArtist: ndSong.albumArtist,
             albumId: ndSong.albumId, artistId: ndSong.artistId,
             track: ndSong.trackNumber, year: ndSong.year, genre: ndSong.allGenres.first,
+            coverArt: ndSong.id,
             size: ndSong.size, suffix: ndSong.suffix,
             duration: ndSong.duration.map { Int($0) }, bitRate: ndSong.bitRate,
             bitDepth: ndSong.bitDepth, samplingRate: ndSong.sampleRate, comment: ndSong.comment,
@@ -91,6 +100,10 @@ final class CachedSong {
         self.mbzArtistId = ndSong.mbzArtistId
         self.mbzAlbumArtistId = ndSong.mbzAlbumArtistId
         self.playCount = ndSong.playCount ?? 0
+        self.rgTrackGain = ndSong.rgTrackGain
+        self.rgTrackPeak = ndSong.rgTrackPeak
+        self.rgAlbumGain = ndSong.rgAlbumGain
+        self.rgAlbumPeak = ndSong.rgAlbumPeak
         if let playDate = ndSong.playDate {
             self.lastPlayed = iso8601.date(from: playDate)
         }
@@ -103,6 +116,7 @@ final class CachedSong {
         albumName = ndSong.album
         albumId = ndSong.albumId
         artistId = ndSong.artistId
+        coverArtId = ndSong.id
         track = ndSong.trackNumber
         discNumber = ndSong.discNumber
         year = ndSong.year
@@ -125,6 +139,10 @@ final class CachedSong {
         isStarred = ndSong.starred ?? false
         rating = ndSong.rating ?? 0
         playCount = ndSong.playCount ?? 0
+        rgTrackGain = ndSong.rgTrackGain
+        rgTrackPeak = ndSong.rgTrackPeak
+        rgAlbumGain = ndSong.rgAlbumGain
+        rgAlbumPeak = ndSong.rgAlbumPeak
         if let playDate = ndSong.playDate {
             lastPlayed = iso8601.date(from: playDate)
         }
@@ -160,7 +178,10 @@ final class CachedSong {
             starred: isStarred ? "true" : nil,
             userRating: rating,
             bpm: bpm,
-            replayGain: nil,
+            replayGain: rgTrackGain.map {
+                ReplayGain(trackGain: $0, albumGain: rgAlbumGain,
+                           trackPeak: rgTrackPeak, albumPeak: rgAlbumPeak, baseGain: nil)
+            },
             musicBrainzId: mbzRecordingId
         )
     }

--- a/Vibrdrome/Core/Persistence/Models/CachedSong.swift
+++ b/Vibrdrome/Core/Persistence/Models/CachedSong.swift
@@ -19,9 +19,20 @@ final class CachedSong {
     var genre: String?
     var duration: Int?
     var bitRate: Int?
+    var bitDepth: Int?
+    var samplingRate: Int?
+    var channels: Int?
+    var comment: String?
     var suffix: String?
     var contentType: String?
     var size: Int?
+    var bpm: Int?
+    var hasCoverArt: Bool = false
+    var isCompilation: Bool = false
+    var dateAdded: Date?
+    var mbzRecordingId: String?
+    var mbzArtistId: String?
+    var mbzAlbumArtistId: String?
     var isStarred: Bool = false
     var rating: Int = 0
     var lastPlayed: Date?
@@ -46,10 +57,76 @@ final class CachedSong {
         self.genre = song.genre
         self.duration = song.duration
         self.bitRate = song.bitRate
+        self.bitDepth = song.bitDepth
+        self.samplingRate = song.samplingRate
+        self.comment = song.comment
         self.suffix = song.suffix
         self.contentType = song.contentType
         self.size = song.size
+        self.bpm = song.bpm
+        self.dateAdded = song.created.flatMap { ISO8601DateFormatter().date(from: $0) }
+        self.mbzRecordingId = song.musicBrainzId
         self.isStarred = song.starred != nil
+    }
+
+    convenience init(from ndSong: NDSong) {
+        self.init(from: Song(
+            id: ndSong.id, title: ndSong.title, album: ndSong.album,
+            artist: ndSong.artist, albumArtist: ndSong.albumArtist,
+            albumId: ndSong.albumId, artistId: ndSong.artistId,
+            track: ndSong.trackNumber, year: ndSong.year, genre: ndSong.allGenres.first,
+            size: ndSong.size, suffix: ndSong.suffix,
+            duration: ndSong.duration.map { Int($0) }, bitRate: ndSong.bitRate,
+            bitDepth: ndSong.bitDepth, samplingRate: ndSong.sampleRate, comment: ndSong.comment,
+            discNumber: ndSong.discNumber, created: ndSong.createdAt,
+            starred: ndSong.starred == true ? "true" : nil,
+            userRating: ndSong.rating, bpm: ndSong.bpm,
+            musicBrainzId: ndSong.mbzReleaseTrackId
+        ))
+        self.channels = ndSong.channels
+        self.hasCoverArt = ndSong.hasCoverArt ?? false
+        self.isCompilation = ndSong.compilation ?? false
+        self.mbzArtistId = ndSong.mbzArtistId
+        self.mbzAlbumArtistId = ndSong.mbzAlbumArtistId
+        self.playCount = ndSong.playCount ?? 0
+        if let playDate = ndSong.playDate {
+            self.lastPlayed = ISO8601DateFormatter().date(from: playDate)
+        }
+    }
+
+    func update(from ndSong: NDSong) {
+        title = ndSong.title
+        artist = ndSong.artist
+        albumArtist = ndSong.albumArtist
+        albumName = ndSong.album
+        albumId = ndSong.albumId
+        artistId = ndSong.artistId
+        track = ndSong.trackNumber
+        discNumber = ndSong.discNumber
+        year = ndSong.year
+        genre = ndSong.allGenres.first
+        duration = ndSong.duration.map { Int($0) }
+        bitRate = ndSong.bitRate
+        bitDepth = ndSong.bitDepth
+        samplingRate = ndSong.sampleRate
+        channels = ndSong.channels
+        comment = ndSong.comment
+        suffix = ndSong.suffix
+        size = ndSong.size
+        bpm = ndSong.bpm
+        hasCoverArt = ndSong.hasCoverArt ?? false
+        isCompilation = ndSong.compilation ?? false
+        dateAdded = ndSong.createdAt.flatMap { ISO8601DateFormatter().date(from: $0) }
+        mbzRecordingId = ndSong.mbzReleaseTrackId
+        mbzArtistId = ndSong.mbzArtistId
+        mbzAlbumArtistId = ndSong.mbzAlbumArtistId
+        isStarred = ndSong.starred ?? false
+        rating = ndSong.rating ?? 0
+        playCount = ndSong.playCount ?? 0
+        if let playDate = ndSong.playDate {
+            lastPlayed = ISO8601DateFormatter().date(from: playDate)
+        }
+        cachedAt = Date()
     }
 
     /// Convert back to a Song value type for playback queue reconstruction.
@@ -72,14 +149,17 @@ final class CachedSong {
             suffix: suffix,
             duration: duration,
             bitRate: bitRate,
+            bitDepth: bitDepth,
+            samplingRate: samplingRate,
+            comment: comment,
             path: nil,
             discNumber: discNumber,
             created: nil,
             starred: isStarred ? "true" : nil,
             userRating: rating,
-            bpm: nil,
+            bpm: bpm,
             replayGain: nil,
-            musicBrainzId: nil
+            musicBrainzId: mbzRecordingId
         )
     }
 }

--- a/Vibrdrome/Core/Persistence/Models/CachedSong.swift
+++ b/Vibrdrome/Core/Persistence/Models/CachedSong.swift
@@ -1,6 +1,8 @@
 import Foundation
 import SwiftData
 
+private let iso8601 = ISO8601DateFormatter()
+
 @Model
 final class CachedSong {
     #Index<CachedSong>([\.title], [\.albumId], [\.artistId], [\.genre], [\.isStarred], [\.lastPlayed])
@@ -64,7 +66,7 @@ final class CachedSong {
         self.contentType = song.contentType
         self.size = song.size
         self.bpm = song.bpm
-        self.dateAdded = song.created.flatMap { ISO8601DateFormatter().date(from: $0) }
+        self.dateAdded = song.created.flatMap { iso8601.date(from: $0) }
         self.mbzRecordingId = song.musicBrainzId
         self.isStarred = song.starred != nil
     }
@@ -90,7 +92,7 @@ final class CachedSong {
         self.mbzAlbumArtistId = ndSong.mbzAlbumArtistId
         self.playCount = ndSong.playCount ?? 0
         if let playDate = ndSong.playDate {
-            self.lastPlayed = ISO8601DateFormatter().date(from: playDate)
+            self.lastPlayed = iso8601.date(from: playDate)
         }
     }
 
@@ -116,7 +118,7 @@ final class CachedSong {
         bpm = ndSong.bpm
         hasCoverArt = ndSong.hasCoverArt ?? false
         isCompilation = ndSong.compilation ?? false
-        dateAdded = ndSong.createdAt.flatMap { ISO8601DateFormatter().date(from: $0) }
+        dateAdded = ndSong.createdAt.flatMap { iso8601.date(from: $0) }
         mbzRecordingId = ndSong.mbzReleaseTrackId
         mbzArtistId = ndSong.mbzArtistId
         mbzAlbumArtistId = ndSong.mbzAlbumArtistId
@@ -124,7 +126,7 @@ final class CachedSong {
         rating = ndSong.rating ?? 0
         playCount = ndSong.playCount ?? 0
         if let playDate = ndSong.playDate {
-            lastPlayed = ISO8601DateFormatter().date(from: playDate)
+            lastPlayed = iso8601.date(from: playDate)
         }
         cachedAt = Date()
     }

--- a/Vibrdrome/Core/Persistence/Models/CachedSong.swift
+++ b/Vibrdrome/Core/Persistence/Models/CachedSong.swift
@@ -33,6 +33,7 @@ final class CachedSong {
     var isCompilation: Bool = false
     var dateAdded: Date?
     var mbzRecordingId: String?
+    var mbzAlbumId: String?
     var mbzArtistId: String?
     var mbzAlbumArtistId: String?
     var rgTrackGain: Double?
@@ -40,6 +41,7 @@ final class CachedSong {
     var rgAlbumGain: Double?
     var rgAlbumPeak: Double?
     var isStarred: Bool = false
+    var starredAt: Date?
     var rating: Int = 0
     var lastPlayed: Date?
     var playCount: Int = 0
@@ -97,6 +99,7 @@ final class CachedSong {
         self.channels = ndSong.channels
         self.hasCoverArt = ndSong.hasCoverArt ?? false
         self.isCompilation = ndSong.compilation ?? false
+        self.mbzAlbumId = ndSong.mbzAlbumId
         self.mbzArtistId = ndSong.mbzArtistId
         self.mbzAlbumArtistId = ndSong.mbzAlbumArtistId
         self.playCount = ndSong.playCount ?? 0
@@ -104,9 +107,8 @@ final class CachedSong {
         self.rgTrackPeak = ndSong.rgTrackPeak
         self.rgAlbumGain = ndSong.rgAlbumGain
         self.rgAlbumPeak = ndSong.rgAlbumPeak
-        if let playDate = ndSong.playDate {
-            self.lastPlayed = iso8601.date(from: playDate)
-        }
+        if let playDate = ndSong.playDate { self.lastPlayed = iso8601.date(from: playDate) }
+        if let at = ndSong.starredAt { self.starredAt = iso8601.date(from: at) }
     }
 
     func update(from ndSong: NDSong) {
@@ -136,16 +138,16 @@ final class CachedSong {
         mbzRecordingId = ndSong.mbzReleaseTrackId
         mbzArtistId = ndSong.mbzArtistId
         mbzAlbumArtistId = ndSong.mbzAlbumArtistId
+        mbzAlbumId = ndSong.mbzAlbumId
         isStarred = ndSong.starred ?? false
+        if let at = ndSong.starredAt { starredAt = iso8601.date(from: at) } else { starredAt = nil }
         rating = ndSong.rating ?? 0
         playCount = ndSong.playCount ?? 0
         rgTrackGain = ndSong.rgTrackGain
         rgTrackPeak = ndSong.rgTrackPeak
         rgAlbumGain = ndSong.rgAlbumGain
         rgAlbumPeak = ndSong.rgAlbumPeak
-        if let playDate = ndSong.playDate {
-            lastPlayed = iso8601.date(from: playDate)
-        }
+        if let playDate = ndSong.playDate { lastPlayed = iso8601.date(from: playDate) }
         cachedAt = Date()
     }
 

--- a/Vibrdrome/Core/Persistence/Models/ExportedPlaylist.swift
+++ b/Vibrdrome/Core/Persistence/Models/ExportedPlaylist.swift
@@ -1,0 +1,62 @@
+import Foundation
+import SwiftData
+
+enum PlaylistExportSyncMode: String, CaseIterable {
+    case addOnly
+    case addAndRemove
+
+    var displayName: String {
+        switch self {
+        case .addOnly: "Add Only"
+        case .addAndRemove: "Add & Remove"
+        }
+    }
+}
+
+@Model
+final class ExportedPlaylist {
+    @Attribute(.unique) var compositeKey: String = ""
+    var serverId: String = ""
+    var playlistId: String = ""
+    var playlistName: String = ""
+    var folderBookmarkData: Data?
+    var syncModeRaw: String = PlaylistExportSyncMode.addOnly.rawValue
+    var transcodeFormat: String?
+    var transcodeBitrate: Int?
+    var appliedTranscodeFormat: String?
+    var lastSyncedAt: Date?
+    var knownSongIds: [String] = []
+    var knownSongPathsData: Data = Data()
+    var isActive: Bool = true
+    var lastSyncError: String?
+    var failedSongIds: [String] = []
+    var failedSongTitles: [String] = []
+
+    var syncModeEnum: PlaylistExportSyncMode {
+        get { PlaylistExportSyncMode(rawValue: syncModeRaw) ?? .addOnly }
+        set { syncModeRaw = newValue.rawValue }
+    }
+
+    var knownSongPaths: [String: String] {
+        get { (try? JSONDecoder().decode([String: String].self, from: knownSongPathsData)) ?? [:] }
+        set { knownSongPathsData = (try? JSONEncoder().encode(newValue)) ?? Data() }
+    }
+
+    var needsResync: Bool {
+        transcodeFormat != appliedTranscodeFormat
+    }
+
+    init(serverId: String, playlistId: String, playlistName: String,
+         folderBookmarkData: Data?, syncMode: PlaylistExportSyncMode,
+         transcodeFormat: String?, transcodeBitrate: Int?, isActive: Bool) {
+        self.compositeKey = "\(serverId)_\(playlistId)"
+        self.serverId = serverId
+        self.playlistId = playlistId
+        self.playlistName = playlistName
+        self.folderBookmarkData = folderBookmarkData
+        self.syncModeRaw = syncMode.rawValue
+        self.transcodeFormat = transcodeFormat
+        self.transcodeBitrate = transcodeBitrate
+        self.isActive = isActive
+    }
+}

--- a/Vibrdrome/Core/Persistence/PersistenceController.swift
+++ b/Vibrdrome/Core/Persistence/PersistenceController.swift
@@ -34,6 +34,7 @@ final class PersistenceController {
             AlbumCollection.self,
             GenreArtwork.self,
             SyncHistory.self,
+            ExportedPlaylist.self,
         ])
 
         let config = ModelConfiguration(

--- a/Vibrdrome/Features/Export/PlaylistExportConfigView.swift
+++ b/Vibrdrome/Features/Export/PlaylistExportConfigView.swift
@@ -1,0 +1,182 @@
+#if os(macOS)
+import SwiftUI
+import SwiftData
+
+struct PlaylistExportConfigView: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.modelContext) private var modelContext
+    @Environment(AppState.self) private var appState
+
+    let playlistId: String
+    let playlistName: String
+    let existingExport: ExportedPlaylist?
+
+    @State private var selectedFolderURL: URL?
+    @State private var folderBookmarkData: Data?
+    @State private var syncMode: PlaylistExportSyncMode = .addOnly
+    @State private var isActive: Bool = true
+    @State private var transcodeFormat: String = ""
+    @State private var transcodeBitrate: Int = 192
+    @State private var isPickingFolder = false
+
+    private var isEditing: Bool { existingExport != nil }
+    private var transcodeFormatBinding: String? { transcodeFormat.isEmpty ? nil : transcodeFormat }
+    private var formatChanged: Bool {
+        guard let existing = existingExport else { return false }
+        let newFormat: String? = transcodeFormat.isEmpty ? nil : transcodeFormat
+        return newFormat != existing.appliedTranscodeFormat
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text(isEditing ? "Export Settings" : "Export Playlist")
+                .font(.headline)
+                .padding(.horizontal)
+                .padding(.top, 16)
+                .padding(.bottom, 12)
+
+            Divider()
+
+            Form {
+                Section("Export Folder") {
+                    HStack {
+                        if let url = selectedFolderURL {
+                            Text(url.path)
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                                .foregroundStyle(.secondary)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        } else {
+                            Text("No folder selected")
+                                .foregroundStyle(.secondary)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+                        Button("Choose…") {
+                            Task { await pickFolder() }
+                        }
+                    }
+                }
+
+                Section("Sync") {
+                    Picker("Mode", selection: $syncMode) {
+                        ForEach(PlaylistExportSyncMode.allCases, id: \.self) { mode in
+                            Text(mode.displayName).tag(mode)
+                        }
+                    }
+                    .pickerStyle(.radioGroup)
+                    Toggle("Auto-sync on launch", isOn: $isActive)
+                }
+
+                Section("Transcode") {
+                    Picker("Format", selection: $transcodeFormat) {
+                        Text("Original (no transcode)").tag("")
+                        Text("MP3").tag("mp3")
+                        Text("AAC").tag("aac")
+                        Text("Opus").tag("opus")
+                        Text("FLAC").tag("flac")
+                    }
+                    .pickerStyle(.menu)
+                    if !transcodeFormat.isEmpty {
+                        HStack {
+                            Text("Bitrate (kbps)")
+                            TextField("192", value: $transcodeBitrate, format: .number)
+                                .frame(width: 80)
+                        }
+                    }
+                    if formatChanged {
+                        Label(
+                            "Changing format will re-download all songs on next sync.",
+                            systemImage: "info.circle"
+                        )
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    }
+                }
+            }
+            .formStyle(.grouped)
+
+            Divider()
+
+            HStack {
+                Spacer()
+                Button("Cancel") { dismiss() }
+                    .keyboardShortcut(.cancelAction)
+                Button(isEditing ? "Save" : "Export") {
+                    save()
+                }
+                .keyboardShortcut(.defaultAction)
+                .disabled(folderBookmarkData == nil)
+            }
+            .padding()
+        }
+        .frame(width: 420)
+        .onAppear { loadExisting() }
+    }
+
+    private func pickFolder() async {
+        guard let url = await PlaylistExportManager.shared.pickFolder() else { return }
+        guard let data = try? PlaylistExportManager.shared.bookmarkData(for: url) else { return }
+        selectedFolderURL = url
+        folderBookmarkData = data
+    }
+
+    private func loadExisting() {
+        guard let export = existingExport else {
+            // Pre-fill from global defaults
+            if let defaultData = UserDefaults.standard.data(forKey: UserDefaultsKeys.exportDefaultFolderBookmark),
+               let (url, _) = try? PlaylistExportManager.shared.resolveBookmark(defaultData) {
+                selectedFolderURL = url
+                folderBookmarkData = defaultData
+            }
+            if let defaultMode = UserDefaults.standard.string(forKey: UserDefaultsKeys.exportDefaultSyncMode),
+               let mode = PlaylistExportSyncMode(rawValue: defaultMode) {
+                syncMode = mode
+            }
+            if let defaultFormat = UserDefaults.standard.string(forKey: UserDefaultsKeys.exportDefaultTranscodeFormat) {
+                transcodeFormat = defaultFormat
+            }
+            let defaultBitrate = UserDefaults.standard.integer(forKey: UserDefaultsKeys.exportDefaultTranscodeBitrate)
+            if defaultBitrate > 0 { transcodeBitrate = defaultBitrate }
+            return
+        }
+        if let data = export.folderBookmarkData,
+           let (url, _) = try? PlaylistExportManager.shared.resolveBookmark(data) {
+            selectedFolderURL = url
+            folderBookmarkData = data
+        }
+        syncMode = export.syncModeEnum
+        isActive = export.isActive
+        transcodeFormat = export.transcodeFormat ?? ""
+        transcodeBitrate = export.transcodeBitrate ?? 192
+    }
+
+    private func save() {
+        guard let bookmarkData = folderBookmarkData else { return }
+        let serverId = appState.activeServerId ?? ""
+        let format: String? = transcodeFormat.isEmpty ? nil : transcodeFormat
+
+        if let export = existingExport {
+            export.folderBookmarkData = bookmarkData
+            export.syncModeEnum = syncMode
+            export.isActive = isActive
+            export.transcodeFormat = format
+            export.transcodeBitrate = format != nil ? transcodeBitrate : nil
+        } else {
+            let export = ExportedPlaylist(
+                serverId: serverId,
+                playlistId: playlistId,
+                playlistName: playlistName,
+                folderBookmarkData: bookmarkData,
+                syncMode: syncMode,
+                transcodeFormat: format,
+                transcodeBitrate: format != nil ? transcodeBitrate : nil,
+                isActive: isActive
+            )
+            modelContext.insert(export)
+        }
+
+        try? modelContext.save()
+        dismiss()
+    }
+}
+#endif

--- a/Vibrdrome/Features/Export/PlaylistExportView.swift
+++ b/Vibrdrome/Features/Export/PlaylistExportView.swift
@@ -1,0 +1,222 @@
+#if os(macOS)
+import SwiftUI
+import SwiftData
+
+struct PlaylistExportView: View {
+    @Environment(AppState.self) private var appState
+    @Query(sort: \ExportedPlaylist.playlistName) private var exports: [ExportedPlaylist]
+    @StateObject private var manager = PlaylistExportManager.shared
+    @State private var editingExport: ExportedPlaylist?
+
+    var body: some View {
+        Group {
+            if exports.isEmpty {
+                emptyState
+            } else {
+                List {
+                    ForEach(exports) { export in
+                        ExportedPlaylistRow(
+                            export: export,
+                            isSyncing: manager.syncingPlaylistIds.contains(export.compositeKey),
+                            onSync: { Task { await manager.sync(export: export, client: appState.subsonicClient) } },
+                            onEdit: { editingExport = export },
+                            onOpenInFinder: { openInFinder(export: export) },
+                            onRemove: { manager.removeExport(export) }
+                        )
+                    }
+                }
+                .listStyle(.inset)
+            }
+        }
+        .navigationTitle("Playlist Export")
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    Task { await manager.syncAllActive(client: appState.subsonicClient) }
+                } label: {
+                    Label("Sync All", systemImage: "arrow.triangle.2.circlepath")
+                }
+                .disabled(exports.filter(\.isActive).isEmpty)
+            }
+        }
+        .sheet(item: $editingExport) { export in
+            PlaylistExportConfigView(
+                playlistId: export.playlistId,
+                playlistName: export.playlistName,
+                existingExport: export
+            )
+        }
+    }
+
+    private var emptyState: some View {
+        ContentUnavailableView(
+            "No Exported Playlists",
+            systemImage: "square.and.arrow.up",
+            description: Text("Open a playlist and choose Export Playlist from the menu.")
+        )
+    }
+
+    private func openInFinder(export: ExportedPlaylist) {
+        guard let data = export.folderBookmarkData,
+              let (url, _) = try? PlaylistExportManager.shared.resolveBookmark(data) else { return }
+        _ = url.startAccessingSecurityScopedResource()
+        NSWorkspace.shared.selectFile(nil, inFileViewerRootedAtPath: url.path)
+        url.stopAccessingSecurityScopedResource()
+    }
+}
+
+private struct ExportedPlaylistRow: View {
+    @ObservedObject var observedManager = PlaylistExportManager.shared
+    let export: ExportedPlaylist
+    let isSyncing: Bool
+    let onSync: () -> Void
+    let onEdit: () -> Void
+    let onOpenInFinder: () -> Void
+    let onRemove: () -> Void
+
+    @State private var showFailures = false
+
+    private var folderPath: String {
+        if let data = export.folderBookmarkData,
+           let (url, _) = try? PlaylistExportManager.shared.resolveBookmark(data) {
+            return url.path
+        }
+        return "No folder selected"
+    }
+
+    private var hasFailures: Bool { !export.failedSongIds.isEmpty }
+
+    private var statusColor: Color {
+        if isSyncing { return .accentColor }
+        if hasFailures { return .red }
+        if export.needsResync { return .orange }
+        return .green
+    }
+
+    private var statusText: String {
+        if isSyncing { return "Syncing…" }
+        if hasFailures { return "\(export.failedSongIds.count) song(s) failed" }
+        if export.needsResync { return "Needs sync" }
+        if export.lastSyncedAt == nil { return "Never synced" }
+        return "Up to date"
+    }
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: "square.and.arrow.up.circle.fill")
+                .font(.title2)
+                .foregroundStyle(.secondary)
+                .frame(width: 36)
+
+            VStack(alignment: .leading, spacing: 2) {
+                HStack {
+                    Text(export.playlistName)
+                        .font(.headline)
+                    Spacer()
+                    syncModeTag
+                }
+                Text(folderPath)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                HStack(spacing: 6) {
+                    if isSyncing {
+                        ProgressView().scaleEffect(0.6)
+                    } else {
+                        Circle()
+                            .fill(statusColor)
+                            .frame(width: 8, height: 8)
+                    }
+                    Text(statusText)
+                        .font(.caption)
+                        .foregroundStyle(isSyncing ? .secondary : statusColor)
+                    if hasFailures && !isSyncing {
+                        Button {
+                            showFailures = true
+                        } label: {
+                            Image(systemName: "chevron.right.circle")
+                                .font(.caption)
+                        }
+                        .buttonStyle(.plain)
+                        .foregroundStyle(.red)
+                        .popover(isPresented: $showFailures, arrowEdge: .bottom) {
+                            FailedSongsPopover(export: export, onRetry: onSync)
+                        }
+                    }
+                    if let date = export.lastSyncedAt {
+                        Text("·")
+                            .foregroundStyle(.secondary)
+                            .font(.caption)
+                        Text(date, style: .relative)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Text("ago")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+        }
+        .padding(.vertical, 4)
+        .contextMenu {
+            Button("Sync Now", action: onSync)
+            Button("Edit Configuration…", action: onEdit)
+            Button("Open in Finder", action: onOpenInFinder)
+            Divider()
+            Button("Remove Export", role: .destructive, action: onRemove)
+        }
+    }
+
+    private var syncModeTag: some View {
+        Text(export.syncModeEnum.displayName)
+            .font(.caption2)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(.quaternary)
+            .clipShape(Capsule())
+    }
+}
+
+private struct FailedSongsPopover: View {
+    let export: ExportedPlaylist
+    let onRetry: () -> Void
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                Text("Failed Downloads")
+                    .font(.headline)
+                Spacer()
+                Button("Retry All") {
+                    dismiss()
+                    onRetry()
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+            }
+            .padding()
+
+            Divider()
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 4) {
+                    ForEach(Array(export.failedSongTitles.enumerated()), id: \.offset) { _, title in
+                        HStack(spacing: 6) {
+                            Image(systemName: "exclamationmark.circle.fill")
+                                .foregroundStyle(.red)
+                                .font(.caption)
+                            Text(title)
+                                .font(.callout)
+                        }
+                    }
+                }
+                .padding()
+            }
+            .frame(maxHeight: 200)
+        }
+        .frame(width: 280)
+    }
+}
+#endif

--- a/Vibrdrome/Features/Library/AlbumDetailView.swift
+++ b/Vibrdrome/Features/Library/AlbumDetailView.swift
@@ -46,7 +46,8 @@ struct AlbumDetailView: View {
                         songs: songs,
                         settings: columnSettings,
                         showDiscSeparators: hasMultipleDiscs,
-                        downloadedSongIds: downloadedSongIds
+                        downloadedSongIds: downloadedSongIds,
+                        embedsScrollView: false
                     )
                     #else
                     LazyVStack(spacing: 0) {

--- a/Vibrdrome/Features/Library/AlbumsView.swift
+++ b/Vibrdrome/Features/Library/AlbumsView.swift
@@ -94,6 +94,7 @@ struct AlbumsView: View {
             #if os(macOS)
             filterRaw = AlbumFilter.all.rawValue
             appState.albumFilter.reset()
+            appState.activeFilterWindowContext = .album
             if let lf = initialLabelFilter {
                 appState.albumFilter.selectedLabels = [lf]
             } else if let gf = initialGenreFilter {
@@ -485,6 +486,7 @@ private struct AlbumFilterWatcher: ViewModifier {
             .onChange(of: filter.selectedGenres) { onChange() }
             .onChange(of: filter.selectedLabels) { onChange() }
             .onChange(of: filter.year) { onChange() }
+            .onChange(of: filter.ruleSet) { onChange() }
             .onChange(of: cache.generation) { _, _ in onChange() }
     }
 }

--- a/Vibrdrome/Features/Library/AlbumsViewModel.swift
+++ b/Vibrdrome/Features/Library/AlbumsViewModel.swift
@@ -340,6 +340,7 @@ final class AlbumsViewModel {
         let filter = appState.albumFilter
         guard filter.isActive else {
             localFilteredAlbums = nil
+            filter.matchCount = nil
             recomputeFilteredAlbums(filterRaw: filterRaw)
             return
         }
@@ -371,6 +372,7 @@ final class AlbumsViewModel {
 
         guard !Task.isCancelled else { return }
         localFilteredAlbums = filtered
+        filter.matchCount = filtered.count
         recomputeFilteredAlbums(filterRaw: filterRaw)
     }
 
@@ -405,6 +407,7 @@ final class AlbumsViewModel {
         let selectedGenres: Set<String>
         let selectedLabels: Set<String>
         let year: Int?
+        let ruleSet: FilterRuleSet
 
         @MainActor
         init(filter: LibraryFilter) {
@@ -414,6 +417,7 @@ final class AlbumsViewModel {
             selectedGenres = filter.selectedGenres
             selectedLabels = filter.selectedLabels
             year = filter.year
+            ruleSet = filter.ruleSet
         }
     }
 
@@ -439,6 +443,10 @@ final class AlbumsViewModel {
         }
         if let yearFilter = snapshot.year {
             guard album.year == yearFilter else { return false }
+        }
+        if !snapshot.ruleSet.isEmpty {
+            let meta = FilterRuleSet.AlbumMeta(album: album)
+            guard snapshot.ruleSet.matches(album: meta) else { return false }
         }
         return true
     }

--- a/Vibrdrome/Features/Library/AlbumsViewModel.swift
+++ b/Vibrdrome/Features/Library/AlbumsViewModel.swift
@@ -349,24 +349,34 @@ final class AlbumsViewModel {
         let artistNames = selectedArtistNames(for: filter, appState: appState, modelContext: modelContext)
         let snapshot = FilterSnapshot(filter: filter)
         let allAlbums: [Album]
-        if let cached = appState.libraryCache.albums {
-            allAlbums = cached
-        } else {
-            do {
-                var descriptor = FetchDescriptor<CachedAlbum>()
-                descriptor.sortBy = [SortDescriptor(\.name)]
-                allAlbums = try modelContext.fetch(descriptor).map { $0.toAlbum() }
-            } catch {
-                logger.error("Failed to fetch albums for filter: \(error)")
-                localFilteredAlbums = nil
-                return
+        let extrasMap: [String: FilterRuleSet.CachedAlbumExtras]
+        do {
+            var descriptor = FetchDescriptor<CachedAlbum>()
+            descriptor.sortBy = [SortDescriptor(\.name)]
+            let rows = try modelContext.fetch(descriptor)
+            if appState.libraryCache.albums == nil {
+                allAlbums = rows.map { $0.toAlbum() }
+            } else {
+                allAlbums = appState.libraryCache.albums!
             }
+            extrasMap = Dictionary(uniqueKeysWithValues: rows.map {
+                ($0.id, FilterRuleSet.CachedAlbumExtras(
+                    releaseType: $0.releaseType, releaseCountry: $0.releaseCountry,
+                    releaseStatus: $0.releaseStatus, mood: $0.mood, grouping: $0.grouping,
+                    mediaType: $0.mediaType, catalogNum: $0.catalogNum
+                ))
+            })
+        } catch {
+            logger.error("Failed to fetch albums for filter: \(error)")
+            localFilteredAlbums = nil
+            return
         }
 
         let filtered = await Task.detached(priority: .userInitiated) {
             allAlbums.filter {
                 AlbumsViewModel.albumMatchesFilter(
-                    $0, snapshot: snapshot, recentIds: recentIds, selectedArtistNames: artistNames)
+                    $0, extras: extrasMap[$0.id],
+                    snapshot: snapshot, recentIds: recentIds, selectedArtistNames: artistNames)
             }
         }.value
 
@@ -423,6 +433,7 @@ final class AlbumsViewModel {
 
     nonisolated static func albumMatchesFilter(
         _ album: Album,
+        extras: FilterRuleSet.CachedAlbumExtras? = nil,
         snapshot: FilterSnapshot,
         recentIds: Set<String>?,
         selectedArtistNames: Set<String>
@@ -445,7 +456,7 @@ final class AlbumsViewModel {
             guard album.year == yearFilter else { return false }
         }
         if !snapshot.ruleSet.isEmpty {
-            let meta = FilterRuleSet.AlbumMeta(album: album)
+            let meta = FilterRuleSet.AlbumMeta(album: album, extras: extras)
             guard snapshot.ruleSet.matches(album: meta) else { return false }
         }
         return true

--- a/Vibrdrome/Features/Library/ArtistDetailView.swift
+++ b/Vibrdrome/Features/Library/ArtistDetailView.swift
@@ -413,7 +413,8 @@ struct ArtistDetailView: View {
 
                         MacTrackTableView(
                             songs: showAllTracks ? topSongs : Array(topSongs.prefix(3)),
-                            settings: columnSettings
+                            settings: columnSettings,
+                            embedsScrollView: false
                         )
                     }
                 }

--- a/Vibrdrome/Features/Library/ArtistsView.swift
+++ b/Vibrdrome/Features/Library/ArtistsView.swift
@@ -233,6 +233,7 @@ struct ArtistsView: View {
         .task {
             #if os(macOS)
             filterRaw = ArtistFilter.all.rawValue
+            appState.activeFilterWindowContext = .artist
             #endif
             await loadArtists()
             await loadFavorites()
@@ -249,6 +250,7 @@ struct ArtistsView: View {
         #if os(macOS)
         .onChange(of: appState.artistFilter.isFavorited) { debouncedApplyLocalFilters() }
         .onChange(of: appState.artistFilter.selectedGenres) { debouncedApplyLocalFilters() }
+        .onChange(of: appState.artistFilter.ruleSet) { debouncedApplyLocalFilters() }
         .onChange(of: appState.libraryCache.generation) { _, _ in debouncedApplyLocalFilters() }
         #endif
     }
@@ -415,6 +417,7 @@ struct ArtistsView: View {
         let filter = appState.artistFilter
         guard filter.isActive else {
             localFilteredArtists = nil
+            filter.matchCount = nil
             recomputeFilteredIndexes()
             return
         }
@@ -450,29 +453,38 @@ struct ArtistsView: View {
                 artistIdsWithMatchingGenres = ids
             }
 
-            let filtered = allArtists.filter { artist in
-                // Favorited filter
-                switch filter.isFavorited {
-                case .yes: if artist.starred == nil { return false }
-                case .no: if artist.starred != nil { return false }
-                case .none: break
-                }
-
-                // Genre filter (via album lookup)
-                if let matchIds = artistIdsWithMatchingGenres {
-                    if !matchIds.contains(artist.id) { return false }
-                }
-
-                return true
+            let ruleSet = filter.ruleSet
+            let filtered = allArtists.filter {
+                artistMatchesFilter($0, isFavorited: filter.isFavorited,
+                                    genreIds: artistIdsWithMatchingGenres, ruleSet: ruleSet)
             }
 
             localFilteredArtists = filtered
+            filter.matchCount = filtered.count
             recomputeFilteredIndexes()
         } catch {
             Logger(subsystem: "com.vibrdrome.app", category: "Artists")
                 .error("Failed to apply local filters: \(error)")
             localFilteredArtists = nil
         }
+    }
+
+    private func artistMatchesFilter(
+        _ artist: Artist,
+        isFavorited: TriState,
+        genreIds: Set<String>?,
+        ruleSet: FilterRuleSet
+    ) -> Bool {
+        switch isFavorited {
+        case .yes: if artist.starred == nil { return false }
+        case .no: if artist.starred != nil { return false }
+        case .none: break
+        }
+        if let matchIds = genreIds, !matchIds.contains(artist.id) { return false }
+        if !ruleSet.isEmpty {
+            if !ruleSet.matches(artist: FilterRuleSet.ArtistMeta(artist: artist)) { return false }
+        }
+        return true
     }
     #endif
 }

--- a/Vibrdrome/Features/Library/FilterContext.swift
+++ b/Vibrdrome/Features/Library/FilterContext.swift
@@ -1,0 +1,12 @@
+/// Which entity type the filter sidebar is controlling.
+enum FilterContext: Hashable, Codable {
+    case album, artist, song
+
+    var windowTitle: String {
+        switch self {
+        case .album:  "Album Filters"
+        case .artist: "Artist Filters"
+        case .song:   "Song Filters"
+        }
+    }
+}

--- a/Vibrdrome/Features/Library/FilterRuleBuilderView.swift
+++ b/Vibrdrome/Features/Library/FilterRuleBuilderView.swift
@@ -97,7 +97,10 @@ struct FilterRuleBuilderView: View {
         }
         .padding(.horizontal, 2)
         .sheet(isPresented: $showSaveSheet) {
-            SaveSmartPlaylistSheet(ruleSet: ruleSet)
+            SmartPlaylistEditorView(
+                mode: .create,
+                initialRules: NSPCriteria(from: ruleSet)
+            )
         }
     }
 
@@ -163,9 +166,16 @@ private struct RuleRowView: View {
     @State private var draftNumber: Int = 0
     @State private var draftRangeLo: Int = 0
     @State private var draftRangeHi: Int = 0
+    @State private var draftDate: Date = Date()
     @State private var debounceTask: Task<Void, Never>?
     /// Non-nil means the regex pattern is currently invalid.
     @State private var regexError: String?
+
+    private static let dateFormatter: DateFormatter = {
+        let fmt = DateFormatter()
+        fmt.dateFormat = "yyyy-MM-dd"
+        return fmt
+    }()
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
@@ -228,6 +238,11 @@ private struct RuleRowView: View {
             } else if newOp != .isBetween, case .range(let lo, _) = rule.value {
                 rule.value = .number(lo)
                 draftNumber = lo
+            }
+            if newOp == .before || newOp == .after {
+                rule.value = .text(Self.dateFormatter.string(from: draftDate))
+            } else if newOp == .inTheLast || newOp == .notInTheLast, case .text = rule.value {
+                rule.value = .number(draftNumber)
             }
             if newOp != .matchesRegex { regexError = nil }
         }
@@ -317,15 +332,26 @@ private struct RuleRowView: View {
 
     // MARK: Days Input
 
+    @ViewBuilder
     private var daysValueInput: some View {
-        HStack(spacing: 4) {
-            TextField("30", value: $draftNumber, format: .number.grouping(.never))
-                .textFieldStyle(.roundedBorder)
-                .font(.caption)
-                .frame(maxWidth: 70)
+        if rule.operator == .before || rule.operator == .after {
+            DatePicker("", selection: $draftDate, displayedComponents: .date)
+                .labelsHidden()
+                .controlSize(.mini)
                 .onAppear { syncDraftsFromRule() }
-                .onChange(of: draftNumber) { _, n in scheduleCommit { .number(n) } }
-            Text("days").font(.caption).foregroundStyle(.secondary)
+                .onChange(of: draftDate) { _, d in
+                    rule.value = .text(Self.dateFormatter.string(from: d))
+                }
+        } else {
+            HStack(spacing: 4) {
+                TextField("30", value: $draftNumber, format: .number.grouping(.never))
+                    .textFieldStyle(.roundedBorder)
+                    .font(.caption)
+                    .frame(maxWidth: 70)
+                    .onAppear { syncDraftsFromRule() }
+                    .onChange(of: draftNumber) { _, n in scheduleCommit { .number(n) } }
+                Text("days").font(.caption).foregroundStyle(.secondary)
+            }
         }
     }
 
@@ -385,122 +411,4 @@ private struct RuleRowView: View {
     }
 }
 
-// MARK: - Save Smart Playlist Sheet
-
-private struct SaveSmartPlaylistSheet: View {
-    @Environment(AppState.self) private var appState
-    @Environment(\.dismiss) private var dismiss
-
-    let ruleSet: FilterRuleSet
-
-    @State private var name = ""
-    @State private var comment = ""
-    @State private var isSaving = false
-    @State private var errorMessage: String?
-    @State private var didSave = false
-
-    private var activeRuleCount: Int { ruleSet.rules.filter { !$0.isEffectivelyEmpty }.count }
-    private var canSave: Bool { !name.trimmingCharacters(in: .whitespaces).isEmpty && !isSaving }
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            Text("Save as Smart Playlist")
-                .font(.headline)
-
-            if let ndClient = appState.navidromeClient {
-                if ndClient.isAvailable {
-                    formContent
-                } else {
-                    unavailableView
-                }
-            } else {
-                unavailableView
-            }
-
-            Spacer(minLength: 0)
-
-            if let error = errorMessage {
-                Text(error)
-                    .font(.caption)
-                    .foregroundStyle(.red)
-            }
-
-            HStack {
-                Button("Cancel") { dismiss() }
-                    .keyboardShortcut(.cancelAction)
-                Spacer()
-                if !didSave {
-                    Button("Save") { save() }
-                        .keyboardShortcut(.defaultAction)
-                        .disabled(!canSave)
-                } else {
-                    Label("Saved", systemImage: "checkmark.circle.fill")
-                        .foregroundStyle(.green)
-                        .font(.callout)
-                }
-            }
-        }
-        .padding(24)
-        .frame(minWidth: 340, minHeight: 200)
-    }
-
-    private var formContent: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            VStack(alignment: .leading, spacing: 4) {
-                Text("Name").font(.caption).foregroundStyle(.secondary)
-                TextField("Smart Playlist Name", text: $name)
-                    .textFieldStyle(.roundedBorder)
-            }
-            VStack(alignment: .leading, spacing: 4) {
-                Text("Description (optional)").font(.caption).foregroundStyle(.secondary)
-                TextField("", text: $comment)
-                    .textFieldStyle(.roundedBorder)
-            }
-            Text("\(activeRuleCount) rule\(activeRuleCount == 1 ? "" : "s") will be saved")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-        }
-    }
-
-    private var unavailableView: some View {
-        VStack(spacing: 8) {
-            Image(systemName: "exclamationmark.triangle")
-                .font(.title2)
-                .foregroundStyle(.orange)
-            Text("Navidrome Smart Playlists are not available.")
-                .font(.callout)
-            Text("Connect to a Navidrome server to use this feature.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.center)
-        }
-        .frame(maxWidth: .infinity)
-        .padding(.vertical, 8)
-    }
-
-    private func save() {
-        guard let ndClient = appState.navidromeClient, canSave else { return }
-        let trimmedName = name.trimmingCharacters(in: .whitespaces)
-        let criteria = NSPCriteria(from: ruleSet)
-        isSaving = true
-        errorMessage = nil
-
-        Task {
-            do {
-                try await ndClient.createSmartPlaylist(name: trimmedName, comment: comment, rules: criteria)
-                await MainActor.run {
-                    isSaving = false
-                    didSave = true
-                }
-                try? await Task.sleep(for: .seconds(1.2))
-                await MainActor.run { dismiss() }
-            } catch {
-                await MainActor.run {
-                    isSaving = false
-                    errorMessage = error.localizedDescription
-                }
-            }
-        }
-    }
-}
 #endif

--- a/Vibrdrome/Features/Library/FilterRuleBuilderView.swift
+++ b/Vibrdrome/Features/Library/FilterRuleBuilderView.swift
@@ -1,0 +1,506 @@
+#if os(macOS)
+import SwiftUI
+
+/// Expandable "Advanced Filters" section rendered inside LibraryFilterSidebarView.
+/// Lets the user compose operator-based rules (including regex) targeting diverse metadata fields.
+struct FilterRuleBuilderView: View {
+    @Binding var ruleSet: FilterRuleSet
+    let allowedFields: [FilterField]
+    /// AppStorage key for persisting the expanded state across sessions.
+    let expandedKey: String
+
+    @AppStorage private var isExpanded: Bool
+    @State private var showSaveSheet = false
+
+    init(ruleSet: Binding<FilterRuleSet>, allowedFields: [FilterField], expandedKey: String) {
+        self._ruleSet = ruleSet
+        self.allowedFields = allowedFields
+        self.expandedKey = expandedKey
+        self._isExpanded = AppStorage(wrappedValue: false, expandedKey)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            expanderHeader
+            if isExpanded {
+                builderContent
+                    .padding(.top, 8)
+            }
+        }
+        .onChange(of: ruleSet.rules.count) { oldCount, newCount in
+            if oldCount == 0 && newCount == 1 {
+                withAnimation(.easeInOut(duration: 0.15)) { isExpanded = true }
+            } else if newCount == 0 {
+                withAnimation(.easeInOut(duration: 0.15)) { isExpanded = false }
+            }
+        }
+    }
+
+    // MARK: - Expander Header
+
+    private var expanderHeader: some View {
+        Button {
+            withAnimation(.easeInOut(duration: 0.15)) { isExpanded.toggle() }
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                Text("Advanced Filters")
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                Spacer()
+                let activeCount = ruleSet.rules.filter { !$0.isEffectivelyEmpty }.count
+                if activeCount > 0 {
+                    Text("\(activeCount)")
+                        .font(.caption2)
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 2)
+                        .background(Color.accentColor.opacity(0.2))
+                        .clipShape(Capsule())
+                        .foregroundStyle(Color.accentColor)
+                }
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Builder Content
+
+    private var builderContent: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            if ruleSet.rules.count > 1 {
+                combinatorPicker
+            }
+
+            if ruleSet.rules.isEmpty {
+                Text("No rules yet — click + to add one.")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding(.vertical, 6)
+            } else {
+                ForEach($ruleSet.rules) { $rule in
+                    RuleRowView(rule: $rule, allowedFields: allowedFields) {
+                        ruleSet.rules.removeAll { $0.id == rule.id }
+                    }
+                }
+            }
+
+            addRuleButton
+
+            if !ruleSet.isEmpty {
+                Divider().padding(.vertical, 4)
+                saveAsSmartPlaylistButton
+            }
+        }
+        .padding(.horizontal, 2)
+        .sheet(isPresented: $showSaveSheet) {
+            SaveSmartPlaylistSheet(ruleSet: ruleSet)
+        }
+    }
+
+    // MARK: - Combinator Picker
+
+    private var combinatorPicker: some View {
+        HStack(spacing: 4) {
+            Text("Match")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Picker("", selection: $ruleSet.combinator) {
+                Text("ALL rules").tag(FilterRuleSet.Combinator.all)
+                Text("ANY rule").tag(FilterRuleSet.Combinator.any)
+            }
+            .pickerStyle(.menu)
+            .controlSize(.mini)
+            .labelsHidden()
+            .frame(maxWidth: 110)
+        }
+    }
+
+    // MARK: - Save as Smart Playlist
+
+    private var saveAsSmartPlaylistButton: some View {
+        Button {
+            showSaveSheet = true
+        } label: {
+            Label("Save as Smart Playlist…", systemImage: "sparkles")
+                .font(.caption)
+                .foregroundStyle(Color.accentColor)
+        }
+        .buttonStyle(.plain)
+        .help("Save these filter rules as a Navidrome Smart Playlist")
+    }
+
+    // MARK: - Add Rule Button
+
+    private var addRuleButton: some View {
+        Button {
+            let defaultField = allowedFields.first ?? .title
+            let defaultOp = FilterOperator.allowed(for: defaultField.kind).first ?? .contains
+            ruleSet.rules.append(
+                FilterRule(field: defaultField, operator: defaultOp, value: .defaultValue(for: defaultField.kind))
+            )
+        } label: {
+            Label("Add Rule", systemImage: "plus.circle")
+                .font(.caption)
+                .foregroundStyle(Color.accentColor)
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Individual Rule Row
+
+private struct RuleRowView: View {
+    @Binding var rule: FilterRule
+    let allowedFields: [FilterField]
+    let onRemove: () -> Void
+
+    /// Local draft buffers — updated every keystroke, committed to rule.value after debounce.
+    @State private var draftText: String = ""
+    @State private var draftNumber: Int = 0
+    @State private var draftRangeLo: Int = 0
+    @State private var draftRangeHi: Int = 0
+    @State private var debounceTask: Task<Void, Never>?
+    /// Non-nil means the regex pattern is currently invalid.
+    @State private var regexError: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 4) {
+                fieldPicker
+                operatorPicker
+                Spacer()
+                removeButton
+            }
+            valuePicker
+            if let err = regexError {
+                Text(err)
+                    .font(.caption2)
+                    .foregroundStyle(.red)
+                    .lineLimit(2)
+            }
+        }
+        .padding(6)
+        .background(Color(nsColor: .controlBackgroundColor).opacity(0.6))
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+    }
+
+    // MARK: Pickers
+
+    private var fieldPicker: some View {
+        Picker("", selection: $rule.field) {
+            ForEach(allowedFields, id: \.self) { field in
+                Text(field.displayName).tag(field)
+            }
+        }
+        .pickerStyle(.menu)
+        .controlSize(.mini)
+        .labelsHidden()
+        .onChange(of: rule.field) { _, newField in
+            debounceTask?.cancel()
+            let allowedOps = FilterOperator.allowed(for: newField.kind)
+            if !allowedOps.contains(rule.operator) {
+                rule.operator = allowedOps[0]
+            }
+            rule.value = .defaultValue(for: newField.kind)
+            regexError = nil
+            syncDraftsFromRule()
+        }
+    }
+
+    private var operatorPicker: some View {
+        let ops = FilterOperator.allowed(for: rule.field.kind)
+        return Picker("", selection: $rule.operator) {
+            ForEach(ops, id: \.self) { op in
+                Text(op.displayName).tag(op)
+            }
+        }
+        .pickerStyle(.menu)
+        .controlSize(.mini)
+        .labelsHidden()
+        .onChange(of: rule.operator) { _, newOp in
+            if newOp == .isBetween, case .number(let n) = rule.value {
+                rule.value = .range(n, n)
+                draftRangeLo = n; draftRangeHi = n
+            } else if newOp != .isBetween, case .range(let lo, _) = rule.value {
+                rule.value = .number(lo)
+                draftNumber = lo
+            }
+            if newOp != .matchesRegex { regexError = nil }
+        }
+    }
+
+    private var removeButton: some View {
+        Button(action: onRemove) {
+            Image(systemName: "minus.circle")
+                .foregroundStyle(.secondary)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Remove rule")
+    }
+
+    // MARK: Value Input
+
+    @ViewBuilder
+    private var valuePicker: some View {
+        switch rule.field.kind {
+        case .text:    textValueInput
+        case .numeric: numericValueInput
+        case .days:    daysValueInput
+        case .boolean: booleanValueInput
+        case .playlist: textValueInput
+        }
+    }
+
+    // MARK: Text Input
+
+    @ViewBuilder
+    private var textValueInput: some View {
+        HStack(spacing: 4) {
+            TextField(rule.operator == .matchesRegex ? "/pattern/flags or pattern…" : "value…", text: $draftText)
+                .textFieldStyle(.roundedBorder)
+                .font(.caption)
+                .onChange(of: draftText) { _, newText in scheduleCommit { .text(newText) }
+                    if rule.operator == .matchesRegex { scheduleRegexValidation(newText) }
+                }
+                .onAppear { syncDraftsFromRule() }
+            if rule.operator == .matchesRegex {
+                Image(systemName: regexError == nil ? "checkmark.circle" : "exclamationmark.circle")
+                    .font(.caption)
+                    .foregroundStyle(regexError == nil ? Color.green : Color.red)
+                    .opacity(draftText.isEmpty ? 0 : 1)
+            }
+        }
+    }
+
+    // MARK: Numeric Inputs
+
+    @ViewBuilder
+    private var numericValueInput: some View {
+        if rule.operator == .isBetween {
+            rangeInput
+        } else {
+            singleNumberInput
+        }
+    }
+
+    private var singleNumberInput: some View {
+        TextField("0", value: $draftNumber, format: .number.grouping(.never))
+            .textFieldStyle(.roundedBorder)
+            .font(.caption)
+            .frame(maxWidth: 90)
+            .onAppear { syncDraftsFromRule() }
+            .onChange(of: draftNumber) { _, n in scheduleCommit { .number(n) } }
+    }
+
+    private var rangeInput: some View {
+        HStack(alignment: .center, spacing: 4) {
+            TextField("from", value: $draftRangeLo, format: .number.grouping(.never))
+                .textFieldStyle(.roundedBorder).font(.caption).frame(maxWidth: 60)
+                .onAppear { syncDraftsFromRule() }
+                .onChange(of: draftRangeLo) { _, lo in
+                    let hi = draftRangeHi
+                    scheduleCommit { .range(lo, hi) }
+                }
+            Text("–").font(.caption).foregroundStyle(.secondary)
+            TextField("to", value: $draftRangeHi, format: .number.grouping(.never))
+                .textFieldStyle(.roundedBorder).font(.caption).frame(maxWidth: 60)
+                .onChange(of: draftRangeHi) { _, hi in
+                    let lo = draftRangeLo
+                    scheduleCommit { .range(lo, hi) }
+                }
+        }
+    }
+
+    // MARK: Days Input
+
+    private var daysValueInput: some View {
+        HStack(spacing: 4) {
+            TextField("30", value: $draftNumber, format: .number.grouping(.never))
+                .textFieldStyle(.roundedBorder)
+                .font(.caption)
+                .frame(maxWidth: 70)
+                .onAppear { syncDraftsFromRule() }
+                .onChange(of: draftNumber) { _, n in scheduleCommit { .number(n) } }
+            Text("days").font(.caption).foregroundStyle(.secondary)
+        }
+    }
+
+    // MARK: Boolean Input
+
+    private var booleanValueInput: some View {
+        let binding = Binding<Bool>(
+            get: { if case .boolean(let b) = rule.value { return b }; return true },
+            set: { rule.value = .boolean($0) }
+        )
+        return Picker("", selection: binding) {
+            Text("Yes").tag(true)
+            Text("No").tag(false)
+        }
+        .pickerStyle(.segmented)
+        .controlSize(.mini)
+        .labelsHidden()
+        .frame(maxWidth: 100)
+    }
+
+    // MARK: Debounce Helpers
+
+    private func scheduleCommit(_ makeValue: @escaping @Sendable () -> FilterValue) {
+        debounceTask?.cancel()
+        debounceTask = Task {
+            try? await Task.sleep(for: .milliseconds(300))
+            guard !Task.isCancelled else { return }
+            rule.value = makeValue()
+        }
+    }
+
+    private func scheduleRegexValidation(_ pattern: String) {
+        guard !pattern.isEmpty else { regexError = nil; return }
+        debounceTask?.cancel()
+        debounceTask = Task {
+            try? await Task.sleep(for: .milliseconds(300))
+            guard !Task.isCancelled else { return }
+            rule.value = .text(pattern)
+            let (rawPattern, options) = FilterRule.parseRegexLiteral(pattern)
+            do {
+                _ = try NSRegularExpression(pattern: rawPattern, options: options)
+                regexError = nil
+            } catch {
+                regexError = "⚠ \(error.localizedDescription)"
+            }
+        }
+    }
+
+    private func syncDraftsFromRule() {
+        switch rule.value {
+        case .text(let s):       draftText = s
+        case .number(let n):     draftNumber = n
+        case .range(let lo, let hi): draftRangeLo = lo; draftRangeHi = hi
+        case .boolean:           break
+        }
+        regexError = nil
+    }
+}
+
+// MARK: - Save Smart Playlist Sheet
+
+private struct SaveSmartPlaylistSheet: View {
+    @Environment(AppState.self) private var appState
+    @Environment(\.dismiss) private var dismiss
+
+    let ruleSet: FilterRuleSet
+
+    @State private var name = ""
+    @State private var comment = ""
+    @State private var isSaving = false
+    @State private var errorMessage: String?
+    @State private var didSave = false
+
+    private var activeRuleCount: Int { ruleSet.rules.filter { !$0.isEffectivelyEmpty }.count }
+    private var canSave: Bool { !name.trimmingCharacters(in: .whitespaces).isEmpty && !isSaving }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Save as Smart Playlist")
+                .font(.headline)
+
+            if let ndClient = appState.navidromeClient {
+                if ndClient.isAvailable {
+                    formContent
+                } else {
+                    unavailableView
+                }
+            } else {
+                unavailableView
+            }
+
+            Spacer(minLength: 0)
+
+            if let error = errorMessage {
+                Text(error)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+            }
+
+            HStack {
+                Button("Cancel") { dismiss() }
+                    .keyboardShortcut(.cancelAction)
+                Spacer()
+                if !didSave {
+                    Button("Save") { save() }
+                        .keyboardShortcut(.defaultAction)
+                        .disabled(!canSave)
+                } else {
+                    Label("Saved", systemImage: "checkmark.circle.fill")
+                        .foregroundStyle(.green)
+                        .font(.callout)
+                }
+            }
+        }
+        .padding(24)
+        .frame(minWidth: 340, minHeight: 200)
+    }
+
+    private var formContent: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Name").font(.caption).foregroundStyle(.secondary)
+                TextField("Smart Playlist Name", text: $name)
+                    .textFieldStyle(.roundedBorder)
+            }
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Description (optional)").font(.caption).foregroundStyle(.secondary)
+                TextField("", text: $comment)
+                    .textFieldStyle(.roundedBorder)
+            }
+            Text("\(activeRuleCount) rule\(activeRuleCount == 1 ? "" : "s") will be saved")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var unavailableView: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.title2)
+                .foregroundStyle(.orange)
+            Text("Navidrome Smart Playlists are not available.")
+                .font(.callout)
+            Text("Connect to a Navidrome server to use this feature.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 8)
+    }
+
+    private func save() {
+        guard let ndClient = appState.navidromeClient, canSave else { return }
+        let trimmedName = name.trimmingCharacters(in: .whitespaces)
+        let criteria = NSPCriteria(from: ruleSet)
+        isSaving = true
+        errorMessage = nil
+
+        Task {
+            do {
+                try await ndClient.createSmartPlaylist(name: trimmedName, comment: comment, rules: criteria)
+                await MainActor.run {
+                    isSaving = false
+                    didSave = true
+                }
+                try? await Task.sleep(for: .seconds(1.2))
+                await MainActor.run { dismiss() }
+            } catch {
+                await MainActor.run {
+                    isSaving = false
+                    errorMessage = error.localizedDescription
+                }
+            }
+        }
+    }
+}
+#endif

--- a/Vibrdrome/Features/Library/LibraryFilterSidebarView.swift
+++ b/Vibrdrome/Features/Library/LibraryFilterSidebarView.swift
@@ -2,11 +2,6 @@
 import SwiftUI
 import SwiftData
 
-/// Which entity type the filter sidebar is controlling.
-enum FilterContext {
-    case album, artist, song
-}
-
 struct FilterArtistItem: Identifiable, Hashable, Sendable {
     let id: String
     let name: String
@@ -14,13 +9,16 @@ struct FilterArtistItem: Identifiable, Hashable, Sendable {
     let albumCount: Int?
 }
 
-/// Feishin-style filter sidebar shown as a macOS side panel.
+/// Feishin-style filter sidebar shown as a macOS side panel or a standalone window.
 /// Adapts its controls based on the entity type being filtered.
 struct LibraryFilterSidebarView: View {
     let context: FilterContext
+    /// True when rendered in a standalone window; hides the SidePanelContainer chrome.
+    var isWindow: Bool = false
 
     @Environment(AppState.self) private var appState
     @Environment(\.modelContext) private var modelContext
+    @Environment(\.openWindow) private var openWindow
     @State private var artists: [FilterArtistItem] = []
     @State private var genres: [String] = []
     @State private var labels: [String] = []
@@ -33,32 +31,51 @@ struct LibraryFilterSidebarView: View {
         }
     }
 
-    private var panelTitle: String {
-        switch context {
-        case .album: "Album Filters"
-        case .artist: "Artist Filters"
-        case .song: "Song Filters"
+    var body: some View {
+        if isWindow {
+            VStack(spacing: 0) {
+                stickyHeader
+                Divider()
+                scrollableContent
+            }
+            .task { await loadCachedMetadata() }
+        } else {
+            SidePanelContainer(
+                title: context.windowTitle,
+                onClose: { appState.activeSidePanel = nil },
+                onPopOut: {
+                    appState.activeFilterWindowContext = context
+                    openWindow(id: "library-filter", value: context)
+                    appState.activeSidePanel = nil
+                }
+            ) {
+                VStack(spacing: 0) {
+                    stickyHeader
+                    Divider()
+                    scrollableContent
+                }
+            }
+            .task { await loadCachedMetadata() }
         }
     }
 
-    var body: some View {
-        SidePanelContainer(title: panelTitle, onClose: {
-            appState.activeSidePanel = nil
-        }) {
-            ScrollView {
-                VStack(alignment: .leading, spacing: 16) {
-                    headerButtons
+    private var stickyHeader: some View {
+        headerButtons
+            .padding(.horizontal, 14)
+            .padding(.vertical, 8)
+    }
 
-                    if appState.librarySyncManager.lastSyncDate == nil {
-                        syncRequiredView
-                    } else {
-                        filterControls
-                    }
+    private var scrollableContent: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                if appState.librarySyncManager.lastSyncDate == nil {
+                    syncRequiredView
+                } else {
+                    filterControls
                 }
-                .padding(14)
             }
+            .padding(14)
         }
-        .task { await loadCachedMetadata() }
     }
 
     // MARK: - Header
@@ -67,9 +84,17 @@ struct LibraryFilterSidebarView: View {
     private var headerButtons: some View {
         HStack {
             if filter.isActive {
-                Text("\(filter.activeFilterCount) active")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                if let count = filter.matchCount {
+                    Text("\(count) result\(count == 1 ? "" : "s")")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .contentTransition(.numericText())
+                        .animation(.easeInOut(duration: 0.2), value: count)
+                } else {
+                    Text("\(filter.activeFilterCount) filter\(filter.activeFilterCount == 1 ? "" : "s") active")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
             }
             Spacer()
             Button("Reset") {
@@ -101,6 +126,7 @@ struct LibraryFilterSidebarView: View {
                 Task {
                     await appState.librarySyncManager.sync(
                         client: appState.subsonicClient,
+                        ndClient: appState.navidromeClient,
                         container: PersistenceController.shared.container
                     )
                     await loadCachedMetadata()
@@ -163,6 +189,36 @@ struct LibraryFilterSidebarView: View {
         if context == .album || context == .song {
             Divider()
             yearFilter
+        }
+
+        Divider()
+        advancedFilterSection
+    }
+
+    // MARK: - Advanced Filter Builder
+
+    @ViewBuilder
+    private var advancedFilterSection: some View {
+        @Bindable var state = appState
+        switch context {
+        case .album:
+            FilterRuleBuilderView(
+                ruleSet: $state.albumFilter.ruleSet,
+                allowedFields: FilterField.albumFields,
+                expandedKey: UserDefaultsKeys.albumFilterRuleBuilderExpanded
+            )
+        case .song:
+            FilterRuleBuilderView(
+                ruleSet: $state.songFilter.ruleSet,
+                allowedFields: FilterField.songFields,
+                expandedKey: UserDefaultsKeys.songFilterRuleBuilderExpanded
+            )
+        case .artist:
+            FilterRuleBuilderView(
+                ruleSet: $state.artistFilter.ruleSet,
+                allowedFields: FilterField.artistFields,
+                expandedKey: UserDefaultsKeys.artistFilterRuleBuilderExpanded
+            )
         }
     }
 

--- a/Vibrdrome/Features/Library/LibraryFilterSidebarView.swift
+++ b/Vibrdrome/Features/Library/LibraryFilterSidebarView.swift
@@ -210,7 +210,7 @@ struct LibraryFilterSidebarView: View {
         case .song:
             FilterRuleBuilderView(
                 ruleSet: $state.songFilter.ruleSet,
-                allowedFields: FilterField.songFields,
+                allowedFields: FilterField.smartPlaylistFields,
                 expandedKey: UserDefaultsKeys.songFilterRuleBuilderExpanded
             )
         case .artist:

--- a/Vibrdrome/Features/Library/MacContentView.swift
+++ b/Vibrdrome/Features/Library/MacContentView.swift
@@ -46,6 +46,11 @@ struct MacContentView: View {
             case .active:
                 engine.restorePlayQueue(client: appState.subsonicClient)
                 engine.refreshPlaybackState()
+                if UserDefaults.standard.bool(forKey: UserDefaultsKeys.exportAutoSyncOnForeground) {
+                    Task {
+                        await PlaylistExportManager.shared.syncAllActive(client: appState.subsonicClient)
+                    }
+                }
             default:
                 break
             }

--- a/Vibrdrome/Features/Library/MacTrackTableView.swift
+++ b/Vibrdrome/Features/Library/MacTrackTableView.swift
@@ -14,6 +14,10 @@ struct MacTrackTableView: View {
     /// Pre-computed from a @Query in the parent so this view's first render doesn't
     /// hit SwiftData on the main actor mid-navigation-animation.
     var downloadedSongIds: Set<String> = []
+    /// Set to false when this view is embedded inside a List or another ScrollView
+    /// that already handles scrolling — avoids nested scroll containers that break
+    /// trackpad/mouse-wheel events on macOS.
+    var embedsScrollView: Bool = true
 
     @State private var sortColumn: TrackTableColumn?
     @State private var sortAscending: Bool = true
@@ -74,44 +78,55 @@ struct MacTrackTableView: View {
                     description: Text("No songs to display.")
                 )
             } else {
-                ScrollView(.vertical) {
-                    LazyVStack(spacing: 0) {
-                        let ordered = displayedSongs
-                        // Pre-compute first-occurrence indices for disc separators — O(n) not O(n²)
-                        let discFirstIndices: Set<Int> = {
-                            guard showDiscSeparators else { return [] }
-                            var seen = Set<Int>()
-                            var result = Set<Int>()
-                            for (idx, song) in ordered.enumerated() {
-                                if let disc = song.discNumber, !seen.contains(disc) {
-                                    seen.insert(disc)
-                                    result.insert(idx)
-                                }
-                            }
-                            return result
-                        }()
+                let trackList = trackListContent
+                if embedsScrollView {
+                    ScrollView(.vertical) {
+                        trackList
+                    }
+                } else {
+                    trackList
+                }
+            }
+        }
+    }
 
-                        ForEach(Array(ordered.enumerated()), id: \.element.id) { index, song in
-                            if showDiscSeparators && discFirstIndices.contains(index),
-                               let disc = song.discNumber {
-                                discSeparator(disc)
-                            }
+    // MARK: - Track list rows
 
-                            MacTrackTableRow(
-                                song: song,
-                                settings: settings,
-                                queue: ordered,
-                                index: index,
-                                downloadedSongIds: downloadedSongIds,
-                                selectedSongId: $selectedSongId
-                            )
-                            .accessibilityIdentifier("macTrackRow_\(song.id)")
-
-                            Divider()
-                                .padding(.leading, 12)
-                        }
+    private var trackListContent: some View {
+        LazyVStack(spacing: 0) {
+            let ordered = displayedSongs
+            // Pre-compute first-occurrence indices for disc separators — O(n) not O(n²)
+            let discFirstIndices: Set<Int> = {
+                guard showDiscSeparators else { return [] }
+                var seen = Set<Int>()
+                var result = Set<Int>()
+                for (idx, song) in ordered.enumerated() {
+                    if let disc = song.discNumber, !seen.contains(disc) {
+                        seen.insert(disc)
+                        result.insert(idx)
                     }
                 }
+                return result
+            }()
+
+            ForEach(Array(ordered.enumerated()), id: \.element.id) { index, song in
+                if showDiscSeparators && discFirstIndices.contains(index),
+                   let disc = song.discNumber {
+                    discSeparator(disc)
+                }
+
+                MacTrackTableRow(
+                    song: song,
+                    settings: settings,
+                    queue: ordered,
+                    index: index,
+                    downloadedSongIds: downloadedSongIds,
+                    selectedSongId: $selectedSongId
+                )
+                .accessibilityIdentifier("macTrackRow_\(song.id)")
+
+                Divider()
+                    .padding(.leading, 12)
             }
         }
     }

--- a/Vibrdrome/Features/Library/SidebarContentView.swift
+++ b/Vibrdrome/Features/Library/SidebarContentView.swift
@@ -57,6 +57,7 @@ struct SidebarContentView: View {
         case radio
         case nowPlaying
         case downloads
+        case export
         case settings
     }
 
@@ -119,6 +120,10 @@ struct SidebarContentView: View {
                         .tag(SidebarItem.folders.rawValue)
                     Label("Downloads", systemImage: "arrow.down.circle")
                         .tag(SidebarItem.downloads.rawValue)
+                    #if os(macOS)
+                    Label("Playlist Export", systemImage: "square.and.arrow.up.circle")
+                        .tag(SidebarItem.export.rawValue)
+                    #endif
                 }
                 if !collections.isEmpty {
                     Section("Collections") {
@@ -324,6 +329,12 @@ struct SidebarContentView: View {
             FolderBrowserView()
         case .downloads:
             DownloadsView()
+        case .export:
+            #if os(macOS)
+            PlaylistExportView()
+            #else
+            EmptyView()
+            #endif
         case .search:
             SearchView()
         case .playlists:

--- a/Vibrdrome/Features/Library/SongsView.swift
+++ b/Vibrdrome/Features/Library/SongsView.swift
@@ -714,11 +714,16 @@ struct SongsView: View {
 
             let recentSongIds = recentlyPlayedSongIds(for: filter)
             let ruleSet = filter.ruleSet
+
+            // Batch-load CachedSong extras once before the filter loop to avoid N+1 queries.
+            let cachedExtrasMap: [String: FilterRuleSet.CachedSongExtras] = ruleSet.needsCachedSong
+                ? buildCachedExtrasMap()
+                : [:]
+
             let filtered = allSongs.filter { song in
                 guard songMatchesFilter(song, filter: filter, recentIds: recentSongIds) else { return false }
                 if !ruleSet.isEmpty {
-                    let extras = ruleSet.needsCachedSong ? fetchCachedSongExtras(songId: song.id) : nil
-                    let meta = FilterRuleSet.SongMeta(song: song, extras: extras)
+                    let meta = FilterRuleSet.SongMeta(song: song, extras: cachedExtrasMap[song.id])
                     if !ruleSet.matches(song: meta) { return false }
                 }
                 return true
@@ -733,19 +738,22 @@ struct SongsView: View {
         }
     }
 
-    private func fetchCachedSongExtras(songId: String) -> FilterRuleSet.CachedSongExtras? {
-        let descriptor = FetchDescriptor<CachedSong>(predicate: #Predicate { $0.id == songId })
-        guard let cached = (try? modelContext.fetch(descriptor))?.first else { return nil }
-        return FilterRuleSet.CachedSongExtras(
-            playCount: cached.playCount,
-            albumRating: 0,
-            albumFavorited: false,
-            hasCoverArt: cached.hasCoverArt,
-            isCompilation: cached.isCompilation,
-            channels: cached.channels,
-            mbzRecordingId: cached.mbzRecordingId,
-            dateAdded: cached.dateAdded
-        )
+    private func buildCachedExtrasMap() -> [String: FilterRuleSet.CachedSongExtras] {
+        guard let rows = try? modelContext.fetch(FetchDescriptor<CachedSong>()) else { return [:] }
+        var map = [String: FilterRuleSet.CachedSongExtras](minimumCapacity: rows.count)
+        for cached in rows {
+            map[cached.id] = FilterRuleSet.CachedSongExtras(
+                playCount: cached.playCount,
+                albumRating: cached.album?.userRating ?? 0,
+                albumFavorited: cached.album?.isStarred ?? false,
+                hasCoverArt: cached.hasCoverArt,
+                isCompilation: cached.isCompilation,
+                channels: cached.channels,
+                mbzRecordingId: cached.mbzRecordingId,
+                dateAdded: cached.dateAdded
+            )
+        }
+        return map
     }
 
     private func recentlyPlayedSongIds(for filter: LibraryFilter) -> Set<String>? {

--- a/Vibrdrome/Features/Library/SongsView.swift
+++ b/Vibrdrome/Features/Library/SongsView.swift
@@ -115,6 +115,7 @@ struct SongsView: View {
         .onChange(of: appState.songFilter.selectedArtistIds) { debouncedApplyLocalFilters() }
         .onChange(of: appState.songFilter.selectedGenres) { debouncedApplyLocalFilters() }
         .onChange(of: appState.songFilter.year) { debouncedApplyLocalFilters() }
+        .onChange(of: appState.songFilter.ruleSet) { debouncedApplyLocalFilters() }
         #endif
     }
 
@@ -532,6 +533,9 @@ struct SongsView: View {
     }
 
     private func initialLoad() async {
+        #if os(macOS)
+        appState.activeFilterWindowContext = .song
+        #endif
         await loadSongs()
         await loadGenres()
         refreshTitleSongCount()
@@ -693,6 +697,7 @@ struct SongsView: View {
         let filter = appState.songFilter
         guard filter.isActive else {
             localFilteredSongs = nil
+            filter.matchCount = nil
             recomputeDisplayedSongs()
             return
         }
@@ -708,13 +713,39 @@ struct SongsView: View {
             }
 
             let recentSongIds = recentlyPlayedSongIds(for: filter)
-            localFilteredSongs = allSongs.filter { songMatchesFilter($0, filter: filter, recentIds: recentSongIds) }
+            let ruleSet = filter.ruleSet
+            let filtered = allSongs.filter { song in
+                guard songMatchesFilter(song, filter: filter, recentIds: recentSongIds) else { return false }
+                if !ruleSet.isEmpty {
+                    let extras = ruleSet.needsCachedSong ? fetchCachedSongExtras(songId: song.id) : nil
+                    let meta = FilterRuleSet.SongMeta(song: song, extras: extras)
+                    if !ruleSet.matches(song: meta) { return false }
+                }
+                return true
+            }
+            localFilteredSongs = filtered
+            filter.matchCount = filtered.count
             recomputeDisplayedSongs()
         } catch {
             Logger(subsystem: "com.vibrdrome.app", category: "Songs")
                 .error("Failed to apply local filters: \(error)")
             localFilteredSongs = nil
         }
+    }
+
+    private func fetchCachedSongExtras(songId: String) -> FilterRuleSet.CachedSongExtras? {
+        let descriptor = FetchDescriptor<CachedSong>(predicate: #Predicate { $0.id == songId })
+        guard let cached = (try? modelContext.fetch(descriptor))?.first else { return nil }
+        return FilterRuleSet.CachedSongExtras(
+            playCount: cached.playCount,
+            albumRating: 0,
+            albumFavorited: false,
+            hasCoverArt: cached.hasCoverArt,
+            isCompilation: cached.isCompilation,
+            channels: cached.channels,
+            mbzRecordingId: cached.mbzRecordingId,
+            dateAdded: cached.dateAdded
+        )
     }
 
     private func recentlyPlayedSongIds(for filter: LibraryFilter) -> Set<String>? {

--- a/Vibrdrome/Features/Library/SongsView.swift
+++ b/Vibrdrome/Features/Library/SongsView.swift
@@ -750,7 +750,11 @@ struct SongsView: View {
                 isCompilation: cached.isCompilation,
                 channels: cached.channels,
                 mbzRecordingId: cached.mbzRecordingId,
-                dateAdded: cached.dateAdded
+                mbzAlbumId: cached.mbzAlbumId,
+                dateAdded: cached.dateAdded,
+                dateLoved: cached.starredAt,
+                albumLastPlayed: cached.album?.lastPlayed,
+                albumDateLoved: cached.album?.starredAt
             )
         }
         return map

--- a/Vibrdrome/Features/Player/SidePanels.swift
+++ b/Vibrdrome/Features/Player/SidePanels.swift
@@ -8,6 +8,7 @@ import os.log
 struct SidePanelContainer<Content: View>: View {
     let title: String
     let onClose: () -> Void
+    var onPopOut: (() -> Void)?
     @ViewBuilder let content: () -> Content
 
     var body: some View {
@@ -16,6 +17,17 @@ struct SidePanelContainer<Content: View>: View {
                 Text(title)
                     .font(.headline)
                 Spacer()
+                if let onPopOut {
+                    Button {
+                        onPopOut()
+                    } label: {
+                        Image(systemName: "arrow.up.forward.app")
+                            .font(.title3)
+                            .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Open \(title) in separate window")
+                }
                 Button {
                     onClose()
                 } label: {

--- a/Vibrdrome/Features/Playlists/CreateSmartPlaylistView.swift
+++ b/Vibrdrome/Features/Playlists/CreateSmartPlaylistView.swift
@@ -1,0 +1,446 @@
+#if os(macOS)
+import SwiftUI
+
+struct SmartPlaylistEditorView: View {
+    enum Mode {
+        case create
+        case edit(playlistId: String)
+    }
+
+    @Environment(AppState.self) private var appState
+    @Environment(\.dismiss) private var dismiss
+
+    let mode: Mode
+    var onSave: (() async -> Void)?
+
+    @State private var name: String
+    @State private var ruleSet: FilterRuleSet
+    @State private var sortField: SortOption = .none
+    @State private var sortAscending = true
+    @State private var limitEnabled = false
+    @State private var limit = 25
+    @State private var isSaving = false
+    @State private var errorMessage: String?
+    @State private var didSave = false
+
+    init(mode: Mode, initialName: String = "", initialRules: NSPCriteria? = nil, onSave: (() async -> Void)? = nil) {
+        self.mode = mode
+        self.onSave = onSave
+        self._name = State(initialValue: initialName)
+        if let criteria = initialRules {
+            self._ruleSet = State(initialValue: FilterRuleSet(from: criteria))
+            self._sortField = State(initialValue: SortOption(nspName: criteria.sort))
+            self._sortAscending = State(initialValue: criteria.order != "desc")
+            if let lim = criteria.limit {
+                self._limitEnabled = State(initialValue: true)
+                self._limit = State(initialValue: lim)
+            }
+        } else {
+            self._ruleSet = State(initialValue: FilterRuleSet())
+        }
+    }
+
+    private var canSave: Bool { !name.trimmingCharacters(in: .whitespaces).isEmpty && !isSaving }
+    private var isCreating: Bool { if case .create = mode { return true }; return false }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Playlist Name") {
+                    TextField("Name", text: $name, prompt: Text("My Smart Playlist"))
+                }
+                Section("Rules") {
+                    RuleEditorContent(ruleSet: $ruleSet)
+                }
+                Section("Sort & Limit") {
+                    sortSection
+                }
+                if let msg = errorMessage {
+                    Section {
+                        Text(msg).foregroundStyle(.red).font(.caption)
+                    }
+                }
+            }
+            .formStyle(.grouped)
+            .navigationTitle(isCreating ? "New Smart Playlist" : "Edit Smart Playlist")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                        .keyboardShortcut(.cancelAction)
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    if didSave {
+                        Label("Saved", systemImage: "checkmark.circle.fill")
+                            .foregroundStyle(.green)
+                    } else {
+                        Button(isCreating ? "Create" : "Save") { save() }
+                            .keyboardShortcut(.defaultAction)
+                            .disabled(!canSave)
+                    }
+                }
+            }
+        }
+        .frame(minWidth: 560, minHeight: 380)
+    }
+
+    // MARK: - Sort & Limit section
+
+    private var sortSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 8) {
+                Text("Sort by")
+                    .foregroundStyle(.secondary)
+                    .frame(width: 60, alignment: .trailing)
+                Picker("", selection: $sortField) {
+                    ForEach(SortOption.allCases, id: \.self) { opt in
+                        Text(opt.label).tag(opt)
+                    }
+                }
+                .labelsHidden()
+                .frame(width: 180)
+                if sortField != .none {
+                    Picker("", selection: $sortAscending) {
+                        Text("Ascending").tag(true)
+                        Text("Descending").tag(false)
+                    }
+                    .labelsHidden()
+                    .frame(width: 130)
+                }
+            }
+            HStack(spacing: 8) {
+                Toggle("Limit to", isOn: $limitEnabled)
+                    .toggleStyle(.checkbox)
+                    .frame(width: 80, alignment: .trailing)
+                if limitEnabled {
+                    TextField("", value: $limit, format: .number.grouping(.never))
+                        .textFieldStyle(.roundedBorder)
+                        .frame(width: 60)
+                    Text("songs")
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .padding(.vertical, 2)
+    }
+
+    // MARK: - Save
+
+    private func save() {
+        guard let ndClient = appState.navidromeClient, canSave else {
+            errorMessage = "Navidrome connection not available"
+            return
+        }
+        isSaving = true
+        errorMessage = nil
+        let trimmedName = name.trimmingCharacters(in: .whitespaces)
+        let criteria = NSPCriteria(
+            from: ruleSet,
+            sort: sortField == .none ? nil : sortField.nspName,
+            order: (sortField != .none && !sortAscending) ? "desc" : nil,
+            limit: limitEnabled ? limit : nil
+        )
+        Task {
+            do {
+                switch mode {
+                case .create:
+                    try await ndClient.createSmartPlaylist(name: trimmedName, comment: "", rules: criteria)
+                case .edit(let playlistId):
+                    try await ndClient.updateSmartPlaylist(id: playlistId, name: trimmedName, rules: criteria)
+                }
+                await MainActor.run { isSaving = false; didSave = true }
+                await onSave?()
+                try? await Task.sleep(for: .seconds(0.8))
+                await MainActor.run { dismiss() }
+            } catch {
+                await MainActor.run {
+                    isSaving = false
+                    errorMessage = error.localizedDescription
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Sort options
+
+private enum SortOption: String, CaseIterable {
+    case none
+    case title, artist, album, genre, year, rating, playCount, lastPlayed
+    case random, dateAdded, bpm, duration
+
+    var label: String {
+        switch self {
+        case .none:       return "None (server default)"
+        case .title:      return "Title"
+        case .artist:     return "Artist"
+        case .album:      return "Album"
+        case .genre:      return "Genre"
+        case .year:       return "Year"
+        case .rating:     return "Rating"
+        case .playCount:  return "Play Count"
+        case .lastPlayed: return "Last Played"
+        case .random:     return "Random"
+        case .dateAdded:  return "Date Added"
+        case .bpm:        return "BPM"
+        case .duration:   return "Duration"
+        }
+    }
+
+    var nspName: String? {
+        switch self {
+        case .none:       return nil
+        case .title:      return "title"
+        case .artist:     return "artist"
+        case .album:      return "album"
+        case .genre:      return "genre"
+        case .year:       return "year"
+        case .rating:     return "rating"
+        case .playCount:  return "playcount"
+        case .lastPlayed: return "lastplayed"
+        case .random:     return "random"
+        case .dateAdded:  return "dateadded"
+        case .bpm:        return "bpm"
+        case .duration:   return "duration"
+        }
+    }
+
+    init(nspName: String?) {
+        guard let name = nspName else { self = .none; return }
+        self = SortOption.allCases.first { $0.nspName == name } ?? .none
+    }
+}
+
+// MARK: - Inline rule editor
+
+private struct RuleEditorContent: View {
+    @Binding var ruleSet: FilterRuleSet
+    let allowedFields = FilterField.smartPlaylistFields
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            if ruleSet.rules.count > 1 {
+                combinatorPicker
+            }
+
+            if ruleSet.rules.isEmpty {
+                Text("No rules yet — click + to add one.")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding(.vertical, 4)
+            } else {
+                ForEach($ruleSet.rules) { $rule in
+                    RuleRow(rule: $rule, allowedFields: allowedFields) {
+                        ruleSet.rules.removeAll { $0.id == rule.id }
+                    }
+                }
+            }
+
+            Button {
+                let field = allowedFields.first ?? .title
+                let op = FilterOperator.allowed(for: field.kind).first(where: \.nspSupported) ?? .contains
+                ruleSet.rules.append(FilterRule(field: field, operator: op, value: .defaultValue(for: field.kind)))
+            } label: {
+                Label("Add Rule", systemImage: "plus.circle")
+                    .font(.caption)
+                    .foregroundStyle(Color.accentColor)
+            }
+            .buttonStyle(.plain)
+            .padding(.top, 2)
+        }
+        .padding(.vertical, 2)
+    }
+
+    private var combinatorPicker: some View {
+        HStack(spacing: 4) {
+            Text("Match")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Picker("", selection: $ruleSet.combinator) {
+                Text("ALL rules").tag(FilterRuleSet.Combinator.all)
+                Text("ANY rule").tag(FilterRuleSet.Combinator.any)
+            }
+            .pickerStyle(.menu)
+            .controlSize(.mini)
+            .labelsHidden()
+            .frame(width: 100)
+        }
+    }
+}
+
+// MARK: - Rule row
+
+private struct RuleRow: View {
+    @Binding var rule: FilterRule
+    let allowedFields: [FilterField]
+    let onRemove: () -> Void
+
+    @State private var draftText = ""
+    @State private var draftNumber = 0
+    @State private var draftRangeLo = 0
+    @State private var draftRangeHi = 0
+    @State private var draftDate = Date()
+
+    var body: some View {
+        HStack(spacing: 6) {
+            fieldPicker
+            operatorPicker
+            valueInput
+            Spacer(minLength: 0)
+            Button(action: onRemove) {
+                Image(systemName: "minus.circle").foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Remove rule")
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 6)
+        .background(Color(nsColor: .controlBackgroundColor).opacity(0.6))
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+    }
+
+    // NSP-supported operators only — drops matchesRegex, isGreaterOrEqual, isLessOrEqual.
+    private func nspOperators(for kind: FilterField.FieldKind) -> [FilterOperator] {
+        FilterOperator.allowed(for: kind).filter { $0.nspSupported }
+    }
+
+    private var fieldPicker: some View {
+        Picker("", selection: $rule.field) {
+            ForEach(allowedFields, id: \.self) { Text($0.displayName).tag($0) }
+        }
+        .pickerStyle(.menu)
+        .controlSize(.small)
+        .labelsHidden()
+        .frame(width: 130)
+        .onChange(of: rule.field) { _, newField in
+            let ops = nspOperators(for: newField.kind)
+            if !ops.contains(rule.operator) { rule.operator = ops[0] }
+            rule.value = .defaultValue(for: newField.kind)
+            syncDrafts()
+        }
+    }
+
+    private var operatorPicker: some View {
+        let ops = nspOperators(for: rule.field.kind)
+        return Picker("", selection: $rule.operator) {
+            ForEach(ops, id: \.self) { Text($0.displayName).tag($0) }
+        }
+        .pickerStyle(.menu)
+        .controlSize(.small)
+        .labelsHidden()
+        .frame(width: 120)
+        .onChange(of: rule.operator) { _, newOp in
+            if newOp == .isBetween, case .number(let n) = rule.value {
+                rule.value = .range(n, n); draftRangeLo = n; draftRangeHi = n
+            } else if newOp != .isBetween, case .range(let lo, _) = rule.value {
+                rule.value = .number(lo); draftNumber = lo
+            }
+            // Switching between days-count and absolute-date operators needs a value type change.
+            if newOp == .before || newOp == .after {
+                rule.value = .text(Self.dateFormatter.string(from: draftDate))
+            } else if newOp == .inTheLast || newOp == .notInTheLast {
+                if case .text = rule.value { rule.value = .number(draftNumber) }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var valueInput: some View {
+        switch rule.field.kind {
+        case .text:     textInput
+        case .numeric:  numericInput
+        case .days:     daysInput
+        case .boolean:  boolInput
+        case .playlist: textInput
+        }
+    }
+
+    private var textInput: some View {
+        TextField("value…", text: $draftText)
+            .textFieldStyle(.roundedBorder)
+            .controlSize(.small)
+            .frame(minWidth: 100)
+            .onChange(of: draftText) { _, v in rule.value = .text(v) }
+            .onAppear { syncDrafts() }
+    }
+
+    @ViewBuilder
+    private var numericInput: some View {
+        if rule.operator == .isBetween {
+            HStack(spacing: 4) {
+                TextField("from", value: $draftRangeLo, format: .number.grouping(.never))
+                    .textFieldStyle(.roundedBorder).controlSize(.small).frame(width: 55)
+                    .onAppear { syncDrafts() }
+                    .onChange(of: draftRangeLo) { _, lo in rule.value = .range(lo, draftRangeHi) }
+                Text("–").foregroundStyle(.secondary)
+                TextField("to", value: $draftRangeHi, format: .number.grouping(.never))
+                    .textFieldStyle(.roundedBorder).controlSize(.small).frame(width: 55)
+                    .onChange(of: draftRangeHi) { _, hi in rule.value = .range(draftRangeLo, hi) }
+            }
+        } else {
+            TextField("0", value: $draftNumber, format: .number.grouping(.never))
+                .textFieldStyle(.roundedBorder).controlSize(.small).frame(width: 80)
+                .onAppear { syncDrafts() }
+                .onChange(of: draftNumber) { _, n in rule.value = .number(n) }
+        }
+    }
+
+    @ViewBuilder
+    private var daysInput: some View {
+        if rule.operator == .before || rule.operator == .after {
+            // Absolute date picker — value stored as "YYYY-MM-DD" text.
+            DatePicker("", selection: $draftDate, displayedComponents: .date)
+                .labelsHidden()
+                .controlSize(.small)
+                .onAppear { syncDrafts() }
+                .onChange(of: draftDate) { _, d in
+                    rule.value = .text(Self.dateFormatter.string(from: d))
+                }
+        } else {
+            // Relative days count.
+            HStack(spacing: 4) {
+                TextField("30", value: $draftNumber, format: .number.grouping(.never))
+                    .textFieldStyle(.roundedBorder).controlSize(.small).frame(width: 60)
+                    .onAppear { syncDrafts() }
+                    .onChange(of: draftNumber) { _, n in rule.value = .number(n) }
+                Text("days").foregroundStyle(.secondary).font(.caption)
+            }
+        }
+    }
+
+    private var boolInput: some View {
+        let binding = Binding<Bool>(
+            get: { if case .boolean(let b) = rule.value { return b }; return true },
+            set: { rule.value = .boolean($0) }
+        )
+        return Picker("", selection: binding) {
+            Text("Yes").tag(true)
+            Text("No").tag(false)
+        }
+        .pickerStyle(.segmented)
+        .controlSize(.small)
+        .labelsHidden()
+        .frame(width: 90)
+    }
+
+    private static let dateFormatter: DateFormatter = {
+        let fmt = DateFormatter()
+        fmt.dateFormat = "yyyy-MM-dd"
+        return fmt
+    }()
+
+    private func syncDrafts() {
+        switch rule.value {
+        case .text(let s):
+            if let date = Self.dateFormatter.date(from: s) {
+                draftDate = date
+            } else {
+                draftText = s
+            }
+        case .number(let n):  draftNumber = n
+        case .range(let lo, let hi): draftRangeLo = lo; draftRangeHi = hi
+        case .boolean: break
+        }
+    }
+}
+#endif

--- a/Vibrdrome/Features/Playlists/PlaylistDetailView.swift
+++ b/Vibrdrome/Features/Playlists/PlaylistDetailView.swift
@@ -28,6 +28,11 @@ struct PlaylistDetailView: View {
     @Query private var downloadedSongs: [DownloadedSong]
     #if os(macOS)
     @State private var columnSettings = TrackTableColumnSettings(viewKey: "playlist")
+    @State private var showExportConfig = false
+    @Query private var allExports: [ExportedPlaylist]
+    private var existingExport: ExportedPlaylist? {
+        allExports.first { $0.playlistId == playlistId }
+    }
     #endif
 
     private var viewMode: PlaylistViewMode { PlaylistViewMode(rawValue: viewModeRaw) ?? .songs }
@@ -191,12 +196,43 @@ struct PlaylistDetailView: View {
                                 }
                             }
                         }
+
+                        #if os(macOS)
+                        Divider()
+                        if let existing = existingExport {
+                            Button {
+                                showExportConfig = true
+                            } label: {
+                                Label("Export Settings…", systemImage: "square.and.arrow.up")
+                            }
+                            Button(role: .destructive) {
+                                PlaylistExportManager.shared.removeExport(existing)
+                            } label: {
+                                Label("Remove Export", systemImage: "square.and.arrow.up.slash")
+                            }
+                        } else {
+                            Button {
+                                showExportConfig = true
+                            } label: {
+                                Label("Export Playlist…", systemImage: "square.and.arrow.up")
+                            }
+                        }
+                        #endif
                     } label: {
                         Image(systemName: "ellipsis.circle")
                     }
                 }
             }
         }
+        #if os(macOS)
+        .sheet(isPresented: $showExportConfig) {
+            PlaylistExportConfigView(
+                playlistId: playlistId,
+                playlistName: playlist?.name ?? playlistId,
+                existingExport: existingExport
+            )
+        }
+        #endif
         .sheet(isPresented: $showBatchAddToPlaylist) {
             AddToPlaylistView(songIds: Array(selectedSongs))
                 .environment(appState)

--- a/Vibrdrome/Features/Playlists/PlaylistDetailView.swift
+++ b/Vibrdrome/Features/Playlists/PlaylistDetailView.swift
@@ -37,154 +37,7 @@ struct PlaylistDetailView: View {
     }
 
     var body: some View {
-        List {
-            if let playlist {
-                // Header section
-                Section {
-                    VStack(spacing: 12) {
-                        AlbumArtView(coverArtId: playlist.coverArt, size: 160, cornerRadius: 12)
-                            .shadow(radius: 6)
-
-                        HStack(spacing: 6) {
-                            Text(playlist.name)
-                                .font(.title3)
-                                .bold()
-                            if isSmartPlaylist {
-                                Image(systemName: "sparkles")
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
-                            }
-                        }
-
-                        HStack(spacing: 8) {
-                            Text(verbatim: "\(playlist.songCount ?? 0) songs")
-                            if let duration = playlist.duration {
-                                Text("·")
-                                Text(formatDuration(duration))
-                            }
-                        }
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-
-                        // Action buttons
-                        HStack(spacing: 16) {
-                            Button {
-                                if let songs = playlist.entry, let first = songs.first {
-                                    AudioEngine.shared.play(song: first, from: songs, at: 0)
-                                    AudioEngine.shared.playingFromContext = "Playlist: \(playlist.name)"
-                                }
-                            } label: {
-                                Label("Play", systemImage: "play.fill")
-                            }
-                            .buttonStyle(.bordered)
-                            .accessibilityIdentifier("playlistPlayButton")
-                            .disabled(playlist.entry?.isEmpty ?? true)
-
-                            Button {
-                                if var songs = playlist.entry, !songs.isEmpty {
-                                    songs.shuffle()
-                                    AudioEngine.shared.play(song: songs[0], from: songs, at: 0)
-                                    AudioEngine.shared.playingFromContext = "Playlist: \(playlist.name)"
-                                }
-                            } label: {
-                                Label("Shuffle", systemImage: "shuffle")
-                            }
-                            .buttonStyle(.bordered)
-                            .accessibilityIdentifier("playlistShuffleButton")
-                            .disabled(playlist.entry?.isEmpty ?? true)
-
-                            Menu {
-                                Button {
-                                    if let songs = playlist.entry, !songs.isEmpty {
-                                        AudioEngine.shared.addToQueueNext(songs)
-                                    }
-                                } label: {
-                                    Label("Play Next", systemImage: "text.insert")
-                                }
-                                Button {
-                                    if let songs = playlist.entry, !songs.isEmpty {
-                                        AudioEngine.shared.addToQueue(songs)
-                                    }
-                                } label: {
-                                    Label("Add to Queue", systemImage: "text.append")
-                                }
-                            } label: {
-                                Label("More", systemImage: "ellipsis.circle")
-                            }
-                            .buttonStyle(.bordered)
-                            .accessibilityIdentifier("playlistMoreButton")
-                            .disabled(playlist.entry?.isEmpty ?? true)
-                        }
-                    }
-                    .frame(maxWidth: .infinity)
-                    .listRowInsets(EdgeInsets())
-                    .listRowBackground(Color.clear)
-                    .padding(.vertical, 12)
-                }
-
-                // Songs
-                Section {
-                    #if os(macOS)
-                    MacTrackTableView(songs: filteredSongs, settings: columnSettings)
-                        .listRowInsets(EdgeInsets())
-                        .listRowSeparator(.hidden)
-                    #else
-                    ForEach(Array(filteredSongs.enumerated()), id: \.element.id) { index, song in
-                        HStack(spacing: 0) {
-                            if isSelecting {
-                                Button {
-                                    toggleSelection(song.id)
-                                } label: {
-                                    Image(systemName: selectedSongs.contains(song.id)
-                                          ? "checkmark.circle.fill" : "circle")
-                                        .foregroundStyle(selectedSongs.contains(song.id)
-                                                         ? Color.accentColor : .secondary)
-                                        .font(.title3)
-                                }
-                                .buttonStyle(.plain)
-                                .padding(.trailing, 8)
-                            }
-
-                            TrackRow(song: song, showTrackNumber: false)
-                                .contentShape(Rectangle())
-                                .onTapGesture {
-                                    if isSelecting {
-                                        toggleSelection(song.id)
-                                    } else {
-                                        playFromPlaylist(song: song, songs: filteredSongs, index: index)
-                                    }
-                                }
-                                .trackContextMenu(song: song, queue: filteredSongs, index: index)
-                        }
-                    }
-                    .onDelete { offsets in
-                        // Map filtered indices to original playlist indices
-                        let allSongs = playlist.entry ?? []
-                        let filtered = filteredSongs
-                        let originalIndices = offsets.compactMap { offset -> Int? in
-                            guard offset < filtered.count else { return nil }
-                            let songId = filtered[offset].id
-                            return allSongs.firstIndex(where: { $0.id == songId })
-                        }
-                        removeFromPlaylist(
-                            at: IndexSet(originalIndices), songs: allSongs
-                        )
-                    }
-                    #endif
-                }
-
-                // Batch action bar
-                if isSelecting && !selectedSongs.isEmpty {
-                    Section {
-                        playlistBatchActionBar(songs: filteredSongs)
-                    }
-                }
-            }
-        }
-        .listStyle(.plain)
-        #if os(iOS)
-        .contentMargins(.bottom, 80)
-        #endif
+        content
         .navigationTitle(playlist?.name ?? "Playlist")
         .searchable(text: $searchText, prompt: "Search in Playlist")
         #if os(iOS)
@@ -355,6 +208,196 @@ struct PlaylistDetailView: View {
         .task { await loadPlaylist() }
         .task { await detectSmartPlaylist() }
         .refreshable { await loadPlaylist() }
+    }
+
+    // MARK: - Content containers
+
+    @ViewBuilder
+    private var content: some View {
+        #if os(macOS)
+        ScrollView {
+            if let playlist {
+                VStack(spacing: 0) {
+                    playlistHeader(playlist)
+                    MacTrackTableView(songs: filteredSongs, settings: columnSettings, embedsScrollView: false)
+                }
+            }
+        }
+        #else
+        List {
+            if let playlist {
+                Section {
+                    VStack(spacing: 12) {
+                        AlbumArtView(coverArtId: playlist.coverArt, size: 160, cornerRadius: 12)
+                            .shadow(radius: 6)
+
+                        HStack(spacing: 6) {
+                            Text(playlist.name)
+                                .font(.title3)
+                                .bold()
+                            if isSmartPlaylist {
+                                Image(systemName: "sparkles")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+
+                        HStack(spacing: 8) {
+                            Text(verbatim: "\(playlist.songCount ?? 0) songs")
+                            if let duration = playlist.duration {
+                                Text("·")
+                                Text(formatDuration(duration))
+                            }
+                        }
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                        playlistActionButtons(playlist)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .listRowInsets(EdgeInsets())
+                    .listRowBackground(Color.clear)
+                    .padding(.vertical, 12)
+                }
+
+                Section {
+                    ForEach(Array(filteredSongs.enumerated()), id: \.element.id) { index, song in
+                        HStack(spacing: 0) {
+                            if isSelecting {
+                                Button {
+                                    toggleSelection(song.id)
+                                } label: {
+                                    Image(systemName: selectedSongs.contains(song.id)
+                                          ? "checkmark.circle.fill" : "circle")
+                                        .foregroundStyle(selectedSongs.contains(song.id)
+                                                         ? Color.accentColor : .secondary)
+                                        .font(.title3)
+                                }
+                                .buttonStyle(.plain)
+                                .padding(.trailing, 8)
+                            }
+
+                            TrackRow(song: song, showTrackNumber: false)
+                                .contentShape(Rectangle())
+                                .onTapGesture {
+                                    if isSelecting {
+                                        toggleSelection(song.id)
+                                    } else {
+                                        playFromPlaylist(song: song, songs: filteredSongs, index: index)
+                                    }
+                                }
+                                .trackContextMenu(song: song, queue: filteredSongs, index: index)
+                        }
+                    }
+                    .onDelete { offsets in
+                        let allSongs = playlist.entry ?? []
+                        let filtered = filteredSongs
+                        let originalIndices = offsets.compactMap { offset -> Int? in
+                            guard offset < filtered.count else { return nil }
+                            let songId = filtered[offset].id
+                            return allSongs.firstIndex(where: { $0.id == songId })
+                        }
+                        removeFromPlaylist(at: IndexSet(originalIndices), songs: allSongs)
+                    }
+                }
+
+                if isSelecting && !selectedSongs.isEmpty {
+                    Section {
+                        playlistBatchActionBar(songs: filteredSongs)
+                    }
+                }
+            }
+        }
+        .listStyle(.plain)
+        .contentMargins(.bottom, 80)
+        #endif
+    }
+
+    #if os(macOS)
+    @ViewBuilder
+    private func playlistHeader(_ playlist: Playlist) -> some View {
+        VStack(spacing: 12) {
+            AlbumArtView(coverArtId: playlist.coverArt, size: 160, cornerRadius: 12)
+                .shadow(radius: 6)
+
+            HStack(spacing: 6) {
+                Text(playlist.name)
+                    .font(.title3)
+                    .bold()
+                if isSmartPlaylist {
+                    Image(systemName: "sparkles")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            HStack(spacing: 8) {
+                Text(verbatim: "\(playlist.songCount ?? 0) songs")
+                if let duration = playlist.duration {
+                    Text("·")
+                    Text(formatDuration(duration))
+                }
+            }
+            .font(.caption)
+            .foregroundStyle(.secondary)
+
+            playlistActionButtons(playlist)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 24)
+    }
+    #endif
+
+    @ViewBuilder
+    private func playlistActionButtons(_ playlist: Playlist) -> some View {
+        HStack(spacing: 16) {
+            Button {
+                if let songs = playlist.entry, let first = songs.first {
+                    AudioEngine.shared.play(song: first, from: songs, at: 0)
+                    AudioEngine.shared.playingFromContext = "Playlist: \(playlist.name)"
+                }
+            } label: {
+                Label("Play", systemImage: "play.fill")
+            }
+            .buttonStyle(.bordered)
+            .accessibilityIdentifier("playlistPlayButton")
+            .disabled(playlist.entry?.isEmpty ?? true)
+
+            Button {
+                if var songs = playlist.entry, !songs.isEmpty {
+                    songs.shuffle()
+                    AudioEngine.shared.play(song: songs[0], from: songs, at: 0)
+                    AudioEngine.shared.playingFromContext = "Playlist: \(playlist.name)"
+                }
+            } label: {
+                Label("Shuffle", systemImage: "shuffle")
+            }
+            .buttonStyle(.bordered)
+            .accessibilityIdentifier("playlistShuffleButton")
+            .disabled(playlist.entry?.isEmpty ?? true)
+
+            Menu {
+                Button {
+                    if let songs = playlist.entry, !songs.isEmpty {
+                        AudioEngine.shared.addToQueueNext(songs)
+                    }
+                } label: {
+                    Label("Play Next", systemImage: "text.insert")
+                }
+                Button {
+                    if let songs = playlist.entry, !songs.isEmpty {
+                        AudioEngine.shared.addToQueue(songs)
+                    }
+                } label: {
+                    Label("Add to Queue", systemImage: "text.append")
+                }
+            } label: {
+                Label("More", systemImage: "ellipsis.circle")
+            }
+            .buttonStyle(.bordered)
+            .accessibilityIdentifier("playlistMoreButton")
+            .disabled(playlist.entry?.isEmpty ?? true)
+        }
     }
 
     private func detectSmartPlaylist() async {

--- a/Vibrdrome/Features/Playlists/PlaylistDetailView.swift
+++ b/Vibrdrome/Features/Playlists/PlaylistDetailView.swift
@@ -164,6 +164,16 @@ struct PlaylistDetailView: View {
         .sheet(isPresented: $showEditSheet) {
             if let playlist {
                 if isSmartPlaylist {
+                    #if os(macOS)
+                    SmartPlaylistEditorView(
+                        mode: .edit(playlistId: playlist.id),
+                        initialName: playlist.name,
+                        initialRules: smartCriteria
+                    ) {
+                        await loadPlaylist()
+                    }
+                    .environment(appState)
+                    #else
                     PlaylistEditorView(
                         mode: .smartPlaylist(
                             playlistId: playlist.id,
@@ -174,6 +184,7 @@ struct PlaylistDetailView: View {
                         await loadPlaylist()
                     }
                     .environment(appState)
+                    #endif
                 } else {
                     PlaylistEditorView(
                         mode: .edit(playlistId: playlist.id, currentName: playlist.name)

--- a/Vibrdrome/Features/Playlists/PlaylistDetailView.swift
+++ b/Vibrdrome/Features/Playlists/PlaylistDetailView.swift
@@ -1,6 +1,10 @@
 import SwiftData
 import SwiftUI
 
+private enum PlaylistViewMode: String {
+    case songs, albums
+}
+
 struct PlaylistDetailView: View {
     let playlistId: String
 
@@ -20,12 +24,46 @@ struct PlaylistDetailView: View {
     @State private var showRemoveOfflineConfirmation = false
     @State private var smartCriteria: NSPCriteria?
     @State private var isLoadingSmartRules = false
+    @AppStorage("playlistDetailViewMode") private var viewModeRaw: String = PlaylistViewMode.songs.rawValue
     @Query private var downloadedSongs: [DownloadedSong]
     #if os(macOS)
     @State private var columnSettings = TrackTableColumnSettings(viewKey: "playlist")
     #endif
 
+    private var viewMode: PlaylistViewMode { PlaylistViewMode(rawValue: viewModeRaw) ?? .songs }
     private var isSmartPlaylist: Bool { smartCriteria != nil }
+
+    private var albumsInPlaylist: [Album] {
+        guard let songs = playlist?.entry else { return [] }
+        var seen = Set<String>()
+        var albums: [Album] = []
+        for song in songs {
+            let albumId = song.albumId ?? song.album ?? song.id
+            guard !seen.contains(albumId) else { continue }
+            seen.insert(albumId)
+            let count = songs.filter { ($0.albumId ?? $0.album ?? $0.id) == albumId }.count
+            albums.append(Album(
+                id: albumId,
+                name: song.album ?? "Unknown Album",
+                artist: song.albumArtist ?? song.artist,
+                artistId: song.artistId,
+                coverArt: song.coverArt,
+                songCount: count,
+                duration: nil,
+                year: song.year,
+                genre: song.genre,
+                genres: nil,
+                starred: nil,
+                created: nil,
+                userRating: nil,
+                song: nil,
+                replayGain: nil,
+                musicBrainzId: nil,
+                recordLabels: nil
+            ))
+        }
+        return albums
+    }
 
     private var filteredSongs: [Song] {
         guard let songs = playlist?.entry else { return [] }
@@ -46,6 +84,14 @@ struct PlaylistDetailView: View {
         .toolbar {
             if playlist != nil {
                 ToolbarItem(placement: .automatic) {
+                    Picker("View", selection: $viewModeRaw) {
+                        Label("Songs", systemImage: "music.note.list").tag(PlaylistViewMode.songs.rawValue)
+                        Label("Albums", systemImage: "square.grid.2x2").tag(PlaylistViewMode.albums.rawValue)
+                    }
+                    .pickerStyle(.segmented)
+                    .accessibilityLabel("View mode")
+                }
+                ToolbarItem(placement: .automatic) {
                     Button {
                         withAnimation(.easeInOut(duration: 0.2)) {
                             isSelecting.toggle()
@@ -56,6 +102,8 @@ struct PlaylistDetailView: View {
                     }
                     .accessibilityLabel(isSelecting ? "Done Selecting" : "Select Songs")
                     .accessibilityIdentifier("playlistSelectButton")
+                    .opacity(viewMode == .songs ? 1 : 0)
+                    .disabled(viewMode == .albums)
                 }
                 ToolbarItem(placement: .primaryAction) {
                     Menu {
@@ -230,18 +278,120 @@ struct PlaylistDetailView: View {
             if let playlist {
                 VStack(spacing: 0) {
                     playlistHeader(playlist)
-                    MacTrackTableView(songs: filteredSongs, settings: columnSettings, embedsScrollView: false)
+                    if viewMode == .albums {
+                        albumGrid
+                            .padding(.horizontal, 24)
+                            .padding(.vertical, 16)
+                    } else {
+                        MacTrackTableView(songs: filteredSongs, settings: columnSettings, embedsScrollView: false)
+                    }
                 }
             }
         }
         #else
-        List {
-            if let playlist {
-                Section {
+        if viewMode == .albums, playlist != nil {
+            albumGridList
+        } else {
+            List {
+                if let playlist {
+                    Section {
+                        VStack(spacing: 12) {
+                            AlbumArtView(coverArtId: playlist.coverArt, size: 160, cornerRadius: 12)
+                                .shadow(radius: 6)
+
+                            HStack(spacing: 6) {
+                                Text(playlist.name)
+                                    .font(.title3)
+                                    .bold()
+                                if isSmartPlaylist {
+                                    Image(systemName: "sparkles")
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+
+                            HStack(spacing: 8) {
+                                Text(verbatim: "\(playlist.songCount ?? 0) songs")
+                                if let duration = playlist.duration {
+                                    Text("·")
+                                    Text(formatDuration(duration))
+                                }
+                            }
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+
+                            playlistActionButtons(playlist)
+                        }
+                        .frame(maxWidth: .infinity)
+                        .listRowInsets(EdgeInsets())
+                        .listRowBackground(Color.clear)
+                        .padding(.vertical, 12)
+                    }
+
+                    Section {
+                        ForEach(Array(filteredSongs.enumerated()), id: \.element.id) { index, song in
+                            HStack(spacing: 0) {
+                                if isSelecting {
+                                    Button {
+                                        toggleSelection(song.id)
+                                    } label: {
+                                        Image(systemName: selectedSongs.contains(song.id)
+                                              ? "checkmark.circle.fill" : "circle")
+                                            .foregroundStyle(selectedSongs.contains(song.id)
+                                                             ? Color.accentColor : .secondary)
+                                            .font(.title3)
+                                    }
+                                    .buttonStyle(.plain)
+                                    .padding(.trailing, 8)
+                                }
+
+                                TrackRow(song: song, showTrackNumber: false)
+                                    .contentShape(Rectangle())
+                                    .onTapGesture {
+                                        if isSelecting {
+                                            toggleSelection(song.id)
+                                        } else {
+                                            playFromPlaylist(song: song, songs: filteredSongs, index: index)
+                                        }
+                                    }
+                                    .trackContextMenu(song: song, queue: filteredSongs, index: index)
+                            }
+                        }
+                        .onDelete { offsets in
+                            let allSongs = playlist.entry ?? []
+                            let filtered = filteredSongs
+                            let originalIndices = offsets.compactMap { offset -> Int? in
+                                guard offset < filtered.count else { return nil }
+                                let songId = filtered[offset].id
+                                return allSongs.firstIndex(where: { $0.id == songId })
+                            }
+                            removeFromPlaylist(at: IndexSet(originalIndices), songs: allSongs)
+                        }
+                    }
+
+                    if isSelecting && !selectedSongs.isEmpty {
+                        Section {
+                            playlistBatchActionBar(songs: filteredSongs)
+                        }
+                    }
+                }
+            }
+            .listStyle(.plain)
+            .contentMargins(.bottom, 80)
+        }
+        #endif
+    }
+
+    // MARK: - Album grid (iOS)
+
+    #if os(iOS)
+    private var albumGridList: some View {
+        ScrollView {
+            VStack(spacing: 0) {
+                if let playlist {
                     VStack(spacing: 12) {
                         AlbumArtView(coverArtId: playlist.coverArt, size: 160, cornerRadius: 12)
                             .shadow(radius: 6)
-
                         HStack(spacing: 6) {
                             Text(playlist.name)
                                 .font(.title3)
@@ -252,7 +402,6 @@ struct PlaylistDetailView: View {
                                     .foregroundStyle(.secondary)
                             }
                         }
-
                         HStack(spacing: 8) {
                             Text(verbatim: "\(playlist.songCount ?? 0) songs")
                             if let duration = playlist.duration {
@@ -262,66 +411,35 @@ struct PlaylistDetailView: View {
                         }
                         .font(.caption)
                         .foregroundStyle(.secondary)
-
                         playlistActionButtons(playlist)
                     }
                     .frame(maxWidth: .infinity)
-                    .listRowInsets(EdgeInsets())
-                    .listRowBackground(Color.clear)
-                    .padding(.vertical, 12)
+                    .padding(.vertical, 16)
                 }
-
-                Section {
-                    ForEach(Array(filteredSongs.enumerated()), id: \.element.id) { index, song in
-                        HStack(spacing: 0) {
-                            if isSelecting {
-                                Button {
-                                    toggleSelection(song.id)
-                                } label: {
-                                    Image(systemName: selectedSongs.contains(song.id)
-                                          ? "checkmark.circle.fill" : "circle")
-                                        .foregroundStyle(selectedSongs.contains(song.id)
-                                                         ? Color.accentColor : .secondary)
-                                        .font(.title3)
-                                }
-                                .buttonStyle(.plain)
-                                .padding(.trailing, 8)
-                            }
-
-                            TrackRow(song: song, showTrackNumber: false)
-                                .contentShape(Rectangle())
-                                .onTapGesture {
-                                    if isSelecting {
-                                        toggleSelection(song.id)
-                                    } else {
-                                        playFromPlaylist(song: song, songs: filteredSongs, index: index)
-                                    }
-                                }
-                                .trackContextMenu(song: song, queue: filteredSongs, index: index)
-                        }
-                    }
-                    .onDelete { offsets in
-                        let allSongs = playlist.entry ?? []
-                        let filtered = filteredSongs
-                        let originalIndices = offsets.compactMap { offset -> Int? in
-                            guard offset < filtered.count else { return nil }
-                            let songId = filtered[offset].id
-                            return allSongs.firstIndex(where: { $0.id == songId })
-                        }
-                        removeFromPlaylist(at: IndexSet(originalIndices), songs: allSongs)
-                    }
-                }
-
-                if isSelecting && !selectedSongs.isEmpty {
-                    Section {
-                        playlistBatchActionBar(songs: filteredSongs)
-                    }
-                }
+                albumGrid
+                    .padding(.horizontal, 16)
+                    .padding(.bottom, 80)
             }
         }
-        .listStyle(.plain)
-        .contentMargins(.bottom, 80)
-        #endif
+    }
+    #endif
+
+    // MARK: - Album grid (shared)
+
+    private var albumGrid: some View {
+        LazyVGrid(
+            columns: [GridItem(.adaptive(minimum: 150), spacing: 16)],
+            spacing: 20
+        ) {
+            ForEach(albumsInPlaylist) { album in
+                NavigationLink {
+                    AlbumDetailView(albumId: album.id)
+                } label: {
+                    AlbumGridCard(album: album, cellWidth: 150)
+                }
+                .buttonStyle(.plain)
+            }
+        }
     }
 
     #if os(macOS)

--- a/Vibrdrome/Features/Playlists/PlaylistDetailView.swift
+++ b/Vibrdrome/Features/Playlists/PlaylistDetailView.swift
@@ -18,10 +18,14 @@ struct PlaylistDetailView: View {
     @State private var isSelecting = false
     @State private var showBatchAddToPlaylist = false
     @State private var showRemoveOfflineConfirmation = false
+    @State private var smartCriteria: NSPCriteria?
+    @State private var isLoadingSmartRules = false
     @Query private var downloadedSongs: [DownloadedSong]
     #if os(macOS)
     @State private var columnSettings = TrackTableColumnSettings(viewKey: "playlist")
     #endif
+
+    private var isSmartPlaylist: Bool { smartCriteria != nil }
 
     private var filteredSongs: [Song] {
         guard let songs = playlist?.entry else { return [] }
@@ -41,9 +45,16 @@ struct PlaylistDetailView: View {
                         AlbumArtView(coverArtId: playlist.coverArt, size: 160, cornerRadius: 12)
                             .shadow(radius: 6)
 
-                        Text(playlist.name)
-                            .font(.title3)
-                            .bold()
+                        HStack(spacing: 6) {
+                            Text(playlist.name)
+                                .font(.title3)
+                                .bold()
+                            if isSmartPlaylist {
+                                Image(systemName: "sparkles")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
 
                         HStack(spacing: 8) {
                             Text(verbatim: "\(playlist.songCount ?? 0) songs")
@@ -198,7 +209,8 @@ struct PlaylistDetailView: View {
                         Button {
                             showEditSheet = true
                         } label: {
-                            Label("Edit Playlist", systemImage: "pencil")
+                            Label(isSmartPlaylist ? "Edit Smart Playlist" : "Edit Playlist",
+                                  systemImage: isSmartPlaylist ? "sparkles" : "pencil")
                         }
 
                         Button {
@@ -298,12 +310,25 @@ struct PlaylistDetailView: View {
         }
         .sheet(isPresented: $showEditSheet) {
             if let playlist {
-                PlaylistEditorView(
-                    mode: .edit(playlistId: playlist.id, currentName: playlist.name)
-                ) {
-                    await loadPlaylist()
+                if isSmartPlaylist {
+                    PlaylistEditorView(
+                        mode: .smartPlaylist(
+                            playlistId: playlist.id,
+                            currentName: playlist.name,
+                            existingRules: smartCriteria
+                        )
+                    ) {
+                        await loadPlaylist()
+                    }
+                    .environment(appState)
+                } else {
+                    PlaylistEditorView(
+                        mode: .edit(playlistId: playlist.id, currentName: playlist.name)
+                    ) {
+                        await loadPlaylist()
+                    }
+                    .environment(appState)
                 }
-                .environment(appState)
             }
         }
         #if os(iOS)
@@ -328,7 +353,18 @@ struct PlaylistDetailView: View {
             }
         }
         .task { await loadPlaylist() }
+        .task { await detectSmartPlaylist() }
         .refreshable { await loadPlaylist() }
+    }
+
+    private func detectSmartPlaylist() async {
+        guard let ndClient = appState.navidromeClient, ndClient.isAvailable else { return }
+        isLoadingSmartRules = true
+        defer { isLoadingSmartRules = false }
+        guard let playlists = try? await ndClient.getPlaylists() else { return }
+        if let match = playlists.first(where: { $0.id == playlistId }) {
+            smartCriteria = match.rules
+        }
     }
 
     private func loadPlaylist() async {

--- a/Vibrdrome/Features/Playlists/PlaylistEditorView.swift
+++ b/Vibrdrome/Features/Playlists/PlaylistEditorView.swift
@@ -4,6 +4,7 @@ struct PlaylistEditorView: View {
     enum Mode {
         case create
         case edit(playlistId: String, currentName: String)
+        case smartPlaylist(playlistId: String, currentName: String, existingRules: NSPCriteria?)
     }
 
     let mode: Mode
@@ -16,7 +17,9 @@ struct PlaylistEditorView: View {
     @State private var searchResults: [Song] = []
     @State private var selectedSongs: [Song] = []
     @State private var isSaving = false
+    @State private var errorMessage: String?
     @State private var searchTask: Task<Void, Never>?
+    @State private var ruleSet: FilterRuleSet = FilterRuleSet()
 
     init(mode: Mode, onSave: (() async -> Void)? = nil) {
         self.mode = mode
@@ -26,6 +29,11 @@ struct PlaylistEditorView: View {
             self._name = State(initialValue: "")
         case .edit(_, let currentName):
             self._name = State(initialValue: currentName)
+        case .smartPlaylist(_, let currentName, let existingRules):
+            self._name = State(initialValue: currentName)
+            if let criteria = existingRules {
+                self._ruleSet = State(initialValue: FilterRuleSet(from: criteria))
+            }
         }
     }
 
@@ -35,6 +43,25 @@ struct PlaylistEditorView: View {
                 Section("Playlist Name") {
                     TextField("Name", text: $name, prompt: Text("My Playlist"))
                 }
+
+                #if os(macOS)
+                if case .smartPlaylist = mode {
+                    Section("Rules") {
+                        FilterRuleBuilderView(
+                            ruleSet: $ruleSet,
+                            allowedFields: FilterField.smartPlaylistFields,
+                            expandedKey: "smartPlaylistEditorExpanded"
+                        )
+                    }
+                    if let msg = errorMessage {
+                        Section {
+                            Text(msg)
+                                .foregroundStyle(.red)
+                                .font(.caption)
+                        }
+                    }
+                }
+                #endif
 
                 if case .create = mode {
                     Section("Add Songs") {
@@ -113,7 +140,7 @@ struct PlaylistEditorView: View {
                     }
                 }
             }
-            .navigationTitle(isCreating ? "New Playlist" : "Edit Playlist")
+            .navigationTitle(navigationTitle)
             #if os(iOS)
             .navigationBarTitleDisplayMode(.inline)
             #endif
@@ -139,8 +166,17 @@ struct PlaylistEditorView: View {
         return false
     }
 
+    private var navigationTitle: String {
+        switch mode {
+        case .create: return "New Playlist"
+        case .edit: return "Edit Playlist"
+        case .smartPlaylist: return "Edit Smart Playlist"
+        }
+    }
+
     private func save() {
         isSaving = true
+        errorMessage = nil
         Task {
             defer { isSaving = false }
             do {
@@ -156,12 +192,22 @@ struct PlaylistEditorView: View {
                         id: playlistId,
                         name: name.trimmingCharacters(in: .whitespaces)
                     )
+                case .smartPlaylist(let playlistId, _, _):
+                    guard let ndClient = appState.navidromeClient else {
+                        errorMessage = "Navidrome connection not available"
+                        return
+                    }
+                    let criteria = NSPCriteria(from: ruleSet)
+                    try await ndClient.updateSmartPlaylist(
+                        id: playlistId,
+                        name: name.trimmingCharacters(in: .whitespaces),
+                        rules: criteria
+                    )
                 }
                 await onSave?()
                 dismiss()
             } catch {
-                // Show error - for now just print
-                print("Failed to save playlist: \(error)")
+                errorMessage = ErrorPresenter.userMessage(for: error)
             }
         }
     }

--- a/Vibrdrome/Features/Playlists/PlaylistsView.swift
+++ b/Vibrdrome/Features/Playlists/PlaylistsView.swift
@@ -8,6 +8,7 @@ struct PlaylistsView: View {
     @State private var error: String?
     @State private var showCreateSheet = false
     @State private var showSmartSheet = false
+    @State private var showSmartPlaylistBuilder = false
     @AppStorage("playlistViewStyle") private var showAsList = false
     @AppStorage(UserDefaultsKeys.gridDensity) private var gridDensityRaw: String = GridDensity.comfortable.rawValue
     private var gridDensity: GridDensity { GridDensity(rawValue: gridDensityRaw) ?? .comfortable }
@@ -134,6 +135,12 @@ struct PlaylistsView: View {
                 }
             }
             ToolbarItem {
+                Button { showSmartPlaylistBuilder = true } label: {
+                    Label("Smart Playlist", systemImage: "wand.and.stars")
+                }
+                .help("Create a smart playlist with custom filter rules")
+            }
+            ToolbarItem {
                 Button {
                     withAnimation(.easeInOut(duration: 0.2)) {
                         showAsList.toggle()
@@ -185,6 +192,14 @@ struct PlaylistsView: View {
                 Task { await loadPlaylists() }
             }
         }
+        #if os(macOS)
+        .sheet(isPresented: $showSmartPlaylistBuilder) {
+            SmartPlaylistEditorView(mode: .create) {
+                await loadPlaylists()
+            }
+            .environment(appState)
+        }
+        #endif
         .overlay {
             if isLoading && playlists.isEmpty {
                 ProgressView("Loading playlists...")

--- a/Vibrdrome/Features/Settings/PlaylistExportSettingsView.swift
+++ b/Vibrdrome/Features/Settings/PlaylistExportSettingsView.swift
@@ -1,0 +1,139 @@
+#if os(macOS)
+import SwiftUI
+
+struct PlaylistExportSettingsView: View {
+    @AppStorage(UserDefaultsKeys.exportDefaultSyncMode) private var defaultPlaylistExportSyncModeRaw = PlaylistExportSyncMode.addOnly.rawValue
+    @AppStorage(UserDefaultsKeys.exportDefaultTranscodeFormat) private var defaultTranscodeFormat = ""
+    @AppStorage(UserDefaultsKeys.exportDefaultTranscodeBitrate) private var defaultTranscodeBitrate = 192
+    @AppStorage(UserDefaultsKeys.exportFfmpegPath) private var ffmpegPath = ""
+    @AppStorage(UserDefaultsKeys.exportAutoSyncOnForeground) private var autoSyncOnForeground = true
+
+    @State private var defaultFolderURL: URL?
+    @State private var ffmpegTestResult: Bool?
+    @State private var isTestingFfmpeg = false
+
+    private var defaultPlaylistExportSyncMode: PlaylistExportSyncMode {
+        get { PlaylistExportSyncMode(rawValue: defaultPlaylistExportSyncModeRaw) ?? .addOnly }
+        nonmutating set { defaultPlaylistExportSyncModeRaw = newValue.rawValue }
+    }
+
+    var body: some View {
+        Form {
+            Section("Default Export Folder") {
+                HStack {
+                    if let url = defaultFolderURL {
+                        Text(url.path)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                            .foregroundStyle(.secondary)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    } else {
+                        Text("No default folder")
+                            .foregroundStyle(.secondary)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    Button("Choose…") {
+                        Task { await pickDefaultFolder() }
+                    }
+                }
+            }
+
+            Section("Sync") {
+                Picker("Default Mode", selection: Binding(
+                    get: { defaultPlaylistExportSyncMode },
+                    set: { defaultPlaylistExportSyncModeRaw = $0.rawValue }
+                )) {
+                    ForEach(PlaylistExportSyncMode.allCases, id: \.self) { mode in
+                        Text(mode.displayName).tag(mode)
+                    }
+                }
+                Toggle("Auto-sync exported playlists on launch", isOn: $autoSyncOnForeground)
+            }
+
+            Section("Transcode Defaults") {
+                Picker("Default Format", selection: $defaultTranscodeFormat) {
+                    Text("Original (no transcode)").tag("")
+                    Text("MP3").tag("mp3")
+                    Text("AAC").tag("aac")
+                    Text("Opus").tag("opus")
+                    Text("FLAC").tag("flac")
+                }
+                .pickerStyle(.menu)
+                if !defaultTranscodeFormat.isEmpty {
+                    HStack {
+                        Text("Default Bitrate (kbps)")
+                        TextField("192", value: $defaultTranscodeBitrate, format: .number)
+                            .frame(width: 80)
+                    }
+                }
+            }
+
+            Section("ffmpeg") {
+                HStack {
+                    TextField("/usr/local/bin/ffmpeg", text: $ffmpegPath)
+                    Button("Locate…") {
+                        Task { await locateFfmpeg() }
+                    }
+                    Button("Test") {
+                        Task { await testFfmpeg() }
+                    }
+                    .disabled(isTestingFfmpeg)
+                }
+                if isTestingFfmpeg {
+                    HStack {
+                        ProgressView().scaleEffect(0.7)
+                        Text("Testing…").font(.caption).foregroundStyle(.secondary)
+                    }
+                } else if let result = ffmpegTestResult {
+                    Label(
+                        result ? "ffmpeg found and working." : "ffmpeg not found or failed.",
+                        systemImage: result ? "checkmark.circle.fill" : "xmark.circle.fill"
+                    )
+                    .foregroundStyle(result ? .green : .red)
+                    .font(.caption)
+                }
+            }
+        }
+        .formStyle(.grouped)
+        .navigationTitle("Playlist Export")
+        .onAppear { loadDefaultFolder() }
+    }
+
+    private func pickDefaultFolder() async {
+        guard let url = await PlaylistExportManager.shared.pickFolder() else { return }
+        guard let data = try? PlaylistExportManager.shared.bookmarkData(for: url) else { return }
+        UserDefaults.standard.set(data, forKey: UserDefaultsKeys.exportDefaultFolderBookmark)
+        defaultFolderURL = url
+    }
+
+    private func loadDefaultFolder() {
+        guard let data = UserDefaults.standard.data(forKey: UserDefaultsKeys.exportDefaultFolderBookmark),
+              let (url, _) = try? PlaylistExportManager.shared.resolveBookmark(data) else { return }
+        defaultFolderURL = url
+    }
+
+    private func locateFfmpeg() async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            let panel = NSOpenPanel()
+            panel.canChooseFiles = true
+            panel.canChooseDirectories = false
+            panel.prompt = "Select ffmpeg"
+            panel.begin { response in
+                if response == .OK, let url = panel.url {
+                    DispatchQueue.main.async { self.ffmpegPath = url.path }
+                }
+                continuation.resume()
+            }
+        }
+    }
+
+    private func testFfmpeg() async {
+        let path = ffmpegPath.isEmpty ? "/usr/local/bin/ffmpeg" : ffmpegPath
+        isTestingFfmpeg = true
+        ffmpegTestResult = nil
+        let result = await PlaylistExportManager.shared.testFfmpeg(path: path)
+        ffmpegTestResult = result
+        isTestingFfmpeg = false
+    }
+}
+#endif

--- a/Vibrdrome/Features/Settings/SettingsView.swift
+++ b/Vibrdrome/Features/Settings/SettingsView.swift
@@ -316,6 +316,15 @@ struct SettingsView: View {
                     Label("Delete All Downloads", systemImage: "trash")
                 }
             }
+
+            #if os(macOS)
+            NavigationLink {
+                PlaylistExportSettingsView()
+            } label: {
+                Label("Playlist Export", systemImage: "square.and.arrow.up.circle")
+                    .foregroundColor(.primary)
+            }
+            #endif
         } header: {
             settingSectionHeader("Downloads", icon: "arrow.down.circle.fill", color: .cyan)
         }

--- a/Vibrdrome/Features/Settings/SettingsView.swift
+++ b/Vibrdrome/Features/Settings/SettingsView.swift
@@ -387,6 +387,7 @@ struct SettingsView: View {
                     Task {
                         await appState.librarySyncManager.sync(
                             client: appState.subsonicClient,
+                            ndClient: appState.navidromeClient,
                             container: PersistenceController.shared.container
                         )
                     }
@@ -405,6 +406,7 @@ struct SettingsView: View {
                     Task {
                         await appState.librarySyncManager.incrementalSync(
                             client: appState.subsonicClient,
+                            ndClient: appState.navidromeClient,
                             container: PersistenceController.shared.container
                         )
                     }
@@ -459,6 +461,7 @@ struct SettingsView: View {
                     // rather than waiting until the next launch.
                     appState.librarySyncManager.startPolling(
                         client: appState.subsonicClient,
+                        ndClient: appState.navidromeClient,
                         container: PersistenceController.shared.container
                     )
                 }

--- a/Vibrdrome/Vibrdrome.entitlements
+++ b/Vibrdrome/Vibrdrome.entitlements
@@ -8,5 +8,7 @@
     <array>
         <string>group.com.vibrdrome.app</string>
     </array>
+    <key>com.apple.security.files.user-selected.read-write</key>
+    <true/>
 </dict>
 </plist>

--- a/Vibrdrome/Vibrdrome.swift
+++ b/Vibrdrome/Vibrdrome.swift
@@ -275,6 +275,17 @@ struct VibrdromeApp: App {
         }
         .defaultSize(width: 700, height: 500)
 
+        WindowGroup("Filters", id: "library-filter", for: FilterContext.self) { $context in
+            if let context {
+                LibraryFilterSidebarView(context: context, isWindow: true)
+                    .environment(appState)
+                    .modelContainer(persistenceController.container)
+                    .preferredColorScheme(colorScheme)
+                    .tint(accentColor)
+            }
+        }
+        .defaultSize(width: 280, height: 600)
+
         WindowGroup("Get Info", id: "get-info", for: GetInfoTarget.self) { $target in
             if let target {
                 NavigationStack {

--- a/VibrdromeTests/Core/PlaylistExportTests.swift
+++ b/VibrdromeTests/Core/PlaylistExportTests.swift
@@ -1,0 +1,148 @@
+import Testing
+import Foundation
+@testable import Vibrdrome
+
+struct PlaylistExportTests {
+
+    private func makeSong(
+        id: String = "1",
+        title: String = "Test Song",
+        artist: String? = "Test Artist",
+        suffix: String? = "flac"
+    ) -> Song {
+        Song(
+            id: id, parent: nil, title: title,
+            album: nil, artist: artist, albumArtist: nil, albumId: nil, artistId: nil,
+            track: nil, year: nil, genre: nil, coverArt: nil,
+            size: nil, contentType: nil, suffix: suffix,
+            duration: 180, bitRate: nil, path: nil,
+            discNumber: nil, created: nil, starred: nil, userRating: nil,
+            bpm: nil, replayGain: nil, musicBrainzId: nil
+        )
+    }
+
+    // MARK: - exportPath
+
+    #if os(macOS)
+    @Test func exportPathUsesPlaylistAndArtistTitle() {
+        let song = makeSong(title: "My Song", artist: "My Artist", suffix: "mp3")
+        let path = PlaylistExportManager.exportPath(song: song, playlistName: "My Playlist", suffix: "mp3")
+        #expect(path == "My Playlist/My Artist - My Song.mp3")
+    }
+
+    @Test func exportPathSanitizesIllegalChars() {
+        let song = makeSong(title: "Song: Live", artist: "Artist/Band", suffix: "flac")
+        let path = PlaylistExportManager.exportPath(song: song, playlistName: "Rock/Pop", suffix: "flac")
+        #expect(!path.contains("/") || path.components(separatedBy: "/").count == 2)
+        #expect(!path.contains(":"))
+    }
+
+    @Test func exportPathFallsBackToIdWhenTitleEmpty() {
+        let song = makeSong(id: "abc123", title: "", artist: "Artist", suffix: "mp3")
+        let path = PlaylistExportManager.exportPath(song: song, playlistName: "Playlist", suffix: "mp3")
+        #expect(path.contains("abc123"))
+    }
+
+    @Test func exportPathUsesUnknownArtistWhenNil() {
+        let song = makeSong(title: "Track", artist: nil, suffix: "flac")
+        let path = PlaylistExportManager.exportPath(song: song, playlistName: "Playlist", suffix: "flac")
+        #expect(path.contains("Unknown Artist"))
+    }
+    #endif
+
+    // MARK: - finalSuffix
+
+    #if os(macOS)
+    @Test func finalSuffixUsesTranscodeFormatWhenSet() {
+        #expect(PlaylistExportManager.finalSuffix(originalSuffix: "flac", transcodeFormat: "mp3") == "mp3")
+        #expect(PlaylistExportManager.finalSuffix(originalSuffix: "flac", transcodeFormat: "aac") == "aac")
+    }
+
+    @Test func finalSuffixFallsBackToOriginalWhenNoTranscode() {
+        #expect(PlaylistExportManager.finalSuffix(originalSuffix: "flac", transcodeFormat: nil) == "flac")
+        #expect(PlaylistExportManager.finalSuffix(originalSuffix: "mp3", transcodeFormat: nil) == "mp3")
+    }
+    #endif
+
+    // MARK: - PlaylistExportSyncMode
+
+    @Test func syncModeRoundTrip() {
+        #expect(PlaylistExportSyncMode(rawValue: "addOnly") == .addOnly)
+        #expect(PlaylistExportSyncMode(rawValue: "addAndRemove") == .addAndRemove)
+        #expect(PlaylistExportSyncMode(rawValue: "unknown") == nil)
+        #expect(PlaylistExportSyncMode.addOnly.rawValue == "addOnly")
+        #expect(PlaylistExportSyncMode.addAndRemove.rawValue == "addAndRemove")
+    }
+
+    @Test func syncModeDisplayNames() {
+        #expect(!PlaylistExportSyncMode.addOnly.displayName.isEmpty)
+        #expect(!PlaylistExportSyncMode.addAndRemove.displayName.isEmpty)
+        #expect(PlaylistExportSyncMode.addOnly.displayName != PlaylistExportSyncMode.addAndRemove.displayName)
+    }
+
+    // MARK: - ExportedPlaylist knownSongPaths encoding
+
+    @Test func knownSongPathsRoundTrip() {
+        let export = ExportedPlaylist(
+            serverId: "s1",
+            playlistId: "p1",
+            playlistName: "Test",
+            folderBookmarkData: nil,
+            syncMode: .addOnly,
+            transcodeFormat: nil,
+            transcodeBitrate: nil,
+            isActive: true
+        )
+        let paths = ["id1": "Playlist/Artist - Song.mp3", "id2": "Playlist/Artist - Other.flac"]
+        export.knownSongPaths = paths
+        #expect(export.knownSongPaths["id1"] == "Playlist/Artist - Song.mp3")
+        #expect(export.knownSongPaths["id2"] == "Playlist/Artist - Other.flac")
+    }
+
+    // MARK: - needsResync
+
+    @Test func needsResyncWhenFormatsDiffer() {
+        let export = ExportedPlaylist(
+            serverId: "s1",
+            playlistId: "p1",
+            playlistName: "Test",
+            folderBookmarkData: nil,
+            syncMode: .addOnly,
+            transcodeFormat: "mp3",
+            transcodeBitrate: nil,
+            isActive: true
+        )
+        export.appliedTranscodeFormat = nil
+        #expect(export.needsResync == true)
+    }
+
+    @Test func noResyncWhenFormatsMatch() {
+        let export = ExportedPlaylist(
+            serverId: "s1",
+            playlistId: "p1",
+            playlistName: "Test",
+            folderBookmarkData: nil,
+            syncMode: .addOnly,
+            transcodeFormat: "mp3",
+            transcodeBitrate: nil,
+            isActive: true
+        )
+        export.appliedTranscodeFormat = "mp3"
+        #expect(export.needsResync == false)
+    }
+
+    @Test func noResyncWhenBothNil() {
+        let export = ExportedPlaylist(
+            serverId: "s1",
+            playlistId: "p1",
+            playlistName: "Test",
+            folderBookmarkData: nil,
+            syncMode: .addOnly,
+            transcodeFormat: nil,
+            transcodeBitrate: nil,
+            isActive: true
+        )
+        export.appliedTranscodeFormat = nil
+        #expect(export.needsResync == false)
+    }
+}

--- a/VibrdromeTests/Features/NSPCriteriaTests.swift
+++ b/VibrdromeTests/Features/NSPCriteriaTests.swift
@@ -1,0 +1,255 @@
+import Foundation
+import Testing
+@testable import Vibrdrome
+
+struct NSPCriteriaTests {
+
+    // MARK: - FilterField → NSP field name
+
+    @Test func textFieldsMappedCorrectly() {
+        let pairs: [(FilterField, String)] = [
+            (.title, "title"),
+            (.artist, "artist"),
+            (.albumTitle, "album"),
+            (.genre, "genre"),
+            (.label, "recordlabel"),
+            (.suffix, "filetype"),
+            (.contentType, "codec"),
+        ]
+        for (field, expected) in pairs {
+            let rule = FilterRule(field: field, operator: .contains, value: .text("x"))
+            let criteria = NSPCriteria(from: FilterRuleSet(combinator: .all, rules: [rule]))
+            #expect(criteria.expressions.count == 1)
+            if case .leaf(let op, let f, _) = criteria.expressions[0] {
+                #expect(f == expected, "Field \(field) should map to '\(expected)', got '\(f)'")
+                #expect(op == "contains")
+            }
+        }
+    }
+
+    @Test func numericFieldsMappedCorrectly() {
+        let pairs: [(FilterField, String)] = [
+            (.year, "year"),
+            (.duration, "duration"),
+            (.bitRate, "bitrate"),
+            (.playCount, "playcount"),
+            (.rating, "rating"),
+            (.trackNumber, "tracknumber"),
+            (.discNumber, "discnumber"),
+        ]
+        for (field, expected) in pairs {
+            let rule = FilterRule(field: field, operator: .isGreaterThan, value: .number(0))
+            let criteria = NSPCriteria(from: FilterRuleSet(combinator: .all, rules: [rule]))
+            #expect(criteria.expressions.count == 1)
+            if case .leaf(_, let f, _) = criteria.expressions[0] {
+                #expect(f == expected)
+            }
+        }
+    }
+
+    @Test func isFavoritedMapsToLoved() {
+        let rule = FilterRule(field: .isFavorited, operator: .isTrue, value: .boolean(true))
+        let criteria = NSPCriteria(from: FilterRuleSet(combinator: .all, rules: [rule]))
+        #expect(criteria.expressions.count == 1)
+        if case .leaf(let op, let field, let value) = criteria.expressions[0] {
+            #expect(field == "loved")
+            #expect(op == "is")
+            if case .bool(let b) = value { #expect(b == true) }
+        }
+    }
+
+    @Test func isDownloadedIsDropped() {
+        let rule = FilterRule(field: .isDownloaded, operator: .isTrue, value: .boolean(true))
+        let criteria = NSPCriteria(from: FilterRuleSet(combinator: .all, rules: [rule]))
+        #expect(criteria.expressions.isEmpty, "isDownloaded has no NSP mapping and should be dropped")
+    }
+
+    // MARK: - Operator mapping
+
+    @Test func textOperators() {
+        let cases: [(FilterOperator, String)] = [
+            (.contains, "contains"),
+            (.notContains, "notContains"),
+            (.equals, "is"),
+            (.notEquals, "isNot"),
+            (.startsWith, "startsWith"),
+            (.endsWith, "endsWith"),
+        ]
+        for (op, expected) in cases {
+            let rule = FilterRule(field: .title, operator: op, value: .text("test"))
+            let criteria = NSPCriteria(from: FilterRuleSet(combinator: .all, rules: [rule]))
+            if case .leaf(let nspOp, _, _) = criteria.expressions.first {
+                #expect(nspOp == expected, "Operator \(op) should map to '\(expected)', got '\(nspOp)'")
+            } else {
+                #expect(Bool(false), "Missing expression for operator \(op)")
+            }
+        }
+    }
+
+    @Test func regexOperatorIsDropped() {
+        let rule = FilterRule(field: .title, operator: .matchesRegex, value: .text(".*love.*"))
+        let criteria = NSPCriteria(from: FilterRuleSet(combinator: .all, rules: [rule]))
+        #expect(criteria.expressions.isEmpty, "matchesRegex has no NSP mapping and should be dropped")
+    }
+
+    @Test func numericEqualTo() {
+        let rule = FilterRule(field: .rating, operator: .isEqualTo, value: .number(4))
+        let criteria = NSPCriteria(from: FilterRuleSet(combinator: .all, rules: [rule]))
+        if case .leaf(let op, _, let val) = criteria.expressions.first {
+            #expect(op == "is")
+            if case .int(let n) = val { #expect(n == 4) }
+        }
+    }
+
+    @Test func numericGreaterThan() {
+        let rule = FilterRule(field: .rating, operator: .isGreaterThan, value: .number(3))
+        let criteria = NSPCriteria(from: FilterRuleSet(combinator: .all, rules: [rule]))
+        if case .leaf(let op, _, let val) = criteria.expressions.first {
+            #expect(op == "gt")
+            if case .int(let n) = val { #expect(n == 3) }
+        }
+    }
+
+    @Test func numericGreaterOrEqualEmulatedWithGtMinusOne() {
+        // ≥ n is emulated as gt(n-1)
+        let rule = FilterRule(field: .rating, operator: .isGreaterOrEqual, value: .number(3))
+        let criteria = NSPCriteria(from: FilterRuleSet(combinator: .all, rules: [rule]))
+        if case .leaf(let op, _, let val) = criteria.expressions.first {
+            #expect(op == "gt")
+            if case .int(let n) = val { #expect(n == 2) }
+        }
+    }
+
+    @Test func numericLessOrEqualEmulatedWithLtPlusOne() {
+        // ≤ n is emulated as lt(n+1)
+        let rule = FilterRule(field: .year, operator: .isLessOrEqual, value: .number(2000))
+        let criteria = NSPCriteria(from: FilterRuleSet(combinator: .all, rules: [rule]))
+        if case .leaf(let op, _, let val) = criteria.expressions.first {
+            #expect(op == "lt")
+            if case .int(let n) = val { #expect(n == 2001) }
+        }
+    }
+
+    @Test func rangeProducesInTheRange() {
+        let rule = FilterRule(field: .year, operator: .isBetween, value: .range(1980, 1989))
+        let criteria = NSPCriteria(from: FilterRuleSet(combinator: .all, rules: [rule]))
+        if case .leaf(let op, let field, let val) = criteria.expressions.first {
+            #expect(op == "inTheRange")
+            #expect(field == "year")
+            if case .range(let lo, let hi) = val {
+                if case .int(let loN) = lo { #expect(loN == 1980) }
+                if case .int(let hiN) = hi { #expect(hiN == 1989) }
+            } else {
+                #expect(Bool(false), "Expected range value")
+            }
+        }
+    }
+
+    // MARK: - Combinator
+
+    @Test func allCombinatorPreserved() {
+        let ruleSet = FilterRuleSet(combinator: .all, rules: [
+            FilterRule(field: .title, operator: .contains, value: .text("a")),
+            FilterRule(field: .artist, operator: .contains, value: .text("b")),
+        ])
+        let criteria = NSPCriteria(from: ruleSet)
+        #expect(criteria.combinator == .all)
+        #expect(criteria.expressions.count == 2)
+    }
+
+    @Test func anyCombinatorPreserved() {
+        let ruleSet = FilterRuleSet(combinator: .any, rules: [
+            FilterRule(field: .title, operator: .contains, value: .text("a")),
+            FilterRule(field: .genre, operator: .equals, value: .text("Rock")),
+        ])
+        let criteria = NSPCriteria(from: ruleSet)
+        #expect(criteria.combinator == .any)
+    }
+
+    // MARK: - Empty / effectively-empty rules skipped
+
+    @Test func emptyTextRuleIsSkipped() {
+        let rule = FilterRule(field: .title, operator: .contains, value: .text(""))
+        let criteria = NSPCriteria(from: FilterRuleSet(combinator: .all, rules: [rule]))
+        #expect(criteria.expressions.isEmpty)
+    }
+
+    @Test func mixedEmptyAndNonEmptyRules() {
+        let ruleSet = FilterRuleSet(combinator: .all, rules: [
+            FilterRule(field: .title, operator: .contains, value: .text("")),
+            FilterRule(field: .genre, operator: .equals, value: .text("Jazz")),
+        ])
+        let criteria = NSPCriteria(from: ruleSet)
+        #expect(criteria.expressions.count == 1)
+    }
+
+    // MARK: - JSON round-trip
+
+    @Test func criteriaRoundTripsJSON() throws {
+        let ruleSet = FilterRuleSet(combinator: .all, rules: [
+            FilterRule(field: .rating, operator: .isGreaterThan, value: .number(3)),
+            FilterRule(field: .isFavorited, operator: .isTrue, value: .boolean(true)),
+            FilterRule(field: .genre, operator: .contains, value: .text("Rock")),
+        ])
+        let criteria = NSPCriteria(from: ruleSet, sort: "rating", order: "desc", limit: 100)
+        let data = try JSONEncoder().encode(criteria)
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+
+        #expect(json?["sort"] as? String == "rating")
+        #expect(json?["order"] as? String == "desc")
+        #expect(json?["limit"] as? Int == 100)
+        #expect(json?["all"] != nil)
+    }
+
+    @Test func toJSONProducesNonNilDictionary() {
+        let ruleSet = FilterRuleSet(combinator: .all, rules: [
+            FilterRule(field: .artist, operator: .contains, value: .text("Beatles")),
+        ])
+        let criteria = NSPCriteria(from: ruleSet)
+        #expect(criteria.toJSON() != nil)
+    }
+
+    // MARK: - Full decode round-trip (catches NSPExpression decoder ordering bugs)
+
+    @Test func decodesNavidromeAPIResponseFormat() throws {
+        // Mirrors the JSON shape Navidrome returns from GET /api/playlist
+        let json = """
+        {
+            "all": [
+                { "contains": { "title": "love" } },
+                { "gt": { "year": 2020 } },
+                { "is": { "loved": true } }
+            ],
+            "sort": "year",
+            "order": "desc",
+            "limit": 50
+        }
+        """
+        let data = json.data(using: .utf8)!
+        let criteria = try JSONDecoder().decode(NSPCriteria.self, from: data)
+
+        #expect(criteria.combinator == .all)
+        #expect(criteria.expressions.count == 3)
+        #expect(criteria.sort == "year")
+        #expect(criteria.order == "desc")
+        #expect(criteria.limit == 50)
+
+        if case .leaf(let op, let field, let value) = criteria.expressions[0] {
+            #expect(op == "contains")
+            #expect(field == "title")
+            if case .string(let s) = value { #expect(s == "love") }
+        } else { #expect(Bool(false), "Expression 0 should be a leaf") }
+
+        if case .leaf(let op, let field, let value) = criteria.expressions[1] {
+            #expect(op == "gt")
+            #expect(field == "year")
+            if case .int(let n) = value { #expect(n == 2020) }
+        } else { #expect(Bool(false), "Expression 1 should be a leaf") }
+
+        if case .leaf(let op, let field, let value) = criteria.expressions[2] {
+            #expect(op == "is")
+            #expect(field == "loved")
+            if case .bool(let b) = value { #expect(b == true) }
+        } else { #expect(Bool(false), "Expression 2 should be a leaf") }
+    }
+}


### PR DESCRIPTION
> **Depends on #64 — please merge that first.**

## Summary

- Adds a macOS-only feature to export playlists to a user-selected folder (security-scoped bookmarks), keep them synced as the server playlist changes, and optionally transcode via ffmpeg
- Per-song failure tracking surfaced in a popover with per-title list and retry button
- iOS build is unaffected — all new code is `#if os(macOS)` guarded

## What's included

**New files (macOS only):**
- `Vibrdrome/Core/Export/PlaylistExportManager.swift` — core sync/download/transcode engine; folder picker, bookmark resolution, diff-based sync (add-only or add+remove), concurrent downloads (max 3), ffmpeg transcoding with tag and cover art embedding from `CachedSong` models and server-fetched JPEG
- `Vibrdrome/Core/Persistence/Models/ExportedPlaylist.swift` — SwiftData model (shared target, only active on macOS); tracks sync state, transcode settings, `knownSongPaths`, and per-song failure lists
- `Vibrdrome/Features/Export/PlaylistExportView.swift` — export manager screen with status indicators and sync controls
- `Vibrdrome/Features/Export/PlaylistExportConfigView.swift` — per-playlist config sheet (folder, sync mode, transcode format/bitrate)
- `Vibrdrome/Features/Settings/PlaylistExportSettingsView.swift` — global defaults (default folder, sync mode, ffmpeg path + test button)
- `VibrdromeTests/Core/PlaylistExportTests.swift` — unit tests for pure logic (exportPath sanitization, finalSuffix, sync mode round-trip, needsResync)

**Modified files:**
- `PersistenceController.swift` — registers `ExportedPlaylist` in schema
- `UserDefaultsKeys.swift` — export default keys
- `PlaylistDetailView.swift` — "Export Playlist…" toolbar menu entry
- `SidebarContentView.swift` — Playlist Export sidebar item
- `MacContentView.swift` — auto-sync on app foreground
- `SettingsView.swift` — link to PlaylistExportSettingsView
- `Vibrdrome.entitlements` — `com.apple.security.files.user-selected.read-write`

## Key design notes

- **Separate from DownloadManager** — writes to user-chosen security-scoped bookmark URLs, not the sandbox Documents folder; no `DownloadedSong` records
- **Transcode change detection** — `appliedTranscodeFormat` tracks the format used in the last successful sync; changing format forces a full re-download
- **Same-format transcode fix** — ffmpeg always writes to a UUID temp path so input path ≠ output path (fixes mp3→mp3 and similar cases)
- **Tag + cover art embedding** — second ffmpeg pass writes tags from `CachedSong` and JPEG art fetched from `/rest/getCoverArt`; two-input approach (`-i audio -i art.jpg`) when art is available

## Test plan

- [x] Export a playlist → files appear in chosen folder as `PlaylistName/Artist - Title.suffix`
- [x] Sync with transcode set to mp3 on an mp3 source — file is re-encoded without error
- [x] Change transcode format → config view shows "will re-download" note → sync re-downloads all
- [x] Remove a song from playlist on server → sync (add+remove mode) → file removed from folder
- [x] Introduce a network error → failed song appears in popover with title and Retry button
- [x] Relaunch app → auto-sync fires; disable toggle → no auto-sync
- [x] iOS build compiles cleanly with no export UI visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)