### PR TITLE
feat(api): support Navidrome 0.62 OpenSubsonic extensions

### DIFF
--- a/Vibrdrome/App/AppState.swift
+++ b/Vibrdrome/App/AppState.swift
@@ -62,9 +62,11 @@ final class AppState {
     /// Active side panel in the macOS main window (Queue / Lyrics / Artist Info / Album Filters).
     /// Mutually exclusive: setting one closes the others.
     enum SidePanel: String, Equatable {
-        case queue, lyrics, artistInfo, albumFilters, artistFilters, songFilters
+        case queue, lyrics, artistInfo, albumFilters, artistFilters, songFilters, similarTracks
     }
     var activeSidePanel: SidePanel?
+    /// Seed song for the similarTracks panel — set before activating the panel.
+    var similarTracksSeed: Song?
 
     /// Context currently shown in the popped-out filter window.
     var activeFilterWindowContext: FilterContext?

--- a/Vibrdrome/Core/Audio/AudioEngine+Observers.swift
+++ b/Vibrdrome/Core/Audio/AudioEngine+Observers.swift
@@ -384,5 +384,23 @@ extension AudioEngine {
             Task { await ListenBrainzClient.shared.submitNowPlaying(song: song) }
             Task { await LastFmClient.shared.updateNowPlaying(song: song) }
         }
+        reportPlaybackState("starting", songId: songId, positionMs: 0)
+    }
+
+    /// Fire-and-forget OpenSubsonic playbackReport state update.
+    func reportPlaybackState(_ state: String, songId: String? = nil, positionMs: Int? = nil) {
+        guard UserDefaults.standard.bool(forKey: UserDefaultsKeys.playbackReportEnabled) else { return }
+        let id = songId ?? currentSong?.id
+        guard let id else { return }
+        let posMs = positionMs ?? Int(currentTime * 1000)
+        Task {
+            do {
+                try await AppState.shared.subsonicClient.reportPlayback(
+                    mediaId: id, positionMs: posMs, state: state
+                )
+            } catch {
+                observerLog.debug("reportPlayback(\(state)) failed: \(error)")
+            }
+        }
     }
 }

