### PR TITLE
fix(prefetch): flush Nuke disk cache after cover art batch

### DIFF
--- a/Vibrdrome/Core/Persistence/LibrarySyncManager+CoverArt.swift
+++ b/Vibrdrome/Core/Persistence/LibrarySyncManager+CoverArt.swift
@@ -65,6 +65,9 @@ extension LibrarySyncManager {
             syncLog.info("Prefetching \(uncachedUrls.count) cover art images (\(alreadyCached) already cached)")
             let fetched = await prefetchBatches(uncachedUrls: uncachedUrls, total: total, alreadyCached: alreadyCached, client: client)
             syncLog.info("Cover art prefetch complete: \(fetched)/\(total) processed")
+            // Flush staging area to disk synchronously so files survive if the app quits
+            // before Nuke's async 1-second flush fires — prevents re-fetching on next launch.
+            dataCache?.flush()
         } else {
             syncLog.info("Cover art prefetch skipped — all \(total) images already on disk")
         }


### PR DESCRIPTION
## Summary

- Nuke's `DataCache` writes asynchronously — there's a 1-second staged flush before data hits disk
- If the app quits during or just after the last prefetch batch, those images are in the in-memory staging area only and are never written to disk
- On next launch `containsData` checks the filesystem, finds nothing, and re-fetches them — causing the "prefetching X/100" progress every launch

## Fix

Call `dataCache.flush()` synchronously immediately after `prefetchBatches` returns. This blocks until all pending staging-area writes are committed to disk, so the files survive an app quit.

## Test plan

- [ ] Run app, let cover art prefetch complete
- [ ] Quit app immediately after prefetch finishes
- [ ] Relaunch — confirm "Prefetching cover art…" does not appear (all images found on disk)

🤖 Generated with [Claude Code](https://claude.com/claude-code)