### PR TITLE
feat(sharing): add Navidrome share links and artist/playlist image upload

### DIFF
--- a/Vibrdrome/Core/Networking/NavidromeNativeClient.swift
+++ b/Vibrdrome/Core/Networking/NavidromeNativeClient.swift
@@ -339,6 +339,16 @@ final class NavidromeNativeClient {
         }
     }
 
+    // MARK: - Image Upload
+
+    /// Upload a JPEG image for an artist or playlist.
+    /// Navidrome accepts `POST /api/{resource}/{id}/image` with multipart form data.
+    nonisolated func uploadImage(resourceType: String, id: String, imageData: Data, mimeType: String) async throws {
+        let path = "api/\(resourceType)/\(id)/image"
+        _ = try await nativeRequestMultipart(path: path, imageData: imageData, mimeType: mimeType)
+        ndLog.info("Uploaded image for \(resourceType) id: \(id)")
+    }
+
     // MARK: - Private helpers
 
     nonisolated private func buildPlaylistBody(name: String, comment: String, rules: NSPCriteria) -> [String: Any] {
@@ -410,6 +420,60 @@ final class NavidromeNativeClient {
         }
 
         return (data, response)
+    }
+
+    nonisolated private func nativeRequestMultipart(path: String, imageData: Data, mimeType: String) async throws -> Data {
+        var tok = await currentToken()
+        if tok == nil {
+            try await login()
+            tok = await currentToken()
+        }
+        guard let tok else {
+            throw NavidromeNativeError.authFailed("No token after login")
+        }
+
+        guard let url = URL(string: path, relativeTo: baseURL) else {
+            throw NavidromeNativeError.invalidURL
+        }
+
+        let boundary = "Boundary-\(UUID().uuidString)"
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(tok)", forHTTPHeaderField: "X-ND-Authorization")
+        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+
+        var body = Data()
+        let boundaryPrefix = "--\(boundary)\r\n"
+        body.append(contentsOf: boundaryPrefix.utf8)
+        body.append(contentsOf: "Content-Disposition: form-data; name=\"image\"; filename=\"image\"\r\n".utf8)
+        body.append(contentsOf: "Content-Type: \(mimeType)\r\n\r\n".utf8)
+        body.append(imageData)
+        body.append(contentsOf: "\r\n--\(boundary)--\r\n".utf8)
+        request.httpBody = body
+
+        let (data, response) = try await session.data(for: request)
+        let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
+
+        if statusCode == 401 {
+            await invalidateToken()
+            try await login()
+            guard let newTok = await currentToken() else {
+                throw NavidromeNativeError.authFailed("Re-login failed")
+            }
+            request.setValue("Bearer \(newTok)", forHTTPHeaderField: "X-ND-Authorization")
+            let (retryData, retryResponse) = try await session.data(for: request)
+            let retryStatus = (retryResponse as? HTTPURLResponse)?.statusCode ?? 0
+            guard (200...299).contains(retryStatus) else {
+                throw NavidromeNativeError.httpError(retryStatus)
+            }
+            return retryData
+        }
+
+        guard (200...299).contains(statusCode) else {
+            throw NavidromeNativeError.httpError(statusCode)
+        }
+
+        return data
     }
 
     private func currentToken() -> String? { token }

--- a/Vibrdrome/Core/Networking/SubsonicClient.swift
+++ b/Vibrdrome/Core/Networking/SubsonicClient.swift
@@ -569,6 +569,32 @@ final class SubsonicClient {
         return directory
     }
 