--- a/Vibrdrome/Core/Audio/AudioEngine+Playback.swift
+++ b/Vibrdrome/Core/Audio/AudioEngine+Playback.swift
@@ -224,6 +224,7 @@ extension AudioEngine {
         isPlaying = false
         disarmStallRecovery(reason: "userPause")   // a user/interruption pause is not a stall
         NowPlayingManager.shared.updatePlaybackState(isPlaying: false, elapsed: currentTime)
+        reportPlaybackState("paused")
     }
 
     func resume() {
@@ -274,6 +275,7 @@ extension AudioEngine {
         }
         isPlaying = true
         NowPlayingManager.shared.updatePlaybackState(isPlaying: true, elapsed: currentTime)
+        reportPlaybackState("playing")
     }
 
     private func resumeGaplessMode() {
@@ -525,7 +527,10 @@ extension AudioEngine {
     func handleTrackEnd() {
         SleepTimer.shared.trackDidEnd()
         // Record the outgoing song (it reached its end)
-        if let current = currentSong { recordSongAsPlayed(current) }
+        if let current = currentSong {
+            recordSongAsPlayed(current)
+            reportPlaybackState("stopped", songId: current.id)
+        }
         if !isPlaying { return }
 
         switch repeatMode {
@@ -699,7 +704,13 @@ extension AudioEngine {
             defer { self.isAutoSuggesting = false }
             do {
                 let client = AppState.shared.subsonicClient
-                let similar = try await client.getSimilarSongs(id: lastSong.id, count: 10)
+                let similar: [Song]
+                if client.supportsSonicSimilarity {
+                    let matches = try await client.getSonicSimilarTracks(id: lastSong.id, count: 10)
+                    similar = matches.map(\.entry)
+                } else {
+                    similar = try await client.getSimilarSongs(id: lastSong.id, count: 10)
+                }
                 let existingIds = Set(queue.map(\.id))
                 let newSongs = similar.filter { !existingIds.contains($0.id) }
                 guard !newSongs.isEmpty else {

--- a/Vibrdrome/Core/Audio/AudioEngine+Radio.swift
+++ b/Vibrdrome/Core/Audio/AudioEngine+Radio.swift
@@ -93,9 +93,8 @@ extension AudioEngine {
     }
 
     /// Play a mix of songs similar to the given track, independent of the
-    /// artist-radio path. Uses `getSimilarSongs` directly so the result is a
-    /// song-level similarity queue, matching what "Instant Mix" / "Radio Mix"
-    /// means in Apple Music / Spotify.
+    /// artist-radio path. Prefers audio-based sonicSimilarity when the server
+    /// supports it, falling back to metadata-based getSimilarSongs2.
     func startSongSimilarityMix(_ song: Song) {
         stopRadioMode()
         isRadioMode = true
@@ -104,7 +103,14 @@ extension AudioEngine {
         setRadioRefillTask(Task { [weak self] in
             guard let self else { return }
             let client = AppState.shared.subsonicClient
-            var songs = (try? await client.getSimilarSongs(id: song.id, count: 30)) ?? []
+            var songs: [Song]
+            if client.supportsSonicSimilarity {
+                let matches = (try? await client.getSonicSimilarTracks(id: song.id, count: 30)) ?? []
+                songs = matches.map(\.entry)
+                radioLog.info("SongMix: sonicSimilarity returned \(songs.count) tracks for \(song.id)")
+            } else {
+                songs = (try? await client.getSimilarSongs(id: song.id, count: 30)) ?? []
+            }
             if songs.isEmpty {
                 songs = (try? await client.getRandomSongs(size: 20)) ?? []
             }
@@ -144,9 +150,12 @@ extension AudioEngine {
 
             var newSongs: [Song] = []
             if let currentId = self.currentSong?.id {
-                newSongs = (try? await client.getSimilarSongs(
-                    id: currentId, count: 30
-                )) ?? []
+                if client.supportsSonicSimilarity {
+                    let matches = (try? await client.getSonicSimilarTracks(id: currentId, count: 30)) ?? []
+                    newSongs = matches.map(\.entry)
+                } else {
+                    newSongs = (try? await client.getSimilarSongs(id: currentId, count: 30)) ?? []
+                }
             }
 
             if newSongs.isEmpty {

--- a/Vibrdrome/Core/Constants/UserDefaultsKeys.swift
+++ b/Vibrdrome/Core/Constants/UserDefaultsKeys.swift
@@ -40,6 +40,7 @@ enum UserDefaultsKeys {
     static func lyricsOffset(songId: String) -> String { "lyricsOffset.\(songId)" }
     static let replayGainMode = "replayGainMode"
     static let scrobblingEnabled = "scrobblingEnabled"
+    static let playbackReportEnabled = "playbackReportEnabled"
     static let preloadSongs = "preloadSongs"
     static let keepSongsInCacheAfterPlayback = "keepSongsInCacheAfterPlayback"
     static let autoSuggestEnabled = "autoSuggestEnabled"

--- a/Vibrdrome/Core/Models/FilterRule.swift
+++ b/Vibrdrome/Core/Models/FilterRule.swift
@@ -37,6 +37,8 @@ enum FilterField: String, CaseIterable, Codable, Sendable {
     case bitDepth
     case sampleRate
     case bpm
+    case replayGainTrackGain  // dB
+    case replayGainAlbumGain  // dB
     case playCount
     case rating         // 1-5 stars (0 = unrated)
     case averageRating  // average across all users
@@ -67,6 +69,7 @@ enum FilterField: String, CaseIterable, Codable, Sendable {
     case hasCoverArt
     case isCompilation
     case isMissing
+    case isPresent
     case isDownloaded
 
     // Playlist membership (value = playlist ID string)
@@ -105,6 +108,8 @@ enum FilterField: String, CaseIterable, Codable, Sendable {
         case .bitDepth:        "Bit Depth"
         case .sampleRate:      "Sample Rate"
         case .bpm:             "BPM"
+        case .replayGainTrackGain: "ReplayGain Track (dB)"
+        case .replayGainAlbumGain: "ReplayGain Album (dB)"
         case .playCount:       "Play Count"
         case .averageRating:   "Avg Rating"
         case .rating:          "Rating"
@@ -131,6 +136,7 @@ enum FilterField: String, CaseIterable, Codable, Sendable {
         case .hasCoverArt:     "Has Cover Art"
         case .isCompilation:   "Compilation"
         case .isMissing:       "File Missing"
+        case .isPresent:       "File Present"
         case .isDownloaded:    "Is Downloaded"
         case .inPlaylist:      "In Playlist"
         case .notInPlaylist:   "Not In Playlist"
@@ -146,6 +152,7 @@ enum FilterField: String, CaseIterable, Codable, Sendable {
              .mbzReleaseTrackId, .mbzReleaseGroupId:
             return .text
         case .year, .duration, .size, .channels, .bitRate, .bitDepth, .sampleRate, .bpm,
+             .replayGainTrackGain, .replayGainAlbumGain,
              .playCount, .rating, .averageRating, .albumRating, .albumPlayCount,
              .artistRating, .artistPlayCount, .trackNumber, .discNumber:
             return .numeric
@@ -154,7 +161,7 @@ enum FilterField: String, CaseIterable, Codable, Sendable {
              .artistLastPlayed, .artistDateLoved, .artistDateRated:
             return .days
         case .isFavorited, .albumFavorited, .artistFavorited,
-             .hasCoverArt, .isCompilation, .isMissing, .isDownloaded:
+             .hasCoverArt, .isCompilation, .isMissing, .isPresent, .isDownloaded:
             return .boolean
         case .inPlaylist, .notInPlaylist:
             return .playlist
@@ -437,6 +444,7 @@ extension FilterField {
         .title, .artist, .albumTitle, .genre, .label, .suffix, .contentType, .comment,
         // Numeric
         .year, .duration, .size, .channels, .bitRate, .bitDepth, .sampleRate, .bpm,
+        .replayGainTrackGain, .replayGainAlbumGain,
         .playCount, .rating, .averageRating, .albumRating, .albumPlayCount,
         .artistRating, .artistPlayCount, .trackNumber, .discNumber,
         // Date-relative
@@ -445,7 +453,7 @@ extension FilterField {
         .artistLastPlayed, .artistDateLoved, .artistDateRated,
         // Boolean
         .isFavorited, .albumFavorited, .artistFavorited,
-        .hasCoverArt, .isCompilation, .isMissing, .isDownloaded,
+        .hasCoverArt, .isCompilation, .isMissing, .isPresent, .isDownloaded,
     ]
     static let albumFields: [FilterField] = [
         .albumTitle, .artist, .genre, .label,
@@ -468,6 +476,7 @@ extension FilterField {
         .mbzReleaseTrackId, .mbzReleaseGroupId,
         // Numeric
         .year, .duration, .size, .channels, .bitRate, .bitDepth, .sampleRate, .bpm,
+        .replayGainTrackGain, .replayGainAlbumGain,
         .playCount, .rating, .averageRating, .albumRating, .albumPlayCount,
         .artistRating, .artistPlayCount, .trackNumber, .discNumber,
         // Date-relative
@@ -476,7 +485,7 @@ extension FilterField {
         .artistLastPlayed, .artistDateLoved, .artistDateRated,
         // Boolean
         .isFavorited, .albumFavorited, .artistFavorited,
-        .hasCoverArt, .isCompilation, .isMissing,
+        .hasCoverArt, .isCompilation, .isMissing, .isPresent,
         // Playlist membership
         .inPlaylist, .notInPlaylist,
     ]

--- a/Vibrdrome/Core/Models/NSPCriteria.swift
+++ b/Vibrdrome/Core/Models/NSPCriteria.swift
@@ -336,6 +336,8 @@ private extension FilterField {
         case .bitDepth:           return "bitdepth"
         case .sampleRate:         return "samplerate"
         case .bpm:                return "bpm"
+        case .replayGainTrackGain: return "replaygain_track_gain"
+        case .replayGainAlbumGain: return "replaygain_album_gain"
         case .playCount:          return "playcount"
         case .rating:             return "rating"
         case .averageRating:      return "averagerating"
@@ -364,6 +366,7 @@ private extension FilterField {
         case .hasCoverArt:        return "hascoverart"
         case .isCompilation:      return "compilation"
         case .isMissing:          return "missing"
+        case .isPresent:          return "present"
         // ND tag fields
         case .releaseType:        return "releasetype"
         case .releaseCountry:     return "releasecountry"

--- a/Vibrdrome/Core/Networking/SubsonicClient.swift
+++ b/Vibrdrome/Core/Networking/SubsonicClient.swift
@@ -361,7 +361,7 @@ final class SubsonicClient {
             isConnected = body.status == "ok"
             if let sv = body.serverVersion { serverVersion = sv }
             if isConnected && (body.openSubsonic == true) {
-                Task { await probeExtensions() }
+                await probeExtensions()
             }
             return isConnected
         } catch {

--- a/Vibrdrome/Core/Networking/SubsonicClient.swift
+++ b/Vibrdrome/Core/Networking/SubsonicClient.swift
@@ -22,6 +22,8 @@ final class SubsonicClient {
     var isConnected: Bool = false
     /// Navidrome serverVersion string from the last successful ping (e.g. "0.52.5").
     private(set) var serverVersion: String?
+    /// True when the server advertises the `sonicSimilarity` OpenSubsonic extension.
+    private(set) var supportsSonicSimilarity: Bool = false
 
     /// WebP cover art requires Navidrome ≥ 0.49.0. Older servers and non-Navidrome
     /// Subsonic implementations don't support the `format` parameter on getCoverArt.
@@ -358,11 +360,21 @@ final class SubsonicClient {
             let body = try await request(.ping)
             isConnected = body.status == "ok"
             if let sv = body.serverVersion { serverVersion = sv }
+            if isConnected && (body.openSubsonic == true) {
+                Task { await probeExtensions() }
+            }
             return isConnected
         } catch {
             isConnected = false
             throw error
         }
+    }
+
+    private func probeExtensions() async {
+        guard let body = try? await request(.getOpenSubsonicExtensions) else { return }
+        let extensions = body.openSubsonicExtensions ?? []
+        supportsSonicSimilarity = extensions.contains { $0.name == "sonicSimilarity" }
+        networkLog.info("OpenSubsonic extensions probed — sonicSimilarity: \(self.supportsSonicSimilarity)")
     }
 
     func getArtists(musicFolderId: String? = nil) async throws -> [ArtistIndex] {
@@ -449,6 +461,24 @@ final class SubsonicClient {
 
     func scrobble(id: String, submission: Bool = true) async throws {
         try await performAction(.scrobble(id: id, submission: submission))
+    }
+
+    func reportPlayback(mediaId: String, positionMs: Int, state: String,
+                        playbackRate: Double = 1.0, ignoreScrobble: Bool = false) async throws {
+        try await performAction(.reportPlayback(
+            mediaId: mediaId, mediaType: "song", positionMs: positionMs,
+            state: state, playbackRate: playbackRate, ignoreScrobble: ignoreScrobble
+        ))
+    }
+
+    func getSonicSimilarTracks(id: String, count: Int = 10) async throws -> [SonicMatchEntry] {
+        let body = try await request(.getSonicSimilarTracks(id: id, count: count))
+        return body.sonicMatch ?? []
+    }
+
+    func findSonicPath(startSongId: String, endSongId: String, count: Int = 25) async throws -> [SonicMatchEntry] {
+        let body = try await request(.findSonicPath(startSongId: startSongId, endSongId: endSongId, count: count))
+        return body.sonicMatch ?? []
     }
 
     func getPlaylists() async throws -> [Playlist] {

--- a/Vibrdrome/Core/Networking/SubsonicEndpoints.swift
+++ b/Vibrdrome/Core/Networking/SubsonicEndpoints.swift
@@ -8,6 +8,7 @@ enum AlbumListType: String, Sendable {
 
 enum SubsonicEndpoint: Sendable {
     case ping
+    case getOpenSubsonicExtensions
     case getArtists(musicFolderId: String? = nil)
     case getArtist(id: String)
     case getAlbum(id: String)
@@ -55,10 +56,15 @@ enum SubsonicEndpoint: Sendable {
     case getMusicDirectory(id: String)
     case jukeboxControl(action: String, index: Int? = nil, offset: Int? = nil,
                         ids: [String]? = nil, gain: Float? = nil)
+    case reportPlayback(mediaId: String, mediaType: String, positionMs: Int,
+                        state: String, playbackRate: Double = 1.0, ignoreScrobble: Bool = false)
+    case getSonicSimilarTracks(id: String, count: Int = 10)
+    case findSonicPath(startSongId: String, endSongId: String, count: Int = 25)
 
     var path: String {
         switch self {
         case .ping: "/rest/ping"
+        case .getOpenSubsonicExtensions: "/rest/getOpenSubsonicExtensions"
         case .getArtists: "/rest/getArtists"
         case .getArtist: "/rest/getArtist"
         case .getAlbum: "/rest/getAlbum"
@@ -97,12 +103,15 @@ enum SubsonicEndpoint: Sendable {
         case .getIndexes: "/rest/getIndexes"
         case .getMusicDirectory: "/rest/getMusicDirectory"
         case .jukeboxControl: "/rest/jukeboxControl"
+        case .reportPlayback: "/rest/reportPlayback"
+        case .getSonicSimilarTracks: "/rest/getSonicSimilarTracks"
+        case .findSonicPath: "/rest/findSonicPath"
         }
     }
 
     var queryItems: [URLQueryItem] {
         switch self {
-        case .ping, .getGenres, .getPlaylists,
+        case .ping, .getOpenSubsonicExtensions, .getGenres, .getPlaylists,
              .getInternetRadioStations, .getPlayQueue, .getBookmarks,
              .getMusicFolders:
             return []
@@ -305,6 +314,30 @@ enum SubsonicEndpoint: Sendable {
             }
             if let gain { items.append(URLQueryItem(name: "gain", value: "\(gain)")) }
             return items
+
+        case .reportPlayback(let mediaId, let mediaType, let positionMs, let state,
+                             let playbackRate, let ignoreScrobble):
+            return [
+                URLQueryItem(name: "mediaId", value: mediaId),
+                URLQueryItem(name: "mediaType", value: mediaType),
+                URLQueryItem(name: "positionMs", value: "\(positionMs)"),
+                URLQueryItem(name: "state", value: state),
+                URLQueryItem(name: "playbackRate", value: "\(playbackRate)"),
+                URLQueryItem(name: "ignoreScrobble", value: ignoreScrobble ? "true" : "false"),
+            ]
+
+        case .getSonicSimilarTracks(let id, let count):
+            return [
+                URLQueryItem(name: "id", value: id),
+                URLQueryItem(name: "count", value: "\(count)"),
+            ]
+
+        case .findSonicPath(let startSongId, let endSongId, let count):
+            return [
+                URLQueryItem(name: "startSongId", value: startSongId),
+                URLQueryItem(name: "endSongId", value: endSongId),
+                URLQueryItem(name: "count", value: "\(count)"),
+            ]
         }
     }
 }

--- a/Vibrdrome/Core/Networking/SubsonicModels.swift
+++ b/Vibrdrome/Core/Networking/SubsonicModels.swift
@@ -43,6 +43,8 @@ struct SubsonicResponseBody: Decodable {
     let indexes: IndexesResponse?
     let jukeboxStatus: JukeboxStatus?
     let jukeboxPlaylist: JukeboxPlaylist?
+    let sonicMatch: [SonicMatchEntry]?
+    let openSubsonicExtensions: [OpenSubsonicExtension]?
 
     enum CodingKeys: String, CodingKey {
         case status, version, type, serverVersion, openSubsonic, error
@@ -52,6 +54,7 @@ struct SubsonicResponseBody: Decodable {
         case artistInfo2, albumInfo, similarSongs2, topSongs
         case musicFolders, directory, indexes
         case jukeboxStatus, jukeboxPlaylist
+        case sonicMatch, openSubsonicExtensions
     }
 
     init(from decoder: Decoder) throws {
@@ -86,6 +89,8 @@ struct SubsonicResponseBody: Decodable {
         indexes = try container.decodeIfPresent(IndexesResponse.self, forKey: .indexes)
         jukeboxStatus = try container.decodeIfPresent(JukeboxStatus.self, forKey: .jukeboxStatus)
         jukeboxPlaylist = try container.decodeIfPresent(JukeboxPlaylist.self, forKey: .jukeboxPlaylist)
+        sonicMatch = try container.decodeIfPresent([SonicMatchEntry].self, forKey: .sonicMatch)
+        openSubsonicExtensions = try container.decodeIfPresent([OpenSubsonicExtension].self, forKey: .openSubsonicExtensions)
     }
 }
 
@@ -269,6 +274,20 @@ struct SimilarSongs2Response: Decodable, Sendable {
 
 struct TopSongsResponse: Decodable, Sendable {
     let song: [Song]?
+}
+
+struct OpenSubsonicExtension: Decodable, Sendable {
+    let name: String
+    let versions: [Int]
+}
+
+struct SonicMatchEntry: Decodable, Sendable {
+    let entry: Song
+    let similarity: Double
+}
+
+struct SonicMatchResponse: Decodable, Sendable {
+    let sonicMatch: [SonicMatchEntry]?
 }
 
 // MARK: - Song Model

--- a/Vibrdrome/Features/Library/AlbumDetailView.swift
+++ b/Vibrdrome/Features/Library/AlbumDetailView.swift
@@ -835,15 +835,22 @@ struct AlbumDetailView: View {
             if let info = try? await appState.subsonicClient.getAlbumInfo(id: albumId) {
                 albumNotes = info.notes
             }
-            // Load similar albums from first song
+            // Load similar albums from first song — prefer sonicSimilarity when available
             if let firstSong = album?.song?.first {
-                let similar = try await appState.subsonicClient.getSimilarSongs(id: firstSong.id, count: 20)
+                let client = appState.subsonicClient
+                let similarSongs: [Song]
+                if client.supportsSonicSimilarity {
+                    let matches = (try? await client.getSonicSimilarTracks(id: firstSong.id, count: 20)) ?? []
+                    similarSongs = matches.map(\.entry)
+                } else {
+                    similarSongs = (try? await client.getSimilarSongs(id: firstSong.id, count: 20)) ?? []
+                }
                 var albums: [Album] = []
                 var seen = Set<String>()
-                for song in similar {
+                for song in similarSongs {
                     if let aid = song.albumId, !seen.contains(aid), aid != albumId {
                         seen.insert(aid)
-                        if let a = try? await appState.subsonicClient.getAlbum(id: aid) {
+                        if let a = try? await client.getAlbum(id: aid) {
                             albums.append(a)
                             if albums.count >= 6 { break }
                         }

--- a/Vibrdrome/Features/Library/SidebarContentView.swift
+++ b/Vibrdrome/Features/Library/SidebarContentView.swift
@@ -376,6 +376,8 @@ struct SidebarContentView: View {
             LibraryFilterSidebarView(context: .artist)
         case .songFilters:
             LibraryFilterSidebarView(context: .song)
+        case .similarTracks:
+            SimilarTracksPanelView()
         }
     }
     #endif

--- a/Vibrdrome/Features/Library/SidebarContentView.swift
+++ b/Vibrdrome/Features/Library/SidebarContentView.swift
@@ -173,10 +173,13 @@ struct SidebarContentView: View {
                         switch route {
                         case .album(let id):
                             AlbumDetailView(albumId: id)
+                                .modifier(SidePanelInspector(sidePanelWidth: sidePanelWidth) { sidePanelView(for: $0) })
                         case .artist(let id):
                             ArtistDetailView(artistId: id)
+                                .modifier(SidePanelInspector(sidePanelWidth: sidePanelWidth) { sidePanelView(for: $0) })
                         case .song(let id):
                             SongDetailView(songId: id)
+                                .modifier(SidePanelInspector(sidePanelWidth: sidePanelWidth) { sidePanelView(for: $0) })
                         case .genre(let name):
                             AlbumsView(listType: .alphabeticalByName,
                                        title: name.cleanedGenreDisplay, initialGenreFilter: name)

--- a/Vibrdrome/Features/Player/SidePanels.swift
+++ b/Vibrdrome/Features/Player/SidePanels.swift
@@ -454,4 +454,170 @@ struct ArtistInfoPanelView: View {
             .trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }
+
+// MARK: - Similar Tracks Panel
+
+struct SimilarTracksPanelView: View {
+    @Environment(AppState.self) private var appState
+
+    private struct TrackEntry: Identifiable {
+        let song: Song
+        let similarity: Double?
+        var id: String { song.id }
+    }
+
+    @State private var entries: [TrackEntry] = []
+    @State private var isLoading = false
+    @State private var error: String?
+    @State private var loadedSongId: String?
+
+    private var seed: Song? { appState.similarTracksSeed }
+
+    var body: some View {
+        SidePanelContainer(title: "Similar Tracks", onClose: {
+            appState.activeSidePanel = nil
+        }) {
+            Group {
+                if isLoading {
+                    ProgressView("Loading...")
+                        .padding(40)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else if let error {
+                    ContentUnavailableView {
+                        Label("Error", systemImage: "exclamationmark.triangle")
+                    } description: {
+                        Text(error)
+                    }
+                    .padding(20)
+                } else if entries.isEmpty {
+                    ContentUnavailableView {
+                        Label("No Similar Tracks", systemImage: "waveform.path")
+                    } description: {
+                        Text("No similar tracks found for this song")
+                    }
+                    .padding(20)
+                } else {
+                    trackList
+                }
+            }
+        }
+        .task(id: seed?.id) {
+            await loadTracks()
+        }
+    }
+
+    private var trackList: some View {
+        List {
+            if let seed {
+                Section {
+                    HStack(spacing: 10) {
+                        AlbumArtView(coverArtId: seed.coverArt, size: 36, cornerRadius: 6)
+                        VStack(alignment: .leading, spacing: 1) {
+                            Text("Similar to")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                            Text(seed.title)
+                                .font(.caption)
+                                .fontWeight(.semibold)
+                                .lineLimit(1)
+                            Text(seed.displayArtist ?? "")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                        }
+                    }
+                    .padding(.vertical, 2)
+                }
+            }
+
+            Section("\(entries.count) tracks") {
+                ForEach(entries) { entry in
+                    similarRow(entry)
+                }
+            }
+        }
+        .listStyle(.inset)
+    }
+
+    private func similarRow(_ entry: TrackEntry) -> some View {
+        HStack(spacing: 10) {
+            AlbumArtView(coverArtId: entry.song.coverArt, size: 40, cornerRadius: 6)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(entry.song.title).font(.subheadline).lineLimit(1)
+                HStack(spacing: 6) {
+                    Text(entry.song.displayArtist ?? "")
+                        .font(.caption).foregroundStyle(.secondary).lineLimit(1)
+                    if let sim = entry.similarity {
+                        Text("·").font(.caption).foregroundStyle(.tertiary)
+                        Text("\(Int(sim * 100))%")
+                            .font(.caption).foregroundStyle(.tertiary).monospacedDigit()
+                    }
+                }
+            }
+            Spacer()
+            if let duration = entry.song.duration {
+                Text(formatDuration(duration))
+                    .font(.caption).foregroundStyle(.tertiary).monospacedDigit()
+            }
+        }
+        .contentShape(Rectangle())
+        .onTapGesture { AudioEngine.shared.addToQueueNext(entry.song) }
+        .contextMenu { similarRowMenu(entry) }
+    }
+
+    @ViewBuilder
+    private func similarRowMenu(_ entry: TrackEntry) -> some View {
+        Button { AudioEngine.shared.play(song: entry.song) } label: {
+            Label("Play", systemImage: "play.fill")
+        }
+        Button { AudioEngine.shared.addToQueueNext(entry.song) } label: {
+            Label("Play Next", systemImage: "text.insert")
+        }
+        Button { AudioEngine.shared.addToQueue(entry.song) } label: {
+            Label("Add to Queue", systemImage: "text.append")
+        }
+        Button {
+            AudioEngine.shared.startSongSimilarityMix(entry.song)
+            appState.activeSidePanel = nil
+        } label: {
+            Label("Find Sonic Mix", systemImage: "waveform.badge.magnifyingglass")
+        }
+        Divider()
+        Button {
+            if let albumId = entry.song.albumId { appState.pendingNavigation = .album(id: albumId) }
+        } label: {
+            Label("Go to Album", systemImage: "square.stack")
+        }
+        .disabled(entry.song.albumId == nil)
+        Button {
+            if let artistId = entry.song.artistId { appState.pendingNavigation = .artist(id: artistId) }
+        } label: {
+            Label("Go to Artist", systemImage: "music.mic")
+        }
+        .disabled(entry.song.artistId == nil)
+    }
+
+    private func loadTracks() async {
+        guard let song = seed else { return }
+        if loadedSongId == song.id { return }
+        isLoading = true
+        error = nil
+        entries = []
+        defer { isLoading = false }
+
+        let client = appState.subsonicClient
+        do {
+            if client.supportsSonicSimilarity {
+                let matches = try await client.getSonicSimilarTracks(id: song.id, count: 50)
+                entries = matches.map { TrackEntry(song: $0.entry, similarity: $0.similarity) }
+            } else {
+                let songs = try await client.getSimilarSongs(id: song.id, count: 50)
+                entries = songs.map { TrackEntry(song: $0, similarity: nil) }
+            }
+            loadedSongId = song.id
+        } catch {
+            self.error = ErrorPresenter.userMessage(for: error)
+        }
+    }
+}
 #endif

--- a/Vibrdrome/Features/Playlists/SmartPlaylistView.swift
+++ b/Vibrdrome/Features/Playlists/SmartPlaylistView.swift
@@ -15,6 +15,10 @@ struct SmartPlaylistView: View {
     @State private var selectedGenre: Genre?
     @State private var searchTask: Task<Void, Never>?
 
+    // Sonic Path state
+    @State private var sonicPathStartSong: Song?
+    @State private var sonicPathEndSong: Song?
+
     enum GeneratorType: String, CaseIterable, Identifiable {
         case artist = "Artist Mix"
         case genre = "Genre Mix"
@@ -22,6 +26,7 @@ struct SmartPlaylistView: View {
         case random = "Random Mix"
         case bsides = "B-Sides & Obscure"
         case curated = "Curated Weekly"
+        case sonicPath = "Sonic Path"
 
         var id: String { rawValue }
         var icon: String {
@@ -32,6 +37,7 @@ struct SmartPlaylistView: View {
             case .random: "dice.fill"
             case .bsides: "record.circle"
             case .curated: "sparkles"
+            case .sonicPath: "point.topright.arrow.triangle.backward.to.point.bottomleft.filled"
             }
         }
         var color: Color {
@@ -42,6 +48,7 @@ struct SmartPlaylistView: View {
             case .random: .indigo
             case .bsides: .teal
             case .curated: .pink
+            case .sonicPath: .green
             }
         }
         var description: String {
@@ -52,7 +59,14 @@ struct SmartPlaylistView: View {
             case .random: "A random mix of your library"
             case .bsides: "Deep cuts and hidden gems"
             case .curated: "Mix of favorites, random, and recent"
+            case .sonicPath: "A journey between two songs"
             }
+        }
+    }
+
+    private var visibleGeneratorTypes: [GeneratorType] {
+        GeneratorType.allCases.filter { type in
+            type != .sonicPath || appState.subsonicClient.supportsSonicSimilarity
         }
     }
 
@@ -65,7 +79,7 @@ struct SmartPlaylistView: View {
                         GridItem(.flexible(), spacing: 12),
                         GridItem(.flexible(), spacing: 12)
                     ], spacing: 12) {
-                        ForEach(GeneratorType.allCases) { type in
+                        ForEach(visibleGeneratorTypes) { type in
                             generatorCard(type)
                         }
                     }
@@ -166,6 +180,8 @@ struct SmartPlaylistView: View {
             generateButton("Generate Curated Weekly") {
                 await generateCurated()
             }
+        case .sonicPath:
+            sonicPathSelectionView
         }
     }
 
@@ -297,6 +313,20 @@ struct SmartPlaylistView: View {
                     .padding(.horizontal, 16)
             }
         }
+    }
+
+    // Sonic Path selection view
+    private var sonicPathSelectionView: some View {
+        VStack(spacing: 16) {
+            SonicPathSongPicker(label: "Start Song", selected: $sonicPathStartSong)
+            SonicPathSongPicker(label: "End Song", selected: $sonicPathEndSong)
+            if sonicPathStartSong != nil && sonicPathEndSong != nil {
+                generateButton("Generate Sonic Path") {
+                    await generateSonicPath()
+                }
+            }
+        }
+        .padding(.horizontal, 16)
     }
 
     // Generate button helper
@@ -446,6 +476,28 @@ struct SmartPlaylistView: View {
         }
     }
 
+    private func generateSonicPath() async {
+        guard let startSong = sonicPathStartSong, let endSong = sonicPathEndSong else { return }
+        isGenerating = true
+        error = nil
+        defer { isGenerating = false }
+        do {
+            let matches = try await appState.subsonicClient.findSonicPath(
+                startSongId: startSong.id, endSongId: endSong.id, count: 25
+            )
+            guard !matches.isEmpty else {
+                error = "No sonic path found between those songs"
+                return
+            }
+            let ids = matches.map(\.entry.id)
+            let name = "Sonic Path: \(startSong.title.prefix(20)) → \(endSong.title.prefix(20))"
+            try await appState.subsonicClient.createPlaylist(name: String(name.prefix(60)), songIds: ids)
+            dismiss()
+        } catch {
+            self.error = ErrorPresenter.userMessage(for: error)
+        }
+    }
+
     private func generateCurated() async {
         isGenerating = true
         error = nil
@@ -492,6 +544,84 @@ struct SmartPlaylistView: View {
             dismiss()
         } catch {
             self.error = ErrorPresenter.userMessage(for: error)
+        }
+    }
+}
+
+// MARK: - Sonic Path Song Picker
+
+private struct SonicPathSongPicker: View {
+    let label: String
+    @Binding var selected: Song?
+
+    @Environment(AppState.self) private var appState
+    @State private var query = ""
+    @State private var results: [Song] = []
+    @State private var searchTask: Task<Void, Never>?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            if let song = selected {
+                HStack(spacing: 10) {
+                    AlbumArtView(coverArtId: song.coverArt, size: 36, cornerRadius: 6)
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text(label).font(.caption).foregroundStyle(.secondary)
+                        Text(song.title).font(.body).fontWeight(.medium)
+                        Text(song.displayArtist ?? "").font(.caption).foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                    Button { selected = nil; query = "" } label: {
+                        Image(systemName: "xmark.circle.fill").foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                }
+                .padding(10)
+                .background(Color.secondary.opacity(0.12), in: RoundedRectangle(cornerRadius: 10))
+            } else {
+                TextField("\(label)...", text: $query)
+                    .textFieldStyle(.roundedBorder)
+                    .autocorrectionDisabled()
+                    #if os(iOS)
+                    .textInputAutocapitalization(.never)
+                    #endif
+                    .onChange(of: query) { _, newValue in
+                        searchTask?.cancel()
+                        guard newValue.count >= 2 else { results = []; return }
+                        searchTask = Task {
+                            try? await Task.sleep(for: .milliseconds(300))
+                            guard !Task.isCancelled else { return }
+                            let result = try? await appState.subsonicClient.search(
+                                query: newValue, artistCount: 0, albumCount: 0, songCount: 8)
+                            results = result?.song ?? []
+                        }
+                    }
+                if !results.isEmpty {
+                    VStack(spacing: 0) {
+                        ForEach(results) { song in
+                            Button {
+                                selected = song
+                                results = []
+                            } label: {
+                                HStack(spacing: 10) {
+                                    AlbumArtView(coverArtId: song.coverArt, size: 32, cornerRadius: 4)
+                                    VStack(alignment: .leading, spacing: 1) {
+                                        Text(song.title).font(.subheadline).foregroundColor(.primary)
+                                        Text(song.displayArtist ?? "").font(.caption).foregroundStyle(.secondary)
+                                    }
+                                    Spacer()
+                                }
+                                .padding(.horizontal, 12)
+                                .padding(.vertical, 8)
+                            }
+                            .buttonStyle(.plain)
+                            if song.id != results.last?.id {
+                                Divider().padding(.leading, 54)
+                            }
+                        }
+                    }
+                    .background(Color.secondary.opacity(0.12), in: RoundedRectangle(cornerRadius: 10))
+                }
+            }
         }
     }
 }

--- a/Vibrdrome/Features/Settings/DebugView.swift
+++ b/Vibrdrome/Features/Settings/DebugView.swift
@@ -36,6 +36,10 @@ struct DebugView: View {
             row("URL", value: appState.serverURL)
             row("Username", value: appState.username)
             row("Connected", value: appState.subsonicClient.isConnected ? "Yes" : "No")
+            if let sv = appState.subsonicClient.serverVersion {
+                row("Server Version", value: sv)
+            }
+            row("sonicSimilarity", value: appState.subsonicClient.supportsSonicSimilarity ? "✓ supported" : "✗ not available")
             row("Servers", value: "\(appState.servers.count)")
             if let activeId = appState.activeServerId {
                 row("Active ID", value: String(activeId.prefix(8)) + "...")
@@ -224,6 +228,8 @@ struct DebugView: View {
         lines.append("Server URL: \(appState.serverURL)")
         lines.append("Username: \(appState.username)")
         lines.append("Connected: \(appState.subsonicClient.isConnected)")
+        lines.append("Server Version: \(appState.subsonicClient.serverVersion ?? "unknown")")
+        lines.append("sonicSimilarity: \(appState.subsonicClient.supportsSonicSimilarity)")
         lines.append("Servers: \(appState.servers.count)")
         lines.append("")
         let engine = AudioEngine.shared

--- a/Vibrdrome/Features/Settings/PlayerSettingsView.swift
+++ b/Vibrdrome/Features/Settings/PlayerSettingsView.swift
@@ -40,6 +40,7 @@ struct PlayerSettingsView: View {
 
     // Scrobbling
     @AppStorage(UserDefaultsKeys.scrobblingEnabled) private var scrobblingEnabled: Bool = true
+    @AppStorage(UserDefaultsKeys.playbackReportEnabled) private var playbackReportEnabled: Bool = false
     @AppStorage(UserDefaultsKeys.listenBrainzEnabled) private var listenBrainzEnabled: Bool = false
     @AppStorage(UserDefaultsKeys.lastFmEnabled) private var lastFmEnabled: Bool = false
     @AppStorage(UserDefaultsKeys.lastFmUsername) private var lastFmUsername: String = ""
@@ -281,6 +282,12 @@ struct PlayerSettingsView: View {
                     .foregroundColor(.primary)
             }
             .accessibilityIdentifier("scrobblingToggle")
+
+            Toggle(isOn: $playbackReportEnabled) {
+                Label("Playback Report (OpenSubsonic)", systemImage: "waveform.and.mic")
+                    .foregroundColor(.primary)
+            }
+            .accessibilityIdentifier("playbackReportToggle")
 
             Toggle(isOn: $listenBrainzEnabled) {
                 Label("ListenBrainz", systemImage: "dot.radiowaves.right")

--- a/Vibrdrome/Features/Settings/SettingsView.swift
+++ b/Vibrdrome/Features/Settings/SettingsView.swift
@@ -714,6 +714,7 @@ struct SettingsView: View {
         UserDefaultsKeys.crossfadeCurve,
         UserDefaultsKeys.replayGainMode,
         UserDefaultsKeys.scrobblingEnabled,
+        UserDefaultsKeys.playbackReportEnabled,
         UserDefaultsKeys.eqEnabled,
         UserDefaultsKeys.eqCurrentPresetId,
         UserDefaultsKeys.eqCurrentGains,

--- a/Vibrdrome/Shared/Components/TrackContextMenu.swift
+++ b/Vibrdrome/Shared/Components/TrackContextMenu.swift
@@ -114,6 +114,15 @@ private struct TrackContextMenuContent: View {
             }
         }
 
+        #if os(macOS)
+        Button {
+            appState.similarTracksSeed = song
+            appState.activeSidePanel = .similarTracks
+        } label: {
+            Label("Show Similar Tracks", systemImage: "waveform.path")
+        }
+        #endif
+
         Button {
             DownloadManager.shared.download(
                 song: song,

--- a/Vibrdrome/Shared/Components/TrackContextMenu.swift
+++ b/Vibrdrome/Shared/Components/TrackContextMenu.swift
@@ -106,6 +106,14 @@ private struct TrackContextMenuContent: View {
             Label("Start Radio", systemImage: "dot.radiowaves.left.and.right")
         }
 
+        if appState.subsonicClient.supportsSonicSimilarity {
+            Button {
+                AudioEngine.shared.startSongSimilarityMix(song)
+            } label: {
+                Label("Find Sonic Mix", systemImage: "waveform.badge.magnifyingglass")
+            }
+        }
+
         Button {
             DownloadManager.shared.download(
                 song: song,


### PR DESCRIPTION
## Summary

- **sonicSimilarity**: Probes `getOpenSubsonicExtensions` on ping to set `SubsonicClient.supportsSonicSimilarity`. All existing similarity surfaces (radio, auto-suggest, similar albums rail) transparently upgrade to audio-based results on capable servers. New user-facing additions: "Find Sonic Mix" song context menu action and "Sonic Path" Smart Playlist generator (both gated on server capability).
- **playbackReport**: New `reportPlayback` endpoint fires `starting`/`playing`/`paused`/`stopped` state at the correct audio lifecycle points. Opt-in toggle in Player Settings (off by default — requires server to advertise the extension).
- **Smart playlist criteria**: `isPresent` boolean field (complement to `isMissing`), plus `replayGainTrackGain` and `replayGainAlbumGain` numeric fields — all mapped to their Navidrome NSP field names.
- **Similar Tracks side panel**: Right-click any track → "Show Similar Tracks" opens the macOS right sidebar with up to 50 results. Shows similarity % when sonicSimilarity is available, falls back to `getSimilarSongs2` otherwise. Results have their own context menu (Play, Play Next, Add to Queue, Find Sonic Mix, Go to Album/Artist).
- **sonicSimilarity probe fix**: `probeExtensions()` is now awaited inline in `ping()` — the flag is guaranteed set before `ping()` returns, so UI gates and DebugView see the correct value immediately on connect.
- **Debug**: DebugView server section shows Server Version and sonicSimilarity support status; both included in the exported log.

## Test plan

- [ ] Connect to a Navidrome 0.62 server **without** AudioMuse-AI — confirm `supportsSonicSimilarity` is `false` in DebugView immediately after connect, "Find Sonic Mix" and "Show Similar Tracks" still appear but use `getSimilarSongs2` fallback, "Sonic Path" card is hidden in Smart Playlists
- [ ] Connect to a Navidrome 0.62 server **with** AudioMuse-AI — confirm `supportsSonicSimilarity: ✓ supported` in DebugView immediately after connect (not after a delay)
- [ ] Right-click a track → "Show Similar Tracks" opens the side panel, seed song shown at top, results load with % similarity scores
- [ ] Single-clicking a similar track queues it next; right-clicking shows context menu with Play/Play Next/Add to Queue/Find Sonic Mix/Go to Album/Go to Artist
- [ ] Right-clicking a different track while the panel is open reloads with the new seed
- [ ] "Find Sonic Mix" starts a radio queue seeded by audio similarity
- [ ] "Sonic Path" in Smart Playlists creates a bridging playlist between two chosen songs
- [ ] Enable "Playback Report" in settings; play, pause, seek, skip — verify server Now Playing panel updates
- [ ] Smart Playlist filter editor — `isPresent`, `ReplayGain Track`, `ReplayGain Album` fields available and round-trip correctly
- [ ] Connect to an older Subsonic server — no regressions, all capability flags stay `false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)