+    // MARK: - Shares
+
+    func getShares() async throws -> [Share] {
+        let body = try await request(.getShares)
+        return body.shares?.share ?? []
+    }
+
+    @discardableResult
+    func createShare(ids: [String], description: String? = nil, expires: Date? = nil) async throws -> Share {
+        let expiresMs = expires.map { Int($0.timeIntervalSince1970 * 1000) }
+        let body = try await request(.createShare(ids: ids, description: description, expires: expiresMs))
+        guard let share = body.shares?.share?.first else {
+            throw SubsonicError.apiError(code: 0, message: "No share returned")
+        }
+        return share
+    }
+
+    func updateShare(id: String, description: String? = nil, expires: Date? = nil) async throws {
+        let expiresMs = expires.map { Int($0.timeIntervalSince1970 * 1000) }
+        try await performAction(.updateShare(id: id, description: description, expires: expiresMs))
+    }
+
+    func deleteShare(id: String) async throws {
+        try await performAction(.deleteShare(id: id))
+    }
+
     // MARK: - Jukebox
 
     func jukeboxGet() async throws -> JukeboxPlaylist {

--- a/Vibrdrome/Core/Networking/SubsonicEndpoints.swift
+++ b/Vibrdrome/Core/Networking/SubsonicEndpoints.swift
@@ -55,6 +55,10 @@ enum SubsonicEndpoint: Sendable {
     case getMusicDirectory(id: String)
     case jukeboxControl(action: String, index: Int? = nil, offset: Int? = nil,
                         ids: [String]? = nil, gain: Float? = nil)
+    case getShares
+    case createShare(ids: [String], description: String? = nil, expires: Int? = nil)
+    case updateShare(id: String, description: String? = nil, expires: Int? = nil)
+    case deleteShare(id: String)
 
     var path: String {
         switch self {
@@ -97,6 +101,10 @@ enum SubsonicEndpoint: Sendable {
         case .getIndexes: "/rest/getIndexes"
         case .getMusicDirectory: "/rest/getMusicDirectory"
         case .jukeboxControl: "/rest/jukeboxControl"
+        case .getShares: "/rest/getShares"
+        case .createShare: "/rest/createShare"
+        case .updateShare: "/rest/updateShare"
+        case .deleteShare: "/rest/deleteShare"
         }
     }
 
@@ -104,7 +112,7 @@ enum SubsonicEndpoint: Sendable {
         switch self {
         case .ping, .getGenres, .getPlaylists,
              .getInternetRadioStations, .getPlayQueue, .getBookmarks,
-             .getMusicFolders:
+             .getMusicFolders, .getShares:
             return []
 
         case .getStarred2(let musicFolderId):
@@ -292,6 +300,21 @@ enum SubsonicEndpoint: Sendable {
             return items
 
         case .getMusicDirectory(let id):
+            return [URLQueryItem(name: "id", value: id)]
+
+        case .createShare(let ids, let description, let expires):
+            var items: [URLQueryItem] = ids.map { URLQueryItem(name: "id", value: $0) }
+            if let description { items.append(URLQueryItem(name: "description", value: description)) }
+            if let expires { items.append(URLQueryItem(name: "expires", value: "\(expires)")) }
+            return items
+
+        case .updateShare(let id, let description, let expires):
+            var items = [URLQueryItem(name: "id", value: id)]
+            if let description { items.append(URLQueryItem(name: "description", value: description)) }
+            if let expires { items.append(URLQueryItem(name: "expires", value: "\(expires)")) }
+            return items
+
+        case .deleteShare(let id):
             return [URLQueryItem(name: "id", value: id)]
 
         case .jukeboxControl(let action, let index, let offset, let ids, let gain):

--- a/Vibrdrome/Core/Networking/SubsonicModels.swift
+++ b/Vibrdrome/Core/Networking/SubsonicModels.swift
@@ -43,6 +43,7 @@ struct SubsonicResponseBody: Decodable {
     let indexes: IndexesResponse?
     let jukeboxStatus: JukeboxStatus?
     let jukeboxPlaylist: JukeboxPlaylist?
+    let shares: SharesWrapper?
 
     enum CodingKeys: String, CodingKey {
         case status, version, type, serverVersion, openSubsonic, error
@@ -52,6 +53,7 @@ struct SubsonicResponseBody: Decodable {
         case artistInfo2, albumInfo, similarSongs2, topSongs
         case musicFolders, directory, indexes
         case jukeboxStatus, jukeboxPlaylist
+        case shares
     }
 
     init(from decoder: Decoder) throws {
@@ -86,6 +88,7 @@ struct SubsonicResponseBody: Decodable {
         indexes = try container.decodeIfPresent(IndexesResponse.self, forKey: .indexes)
         jukeboxStatus = try container.decodeIfPresent(JukeboxStatus.self, forKey: .jukeboxStatus)
         jukeboxPlaylist = try container.decodeIfPresent(JukeboxPlaylist.self, forKey: .jukeboxPlaylist)
+        shares = try container.decodeIfPresent(SharesWrapper.self, forKey: .shares)
     }
 }
 
@@ -797,6 +800,24 @@ struct JukeboxPlaylist: Decodable, Sendable {
     let playing: Bool?
     let gain: Float?
     let position: Int?
+    let entry: [Song]?
+}
+
+// MARK: - Shares
+
+struct SharesWrapper: Decodable, Sendable {
+    let share: [Share]?
+}
+
+struct Share: Decodable, Identifiable, Sendable {
+    let id: String
+    let url: String
+    let description: String?
+    let username: String
+    let created: String
+    let expires: String?
+    let lastVisited: String?
+    let visitCount: Int
     let entry: [Song]?
 }
 

--- a/Vibrdrome/Features/Library/AlbumDetailView.swift
+++ b/Vibrdrome/Features/Library/AlbumDetailView.swift
@@ -17,6 +17,7 @@ struct AlbumDetailView: View {
     @State private var isSelecting = false
     @State private var showAddToPlaylist = false
     @State private var isStarred = false
+    @State private var isCreatingAlbumShare = false
     // Single query for all completed downloads — passed into track rows to avoid per-row
     // SwiftData fetchCount calls on the main actor during the push/pop animation.
     @Query(filter: #Predicate<DownloadedSong> { $0.isComplete == true })
@@ -607,6 +608,10 @@ struct AlbumDetailView: View {
                     DownloadManager.shared.downloadAlbum(songs: songs, client: appState.subsonicClient)
                 }
             } label: { SwiftUI.Label("Download", systemImage: "arrow.down.circle") }
+
+            Divider()
+
+            albumShareActions(album)
         } label: {
             label()
         }
@@ -873,5 +878,42 @@ struct AlbumDetailView: View {
                 isStarred = wasStarred
             }
         }
+    }
+}
+
+// MARK: - Share Actions
+
+private extension AlbumDetailView {
+    @ViewBuilder
+    func albumShareActions(_ album: Album) -> some View {
+        let shareText = "💿 \(album.name)\(album.artist.map { " — \($0)" } ?? "")\nvibrdrome://album/\(album.id)"
+        ShareLink(item: shareText) {
+            SwiftUI.Label("Share", systemImage: "square.and.arrow.up")
+        }
+
+        Button {
+            guard !isCreatingAlbumShare else { return }
+            let songIds = album.song?.map(\.id) ?? []
+            guard !songIds.isEmpty else { return }
+            isCreatingAlbumShare = true
+            Task {
+                defer { isCreatingAlbumShare = false }
+                do {
+                    let share = try await appState.subsonicClient.createShare(ids: songIds)
+                    #if os(macOS)
+                    NSPasteboard.general.clearContents()
+                    NSPasteboard.general.setString(share.url, forType: .string)
+                    #else
+                    UIPasteboard.general.string = share.url
+                    #endif
+                } catch {}
+            }
+        } label: {
+            SwiftUI.Label(
+                isCreatingAlbumShare ? "Creating Share…" : "Copy Navidrome Share Link",
+                systemImage: "link"
+            )
+        }
+        .disabled(isCreatingAlbumShare)
     }
 }

--- a/Vibrdrome/Features/Library/AlbumsView.swift
+++ b/Vibrdrome/Features/Library/AlbumsView.swift
@@ -443,6 +443,33 @@ private struct AlbumContextMenu: View {
 
         Divider()
 
+        let shareText = "💿 \(album.name)\(album.artist.map { " — \($0)" } ?? "")\nvibrdrome://album/\(album.id)"
+        ShareLink(item: shareText) {
+            Label("Share", systemImage: "square.and.arrow.up")
+        }
+
+        Button {
+            fetch { songs in
+                let songIds = songs.map(\.id)
+                Task {
+                    do {
+                        let share = try await appState.subsonicClient.createShare(ids: songIds)
+                        #if os(macOS)
+                        NSPasteboard.general.clearContents()
+                        NSPasteboard.general.setString(share.url, forType: .string)
+                        #else
+                        UIPasteboard.general.string = share.url
+                        #endif
+                    } catch {
+                        Logger(subsystem: "com.vibrdrome.app", category: "Sharing")
+                            .error("Failed to create album share: \(error)")
+                    }
+                }
+            }
+        } label: { Label("Copy Navidrome Share Link", systemImage: "link") }
+
+        Divider()
+
         Button {
             #if os(macOS)
             openWindow(id: "get-info", value: GetInfoTarget(type: .album, id: album.id))

--- a/Vibrdrome/Features/Library/ArtistDetailView.swift
+++ b/Vibrdrome/Features/Library/ArtistDetailView.swift
@@ -1,6 +1,8 @@
-import SwiftUI
-import SwiftData
+import os.log
+import PhotosUI
 import NukeUI
+import SwiftData
+import SwiftUI
 
 #if os(macOS)
 private struct ArtistBlurredBackground: View {
@@ -75,6 +77,9 @@ struct ArtistDetailView: View {
     @State private var isLoading = true
     @State private var error: String?
     @State private var isStarred = false
+    @State private var showImagePicker = false
+    @State private var selectedPhotoItem: PhotosPickerItem?
+    @State private var isUploadingImage = false
     #if os(macOS)
     @State private var columnSettings = TrackTableColumnSettings(viewKey: "artist")
     @State private var showFullBio = false
@@ -306,7 +311,34 @@ struct ArtistDetailView: View {
             .accessibilityLabel(isStarred ? "Unfavorite Artist" : "Favorite Artist")
             .accessibilityIdentifier("artistFavoriteButton")
 
+            if appState.navidromeClient?.isAvailable == true {
+                artistImagePickerButton
+            }
+
             artistExternalLinks(artist)
+        }
+    }
+
+    @ViewBuilder
+    private var artistImagePickerButton: some View {
+        PhotosPicker(
+            selection: $selectedPhotoItem,
+            matching: .images,
+            photoLibrary: .shared()
+        ) {
+            Image(systemName: isUploadingImage ? "arrow.triangle.2.circlepath" : "photo.badge.arrow.down")
+                .fontWeight(.semibold)
+                .padding(.vertical, 10)
+                .padding(.horizontal, 18)
+                .background(.ultraThinMaterial, in: Capsule())
+                .foregroundStyle(.white)
+        }
+        .buttonStyle(.plain)
+        .disabled(isUploadingImage)
+        .help("Change Artist Image")
+        .onChange(of: selectedPhotoItem) { _, item in
+            guard let item else { return }
+            Task { await uploadArtistImage(from: item) }
         }
     }
 
@@ -611,6 +643,16 @@ struct ArtistDetailView: View {
                 }
             }
         }
+        .photosPicker(
+            isPresented: $showImagePicker,
+            selection: $selectedPhotoItem,
+            matching: .images,
+            photoLibrary: .shared()
+        )
+        .onChange(of: selectedPhotoItem) { _, item in
+            guard let item else { return }
+            Task { await uploadArtistImage(from: item) }
+        }
         .toolbar {
             if artist != nil {
                 ToolbarItem(placement: .primaryAction) {
@@ -632,6 +674,16 @@ struct ArtistDetailView: View {
                         Label("Start Radio", systemImage: "dot.radiowaves.left.and.right")
                     }
                     .accessibilityIdentifier("startRadioButton")
+                }
+            }
+            if appState.navidromeClient?.isAvailable == true {
+                ToolbarItem(placement: .primaryAction) {
+                    Button {
+                        showImagePicker = true
+                    } label: {
+                        Label("Change Image", systemImage: "photo.badge.arrow.down")
+                    }
+                    .disabled(isUploadingImage)
                 }
             }
         }
@@ -726,6 +778,23 @@ struct ArtistDetailView: View {
             } catch {
                 isStarred = wasStarred
             }
+        }
+    }
+
+    private func uploadArtistImage(from item: PhotosPickerItem) async {
+        guard let client = appState.navidromeClient else { return }
+        isUploadingImage = true
+        defer {
+            isUploadingImage = false
+            selectedPhotoItem = nil
+        }
+        do {
+            guard let data = try await item.loadTransferable(type: Data.self) else { return }
+            try await client.uploadImage(resourceType: "artist", id: artistId, imageData: data, mimeType: "image/jpeg")
+            await loadArtist()
+        } catch {
+            Logger(subsystem: "com.vibrdrome.app", category: "ArtistDetail")
+                .error("Failed to upload artist image: \(error)")
         }
     }
 }

--- a/Vibrdrome/Features/Playlists/PlaylistDetailView.swift
+++ b/Vibrdrome/Features/Playlists/PlaylistDetailView.swift
@@ -1,3 +1,4 @@
+import PhotosUI
 import SwiftData
 import SwiftUI
 
@@ -24,6 +25,8 @@ struct PlaylistDetailView: View {
     @State private var showRemoveOfflineConfirmation = false
     @State private var smartCriteria: NSPCriteria?
     @State private var isLoadingSmartRules = false
+    @State private var selectedPhotoItem: PhotosPickerItem?
+    @State private var isUploadingImage = false
     @AppStorage("playlistDetailViewMode") private var viewModeRaw: String = PlaylistViewMode.songs.rawValue
     @Query private var downloadedSongs: [DownloadedSong]
     #if os(macOS)
@@ -121,6 +124,21 @@ struct PlaylistDetailView: View {
                         } label: {
                             Label(isSmartPlaylist ? "Edit Smart Playlist" : "Edit Playlist",
                                   systemImage: isSmartPlaylist ? "sparkles" : "pencil")
+                        }
+
+                        if appState.navidromeClient?.isAvailable == true {
+                            PhotosPicker(
+                                selection: $selectedPhotoItem,
+                                matching: .images,
+                                photoLibrary: .shared()
+                            ) {
+                                Label("Change Image", systemImage: "photo.badge.arrow.down")
+                            }
+                            .disabled(isUploadingImage)
+                            .onChange(of: selectedPhotoItem) { _, item in
+                                guard let item else { return }
+                                Task { await uploadPlaylistImage(from: item) }
+                            }
                         }
 
                         Button {
@@ -669,6 +687,24 @@ struct PlaylistDetailView: View {
                 self.error = ErrorPresenter.userMessage(for: error)
             }
             await loadPlaylist()
+        }
+    }
+
+    // MARK: - Image Upload
+
+    private func uploadPlaylistImage(from item: PhotosPickerItem) async {
+        guard let client = appState.navidromeClient else { return }
+        isUploadingImage = true
+        defer {
+            isUploadingImage = false
+            selectedPhotoItem = nil
+        }
+        do {
+            guard let data = try await item.loadTransferable(type: Data.self) else { return }
+            try await client.uploadImage(resourceType: "playlist", id: playlistId, imageData: data, mimeType: "image/jpeg")
+            await loadPlaylist()
+        } catch {
+            self.error = ErrorPresenter.userMessage(for: error)
         }
     }
 

--- a/Vibrdrome/Features/Playlists/PlaylistDetailView.swift
+++ b/Vibrdrome/Features/Playlists/PlaylistDetailView.swift
@@ -27,6 +27,7 @@ struct PlaylistDetailView: View {
     @State private var isLoadingSmartRules = false
     @State private var selectedPhotoItem: PhotosPickerItem?
     @State private var isUploadingImage = false
+    @State private var isCreatingShare = false
     @AppStorage("playlistDetailViewMode") private var viewModeRaw: String = PlaylistViewMode.songs.rawValue
     @Query private var downloadedSongs: [DownloadedSong]
     #if os(macOS)
@@ -156,6 +157,31 @@ struct PlaylistDetailView: View {
                             ShareLink(item: shareText) {
                                 Label("Share", systemImage: "square.and.arrow.up")
                             }
+
+                            Button {
+                                guard !isCreatingShare else { return }
+                                let songIds = playlist.entry?.map(\.id) ?? []
+                                guard !songIds.isEmpty else { return }
+                                isCreatingShare = true
+                                Task {
+                                    defer { isCreatingShare = false }
+                                    do {
+                                        let share = try await appState.subsonicClient.createShare(ids: songIds)
+                                        #if os(macOS)
+                                        NSPasteboard.general.clearContents()
+                                        NSPasteboard.general.setString(share.url, forType: .string)
+                                        #else
+                                        UIPasteboard.general.string = share.url
+                                        #endif
+                                    } catch {}
+                                }
+                            } label: {
+                                Label(
+                                    isCreatingShare ? "Creating Share…" : "Copy Navidrome Share Link",
+                                    systemImage: "link"
+                                )
+                            }
+                            .disabled(isCreatingShare)
                         }
 
                         Button {

--- a/Vibrdrome/Features/Playlists/PlaylistsView.swift
+++ b/Vibrdrome/Features/Playlists/PlaylistsView.swift
@@ -390,6 +390,33 @@ struct PlaylistsView: View {
 
         Divider()
 
+        let shareText = "🎶 \(playlist.name) — \(playlist.songCount ?? 0) songs\nvibrdrome://playlist/\(playlist.id)"
+        ShareLink(item: shareText) {
+            Label("Share", systemImage: "square.and.arrow.up")
+        }
+
+        Button {
+            Task {
+                do {
+                    let detail = try await appState.subsonicClient.getPlaylist(id: playlist.id)
+                    let songIds = detail.entry?.map(\.id) ?? []
+                    guard !songIds.isEmpty else { return }
+                    let share = try await appState.subsonicClient.createShare(ids: songIds)
+                    #if os(macOS)
+                    NSPasteboard.general.clearContents()
+                    NSPasteboard.general.setString(share.url, forType: .string)
+                    #else
+                    UIPasteboard.general.string = share.url
+                    #endif
+                } catch {
+                    Logger(subsystem: "com.vibrdrome.app", category: "Sharing")
+                        .error("Failed to create playlist share: \(error)")
+                }
+            }
+        } label: { Label("Copy Navidrome Share Link", systemImage: "link") }
+
+        Divider()
+
         Button(role: .destructive) {
             deletePlaylist(playlist)
         } label: { Label("Delete", systemImage: "trash") }

--- a/Vibrdrome/Shared/Components/GetInfoContextMenus.swift
+++ b/Vibrdrome/Shared/Components/GetInfoContextMenus.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import os.log
 
 struct ArtistGetInfoContextMenuModifier: ViewModifier {
     let artist: Artist
@@ -41,9 +42,10 @@ struct ArtistGetInfoContextMenuModifier: ViewModifier {
 struct AlbumGetInfoContextMenuModifier: ViewModifier {
     let album: Album
 
-    @Environment(\.openWindow) private var openWindow
-    #if os(iOS)
     @Environment(AppState.self) private var appState
+    @Environment(\.openWindow) private var openWindow
+    @State private var isCreatingShare = false
+    #if os(iOS)
     @State private var showGetInfo = false
     #endif
 
@@ -59,6 +61,41 @@ struct AlbumGetInfoContextMenuModifier: ViewModifier {
                 } label: {
                     Label("Get Info", systemImage: "doc.text.magnifyingglass")
                 }
+
+                Divider()
+
+                let shareText = "💿 \(album.name)\(album.artist.map { " — \($0)" } ?? "")\nvibrdrome://album/\(album.id)"
+                ShareLink(item: shareText) {
+                    Label("Share", systemImage: "square.and.arrow.up")
+                }
+
+                Button {
+                    guard !isCreatingShare else { return }
+                    isCreatingShare = true
+                    Task {
+                        defer { isCreatingShare = false }
+                        do {
+                            let songIds = try await appState.subsonicClient.getAlbum(id: album.id).song?.map(\.id) ?? []
+                            guard !songIds.isEmpty else { return }
+                            let share = try await appState.subsonicClient.createShare(ids: songIds)
+                            #if os(macOS)
+                            NSPasteboard.general.clearContents()
+                            NSPasteboard.general.setString(share.url, forType: .string)
+                            #else
+                            UIPasteboard.general.string = share.url
+                            #endif
+                        } catch {
+                            Logger(subsystem: "com.vibrdrome.app", category: "Sharing")
+                                .error("Failed to create album share: \(error)")
+                        }
+                    }
+                } label: {
+                    Label(
+                        isCreatingShare ? "Creating Share…" : "Copy Navidrome Share Link",
+                        systemImage: "link"
+                    )
+                }
+                .disabled(isCreatingShare)
             }
             #if os(iOS)
             .sheet(isPresented: $showGetInfo) {
@@ -76,6 +113,50 @@ struct AlbumGetInfoContextMenuModifier: ViewModifier {
     }
 }
 
+struct PlaylistContextMenuModifier: ViewModifier {
+    let playlist: Playlist
+
+    @Environment(AppState.self) private var appState
+    @State private var isCreatingShare = false
+
+    func body(content: Content) -> some View {
+        content.contextMenu {
+            let shareText = "🎶 \(playlist.name) — \(playlist.songCount ?? 0) songs\nvibrdrome://playlist/\(playlist.id)"
+            ShareLink(item: shareText) {
+                Label("Share", systemImage: "square.and.arrow.up")
+            }
+
+            Button {
+                guard !isCreatingShare else { return }
+                let songIds = playlist.entry?.map(\.id) ?? []
+                guard !songIds.isEmpty else { return }
+                isCreatingShare = true
+                Task {
+                    defer { isCreatingShare = false }
+                    do {
+                        let share = try await appState.subsonicClient.createShare(ids: songIds)
+                        #if os(macOS)
+                        NSPasteboard.general.clearContents()
+                        NSPasteboard.general.setString(share.url, forType: .string)
+                        #else
+                        UIPasteboard.general.string = share.url
+                        #endif
+                    } catch {
+                        Logger(subsystem: "com.vibrdrome.app", category: "Sharing")
+                            .error("Failed to create playlist share: \(error)")
+                    }
+                }
+            } label: {
+                Label(
+                    isCreatingShare ? "Creating Share…" : "Copy Navidrome Share Link",
+                    systemImage: "link"
+                )
+            }
+            .disabled(isCreatingShare)
+        }
+    }
+}
+
 extension View {
     func artistGetInfoContextMenu(artist: Artist) -> some View {
         modifier(ArtistGetInfoContextMenuModifier(artist: artist))
@@ -83,5 +164,9 @@ extension View {
 
     func albumGetInfoContextMenu(album: Album) -> some View {
         modifier(AlbumGetInfoContextMenuModifier(album: album))
+    }
+
+    func playlistContextMenu(playlist: Playlist) -> some View {
+        modifier(PlaylistContextMenuModifier(playlist: playlist))
     }
 }

--- a/Vibrdrome/Shared/Components/TrackContextMenu.swift
+++ b/Vibrdrome/Shared/Components/TrackContextMenu.swift
@@ -11,6 +11,7 @@ struct TrackContextMenuModifier: ViewModifier, Equatable {
     @Environment(\.openWindow) private var openWindow
     @State private var showAddToPlaylist = false
     @State private var showGetInfo = false
+    @State private var isCreatingShare = false
 
     nonisolated static func == (lhs: TrackContextMenuModifier, rhs: TrackContextMenuModifier) -> Bool {
         lhs.song == rhs.song && lhs.index == rhs.index
@@ -26,7 +27,8 @@ struct TrackContextMenuModifier: ViewModifier, Equatable {
                     song: song, queue: queue, index: index,
                     onRemove: onRemove,
                     showAddToPlaylist: $showAddToPlaylist,
-                    showGetInfo: $showGetInfo
+                    showGetInfo: $showGetInfo,
+                    isCreatingShare: $isCreatingShare
                 )
             }
             .sheet(isPresented: $showAddToPlaylist) {
@@ -56,6 +58,7 @@ private struct TrackContextMenuContent: View {
     var onRemove: (() -> Void)?
     @Binding var showAddToPlaylist: Bool
     @Binding var showGetInfo: Bool
+    @Binding var isCreatingShare: Bool
 
     @Environment(AppState.self) private var appState
     #if os(macOS)
@@ -213,6 +216,32 @@ private struct TrackContextMenuContent: View {
         ShareLink(item: shareText) {
             Label("Share", systemImage: "square.and.arrow.up")
         }
+
+        Button {
+            isCreatingShare = true
+            Task {
+                defer { isCreatingShare = false }
+                do {
+                    let share = try await appState.subsonicClient.createShare(ids: [song.id])
+                    #if os(macOS)
+                    NSPasteboard.general.clearContents()
+                    NSPasteboard.general.setString(share.url, forType: .string)
+                    #else
+                    UIPasteboard.general.string = share.url
+                    #endif
+                } catch {
+                    Logger(subsystem: "com.vibrdrome.app", category: "Sharing")
+                        .error("Failed to create Navidrome share: \(error)")
+                }
+            }
+        } label: {
+            if isCreatingShare {
+                Label("Creating Share…", systemImage: "link")
+            } else {
+                Label("Copy Navidrome Share Link", systemImage: "link")
+            }
+        }
+        .disabled(isCreatingShare)
     }
 }
 


### PR DESCRIPTION
Closes #65

## Summary

- **Share links**: Full Subsonic sharing API (`createShare`, `getShares`, `updateShare`, `deleteShare`). Track context menus gain a **"Copy Navidrome Share Link"** action that creates a server-side share and copies the public URL to the clipboard.
- **Artist image upload**: A `PhotosPicker` button appears in the artist header action row (macOS) and toolbar (iOS) when the Navidrome native API is available. Selecting a photo uploads it via `POST /api/artist/{id}/image` and reloads the view.
- **Playlist image upload**: A **"Change Image"** item in the playlist `…` menu, same upload mechanism via `POST /api/playlist/{id}/image`.

## Changes

- `SubsonicModels.swift` — `Share` + `SharesWrapper` models
- `SubsonicEndpoints.swift` — `getShares`, `createShare`, `updateShare`, `deleteShare` cases
- `SubsonicClient.swift` — `getShares()`, `createShare()`, `updateShare()`, `deleteShare()` methods
- `NavidromeNativeClient.swift` — `uploadImage(resourceType:id:imageData:mimeType:)` with multipart POST
- `TrackContextMenu.swift` — "Copy Navidrome Share Link" action
- `ArtistDetailView.swift` — PhotosPicker + upload flow for artist images
- `PlaylistDetailView.swift` — PhotosPicker menu item + upload flow for playlist images

## Test plan

- [ ] Track context menu → "Copy Navidrome Share Link" → clipboard contains a valid `https://…/share/…` URL
- [ ] Artist detail → change image button → photo picker → image updates after reload
- [ ] Playlist detail → `…` menu → "Change Image" → photo picker → cover art updates after reload
- [ ] Image upload and share link buttons are hidden when connected to a non-Navidrome Subsonic server
- [ ] SwiftLint: 0 violations
- [ ] iOS build: 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)